### PR TITLE
A more succinct option for creating columns #294

### DIFF
--- a/tests/connectors/test_test.py
+++ b/tests/connectors/test_test.py
@@ -110,7 +110,49 @@ def test_random_list():
       - test:
           rows: 3
           values:
-            random_list: random<["true", "false"]>
+            random_list: <random(["true", "false"])>
     """
     df = wrangles.recipe.run(recipe)
     assert df.iloc[0][0] == 'true' or df.iloc[0][0] == 'false'
+    
+def test_random_list_objects():
+    """
+    Test using an object in random list
+    """
+    recipe = """
+    read:
+      - test:
+            rows: 3
+            values:
+                random_list: <random([{"a":1}, {"b":2}])>
+    """
+    df = wrangles.recipe.run(recipe)
+    assert df.iloc[0][0] == {'a': 1} or df.iloc[0][0] == {'b': 2}
+    
+def test_random_list_true_false():
+    """
+    Test using a random list (random<["true", "False"]>)
+    """
+    recipe = """
+    read:
+      - test:
+          rows: 3
+          values:
+            random_list: <random([true, false])>
+    """
+    df = wrangles.recipe.run(recipe)
+    assert df.iloc[0][0] == True or df.iloc[0][0] == False
+    
+def test_random_list_numbers():
+    """
+    Test using a random list (random<["true", "False"]>)
+    """
+    recipe = """
+    read:
+      - test:
+          rows: 3
+          values:
+            random_list: <random([1, 2])>
+    """
+    df = wrangles.recipe.run(recipe)
+    assert df.iloc[0][0] == 1 or df.iloc[0][0] == 2

--- a/tests/connectors/test_test.py
+++ b/tests/connectors/test_test.py
@@ -83,3 +83,34 @@ def test_date_5():
     """
     df = wrangles.recipe.run(recipe)
     assert df.iloc[0]['dates'].strftime("%Y") == '2022'
+    
+def test_order_list():
+    """
+    Test using an order lists of values
+    """
+    recipe = """
+    read:
+      - test:
+          rows: 3
+          values:
+            order_list:
+              - apple
+              - orange
+              - banana
+    """
+    df = wrangles.recipe.run(recipe)
+    assert df.iloc[0].tolist() == [['apple', 'orange', 'banana']]
+    
+def test_random_list():
+    """
+    Test using a random list (random<["true", "False"]>)
+    """
+    recipe = """
+    read:
+      - test:
+          rows: 3
+          values:
+            random_list: random<["true", "false"]>
+    """
+    df = wrangles.recipe.run(recipe)
+    assert df.iloc[0][0] == 'true' or df.iloc[0][0] == 'false'

--- a/tests/connectors/test_test.py
+++ b/tests/connectors/test_test.py
@@ -51,27 +51,33 @@ def test_data_generation_2():
     
 # testing todays date
 def test_date_today_generation_3():
+    """
+    Get today's date
+    """
     recipe = """
     read:
       - test:
           rows: 1
           values:
-            date: <date_today>
+            date: <date>
     """
     df = wrangles.recipe.run(recipe)
     assert df.iloc[0]['date'].date() == datetime.today().date()
     
 # testing date ranges
 def test_date_ranges_4():
+    """
+    Get a random date from a range of dates
+    """
     recipe = """
     read:
       - test:
-          rows: 2
+          rows: 10
           values:
-            date_range: <12-25-2022 to 12-31-2022>
+            date_range: <date(12-25-2022 to 12-31-2022)>
     """
     df = wrangles.recipe.run(recipe)
-    assert 1 # this will generate a random date. Testing that it works
+    assert df['date_range'][3].day <= 31 and df['date_range'][3].day >= 25
   
 def test_date_5():
     recipe = """
@@ -79,10 +85,24 @@ def test_date_5():
       - test:
           rows: 2
           values:
-            dates: <date 12-25-2022>
+            dates: <date(12-25-2022)>
     """
     df = wrangles.recipe.run(recipe)
     assert df.iloc[0]['dates'].strftime("%Y") == '2022'
+    
+def test_date_6_():
+    """
+    This should be just the string <date 2006-06-06 >
+    """
+    recipe = """
+    read:
+        - test:
+            rows: 2
+            values:
+                dates: <date 2006-06-06>
+    """
+    df = wrangles.recipe.run(recipe)
+    assert df['dates'][0] == '<date 2006-06-06>'
     
 def test_order_list():
     """

--- a/tests/recipes/wrangles/test_create.py
+++ b/tests/recipes/wrangles/test_create.py
@@ -323,7 +323,27 @@ def test_create_column_succinct_7():
         dataframe=data
     )
     assert df['col2'][0] == 'World2'
-
+    
+def test_create_column_succinct_8():
+    """
+    Having a dictionary in the output with more than one key:value pair. Should only get the first value
+    """
+    data = pd.DataFrame({
+        'col1': ['Hello']
+    })
+    df = wrangles.recipe.run(
+        recipe="""
+        wrangles:
+          - create.column:
+              output:
+                - col2: World
+                  col2.5: Nothing here
+                - col3: <boolean>
+        """,
+        dataframe=data
+    )
+    assert list(df.columns) == ['col1', 'col2', 'col3']
+    
 #
 # Index
 #

--- a/tests/recipes/wrangles/test_create.py
+++ b/tests/recipes/wrangles/test_create.py
@@ -69,9 +69,7 @@ def test_create_columns_4():
             output:
               - column3
               - column4
-            value:
-              - <boolean>
-              - <number(1-3)>
+            value: <number(1-3)>
     """
     df = wrangles.recipe.run(recipe, dataframe=data)
     assert df.iloc[0]['column4'] in [1, 2, 3, 4]
@@ -84,8 +82,7 @@ def test_create_columns_5():
         - create.column:
             output:
               - column3
-            value:
-              - <boolean>
+            value: <boolean>
     """
     df = wrangles.recipe.run(recipe, dataframe=data)
     assert df.iloc[0]['column3'] in [True, False]
@@ -128,6 +125,50 @@ def test_column_exists_list():
         info.typename == 'ValueError' and
         "['col'] column(s)" in info.value.args[0]
     )
+
+def test_create_column_value_number():
+    """
+    Test create.column using a number as the value
+    """
+    data = pd.DataFrame({
+        'col1': ['stuff', 'stuff', 'more stuff'],
+    })
+    df = wrangles.recipe.run(
+        recipe="""
+        wrangles:
+          - create.column:
+              output:
+                - col2
+              value: ${value}
+        """,
+        variables={
+            "value": 1
+        },
+        dataframe=data
+    )
+    assert df['col2'][0] == 1
+    
+def test_create_column_value_boolean():
+    """
+    Test create.column using a boolean as the value
+    """
+    data = pd.DataFrame({
+        'col1': ['stuff', 'stuff', 'more stuff'],
+    })
+    df = wrangles.recipe.run(
+        recipe="""
+        wrangles:
+          - create.column:
+              output:
+                - col2
+              value: ${value}
+        """,
+        variables={
+            "value": True
+        },
+        dataframe=data
+    )
+    assert df['col2'][0] == True
     
 def test_create_column_succinct_1():
     """
@@ -165,7 +206,7 @@ def test_create_column_succinct_2():
         wrangles:
         - create.column:
             output:
-                - col2: 
+                - col2
                 - col3: <boolean>
                 - col4: <code(10)>
                 - col5: ""
@@ -196,7 +237,7 @@ def test_create_column_succinct_3():
     
 def test_create_column_succinct_4():
     """
-    Error if using dicts and value being a list
+    Error if using a list in value
     """
     data = pd.DataFrame({
         'col1': ['Hello']
@@ -219,7 +260,7 @@ def test_create_column_succinct_4():
         raise wrangles.recipe.run(recipe, dataframe=data)
     assert (
         info.typename == 'ValueError' and
-        info.value.args[0] == 'create.column - When using mix dictionaries and strings in the output, Value must be a string'
+        info.value.args[0] == 'create.column - Value must be a string and not a list'
     )
     
 def test_create_column_succinct_5():

--- a/tests/recipes/wrangles/test_create.py
+++ b/tests/recipes/wrangles/test_create.py
@@ -128,6 +128,103 @@ def test_column_exists_list():
         info.typename == 'ValueError' and
         "['col'] column(s)" in info.value.args[0]
     )
+    
+def test_create_column_succinct_1():
+    """
+    Create columns using a more succinct format. Dicts for output (col_name: value)
+    Value is not None
+    """
+    data = pd.DataFrame({
+        'col1': ['Hello']
+    })
+    df = wrangles.recipe.run(
+        recipe="""
+        wrangles:
+        - create.column:
+            output:
+                - col2: World
+                - col3: <boolean>
+                - col4: <code(10)>
+                - col5
+            value: THIS IS A TEST
+        """,
+        dataframe=data
+    )
+    assert len(df.iloc[0][3]) == 10
+    
+def test_create_column_succinct_2():
+    """
+    Create columns using a more succinct format. Dicts for output (col_name: value)
+    Value is None
+    """
+    data = pd.DataFrame({
+        'col1': ['Hello']
+    })
+    df = wrangles.recipe.run(
+        recipe="""
+        wrangles:
+        - create.column:
+            output:
+                - col2: 
+                - col3: <boolean>
+                - col4: <code(10)>
+                - col5: ""
+        """,
+        dataframe=data
+    )
+    assert df.iloc[0][2] == True or df.iloc[0][2] == False
+    
+def test_create_column_succinct_3():
+    """
+    Cannot mix dictionaries and strings in the output list with no value provided.
+    col2 and col5 are strings, the rest are dicts
+    """
+    data = pd.DataFrame({
+        'col1': ['Hello']
+    })
+    recipe="""
+        wrangles:
+        - create.column:
+            output:
+                - col2 
+                - col3: <boolean>
+                - col4: <code(10)>
+                - col5
+        """
+    with pytest.raises(ValueError) as info:
+        raise wrangles.recipe.run(recipe, dataframe=data)
+    assert (
+        info.typename == 'ValueError' and
+        info.value.args[0] == 'create.column - Cannot mix dictionaries and strings in the output list with no value provided.'
+    )
+    
+def test_create_column_succinct_4():
+    """
+    Error if using dicts and value being a list
+    """
+    data = pd.DataFrame({
+        'col1': ['Hello']
+    })
+    recipe="""
+        wrangles:
+        - create.column:
+            output:
+                - col2: <boolean>
+                - col3: <boolean>
+                - col4: <code(10)>
+                - col5
+            value:
+                - <boolean>
+                - <boolean>
+                - <code(10)>
+                - ""
+        """
+    with pytest.raises(ValueError) as info:
+        raise wrangles.recipe.run(recipe, dataframe=data)
+    assert (
+        info.typename == 'ValueError' and
+        info.value.args[0] == 'create.column - When using mix dictionaries and strings in the output, Value must be a string'
+    )
 
 #
 # Index

--- a/tests/recipes/wrangles/test_create.py
+++ b/tests/recipes/wrangles/test_create.py
@@ -191,12 +191,8 @@ def test_create_column_succinct_3():
                 - col4: <code(10)>
                 - col5
         """
-    with pytest.raises(ValueError) as info:
-        raise wrangles.recipe.run(recipe, dataframe=data)
-    assert (
-        info.typename == 'ValueError' and
-        info.value.args[0] == 'create.column - Cannot mix dictionaries and strings in the output list with no value provided.'
-    )
+    df = wrangles.recipe.run(recipe, dataframe=data)
+    assert df['col2'][0] == '' and df['col5'][0] == ''
     
 def test_create_column_succinct_4():
     """
@@ -225,6 +221,28 @@ def test_create_column_succinct_4():
         info.typename == 'ValueError' and
         info.value.args[0] == 'create.column - When using mix dictionaries and strings in the output, Value must be a string'
     )
+    
+def test_create_column_succinct_5():
+    """
+    Testing the column that is not a dict and has no value
+    """
+    data = pd.DataFrame({
+        'col1': ['Hello']
+    })
+    df = wrangles.recipe.run(
+        recipe="""
+        wrangles:
+        - create.column:
+            output:
+                - col2: World
+                - col3: <boolean>
+                - col4: <code(10)>
+                - col5
+            value: THIS IS A TEST
+        """,
+        dataframe=data
+    )
+    assert df['col5'][0] == 'THIS IS A TEST'
 
 #
 # Index

--- a/tests/recipes/wrangles/test_create.py
+++ b/tests/recipes/wrangles/test_create.py
@@ -284,6 +284,45 @@ def test_create_column_succinct_5():
         dataframe=data
     )
     assert df['col5'][0] == 'THIS IS A TEST'
+    
+def test_create_column_succinct_6():
+    """
+    Having a duplicate column in the creation process
+    """
+    data = pd.DataFrame({
+        'col1': ['Hello']
+    })
+    df = wrangles.recipe.run(
+        recipe="""
+        wrangles:
+          - create.column:
+              output:
+                - col2: World
+                - col2: World2
+        """,
+        dataframe=data
+    )
+    assert df['col2'][0] == 'World2'
+    
+def test_create_column_succinct_7():
+    """
+    Having a duplicate column in the creation process
+    """
+    data = pd.DataFrame({
+        'col1': ['Hello']
+    })
+    df = wrangles.recipe.run(
+        recipe="""
+        wrangles:
+          - create.column:
+              output:
+                - col2: World
+                - col2.5: Nothing here
+                - col2: World2
+        """,
+        dataframe=data
+    )
+    assert df['col2'][0] == 'World2'
 
 #
 # Index

--- a/wrangles/connectors/test.py
+++ b/wrangles/connectors/test.py
@@ -33,10 +33,7 @@ def _generate_cell_values(data_type: _Union[str, list], rows: int):
     :param data_type: String or code to create random data
     :param rows: Number of rows to create
     """
-    if isinstance(data_type, list):
-        return [data_type for _ in range(rows)]
-        # return [data_type[_random.randint(0, len(data_type) - 1)] for _ in range(rows)]
-    elif isinstance(data_type, str):
+    if isinstance(data_type, str):
         if data_type == '<char>':
             return [_random.choice(_string.ascii_lowercase) for _ in range(rows)]
 

--- a/wrangles/connectors/test.py
+++ b/wrangles/connectors/test.py
@@ -49,10 +49,10 @@ def _generate_cell_values(data_type: _Union[str, list], rows: int):
         elif data_type == '<boolean>':
             return [bool(_random.getrandbits(1)) for _ in range(rows)]
         
-        elif 'random<[' in data_type:
+        elif '<random([' in data_type:
             try:
                 # return a random value from a list of values
-                random_list = _json.loads(_re.search(r'random<(.+)>', data_type).group(1))
+                random_list = _json.loads(_re.search(r'<random\((.+)\)>', data_type).group(1))
                 return [random_list[_random.randint(0, len(random_list) - 1)] for _ in range(rows)]
             except:
                 # return the string as is if it can't be parsed
@@ -124,7 +124,7 @@ def read(rows: int, values: dict = {}) -> _pd.DataFrame:
     <boolean> : Randomly True or False
     <number(2.718-3.141)> : Random numbers (2.718-3.141) sets the range and decimal places
     <int(1-10)> : Random integers (1-10) sets the range
-    <random<["one", "two", "three"]>> : Randomly select a value from a list
+    <random(["true", "false"])> : Randomly select a value from a list
 
     :param rows: Number of rows to include in the created dataframe
     :param values: Dictionary of header and values

--- a/wrangles/connectors/test.py
+++ b/wrangles/connectors/test.py
@@ -85,20 +85,21 @@ def _generate_cell_values(data_type: _Union[str, list], rows: int):
                 length = 8
             return [''.join(_random.choice(_string.ascii_uppercase + _string.digits) for _ in range(length)) for _ in range(rows)]
         
-        elif data_type == '<date_today>':
+        elif data_type == '<date>':
             return [_pd.to_datetime('today').normalize() for _ in range(rows)]
         
         # Get a random date from a range of dates
-        elif _re.findall(r'<\d+-\d+-\d+\sto\s\d+-\d+-\d+>', data_type):
-            date_range_string = _re.findall(r'\d+-\d+-\d+\sto\s\d+-\d+-\d+', data_type)[0] 
-            start_date = _pd.to_datetime(date_range_string.split(' to ')[0])
-            end_date = _pd.to_datetime(date_range_string.split(' to ')[1])
-            return [_random_date(start_date, end_date) for _ in range(rows)]
-        
-        # Enter a date
-        elif _re.findall(r'<date\s\d+-\d+-\d+>', data_type):
-            date = _pd.to_datetime(_re.findall(r'\d+-\d+-\d+', data_type)[0])
-            return [date for _ in range(rows)]
+        elif '<date(' in data_type:
+            # check if there is a "to" in the string
+            if 'to' in data_type:
+                date_range_string = _re.findall(r'\d+-\d+-\d+\sto\s\d+-\d+-\d+', data_type)[0] 
+                start_date = _pd.to_datetime(date_range_string.split(' to ')[0])
+                end_date = _pd.to_datetime(date_range_string.split(' to ')[1])
+                return [_random_date(start_date, end_date) for _ in range(rows)]
+            else:
+                # get the single date from the string =  <date(2020-01-01)> -> 2020-01-01
+                date = _pd.to_datetime(_re.findall(r'\d+-\d+-\d+', data_type)[0])
+                return [date for _ in range(rows)]
         
         else:
             return [data_type for _ in range(rows)]

--- a/wrangles/connectors/test.py
+++ b/wrangles/connectors/test.py
@@ -8,6 +8,7 @@ import random as _random
 import string as _string
 from typing import Union as _Union
 import re as _re
+import json as _json
 
 
 _lorem = _TextLorem()
@@ -33,7 +34,8 @@ def _generate_cell_values(data_type: _Union[str, list], rows: int):
     :param rows: Number of rows to create
     """
     if isinstance(data_type, list):
-        return [data_type[_random.randint(0, len(data_type) - 1)] for _ in range(rows)]
+        return [data_type for _ in range(rows)]
+        # return [data_type[_random.randint(0, len(data_type) - 1)] for _ in range(rows)]
     elif isinstance(data_type, str):
         if data_type == '<char>':
             return [_random.choice(_string.ascii_lowercase) for _ in range(rows)]
@@ -46,6 +48,15 @@ def _generate_cell_values(data_type: _Union[str, list], rows: int):
 
         elif data_type == '<boolean>':
             return [bool(_random.getrandbits(1)) for _ in range(rows)]
+        
+        elif 'random<[' in data_type:
+            try:
+                # return a random value from a list of values
+                random_list = _json.loads(_re.search(r'random<(.+)>', data_type).group(1))
+                return [random_list[_random.randint(0, len(random_list) - 1)] for _ in range(rows)]
+            except:
+                # return the string as is if it can't be parsed
+                return [data_type for _ in range(rows)]
 
         elif _re.match(r'^\<int(\(\d+-\d+\))?\>$', data_type):
             # Match <int(1-10)> -> where (1-10) sets the range
@@ -113,6 +124,7 @@ def read(rows: int, values: dict = {}) -> _pd.DataFrame:
     <boolean> : Randomly True or False
     <number(2.718-3.141)> : Random numbers (2.718-3.141) sets the range and decimal places
     <int(1-10)> : Random integers (1-10) sets the range
+    <random<["one", "two", "three"]>> : Randomly select a value from a list
 
     :param rows: Number of rows to include in the created dataframe
     :param values: Dictionary of header and values

--- a/wrangles/recipe_wrangles/create.py
+++ b/wrangles/recipe_wrangles/create.py
@@ -115,7 +115,9 @@ def column(df: _pd.DataFrame, output: _Union[str, list], value = None) -> _pd.Da
     output_dict = {}
     for out in output:
         if isinstance(out, dict):
-            output_dict.update(out)
+            # get the first key and value only and append dictionary to output_dict
+            temp_key, temp_value = list(out.items())[0]
+            output_dict.update({temp_key: temp_value})
         else:
             output_dict.update({out: value})
                 

--- a/wrangles/recipe_wrangles/create.py
+++ b/wrangles/recipe_wrangles/create.py
@@ -111,27 +111,20 @@ def column(df: _pd.DataFrame, output: _Union[str, list], value = None) -> _pd.Da
         raise ValueError(f'"{output}" column already exists in dataFrame.')
       output = [output]
     
-    values = []
-    outputs = []
-    # iterate over the list of output columns and check if they are dictionaries
+    # gather the columns and values in a dictionary, if not a dict then use value as the value of dictionary
+    output_dict = {}
     for out in output:
         if isinstance(out, dict):
-            # get the value and append to the values list
-            values.append(list(out.values())[0])
-            # get the key and append to the outputs list
-            outputs.append(list(out.keys())[0])
+            output_dict.update(out)
         else:
-            # append the "value" to the list
-            values.append(value)
-            # append the output to the list
-            outputs.append(out)
-        
+            output_dict.update({out: value})
+                
     # Check if the list of outputs exist in dataFrame
-    check_list = [x for x in outputs if x in existing_column]
+    check_list = [x for x in (output_dict.keys()) if x in existing_column]
     if len(check_list) > 0:
       raise ValueError(f'{check_list} column(s) already exists in the dataFrame') 
     
-    for output_column, values_list in zip(outputs, values):
+    for output_column, values_list in zip(output_dict.keys(), output_dict.values()):
         # Data to generate
         data = _pd.DataFrame(_generate_cell_values(values_list, rows), columns=[output_column])
         data.set_index(df.index, inplace=True)  # use the same index as original to match rows

--- a/wrangles/recipe_wrangles/create.py
+++ b/wrangles/recipe_wrangles/create.py
@@ -87,11 +87,31 @@ def column(df: _pd.DataFrame, output: _Union[str, list], value = None) -> _pd.Da
         type:
           - string
           - array
-        description: Name or list of names of new columns
+          - object
+        description: Name or list of names of new columns or column_name: value pairs
       value:
         type: string
         description: (Optional) Value to add in the new column(s). If omitted, defaults to None.
-    """
+    """    
+    
+    # check if the output is a list and if there are any dictionaries in the list
+    if isinstance(output, list) and any(isinstance(x, dict) for x in output):
+
+        if value == None:
+            if any(isinstance(x, str) for x in output):
+                raise ValueError('Cannot mix dictionaries and strings in the output list with no value provided.')
+            # use all of the values in the dictionary (output dictionary)
+            value = [list(values.values())[0] for values in output]
+        else:
+            # check that value is not a list, if it is, raise an error to avoid confusion
+            if isinstance(value, list):
+                raise ValueError('When using mix dictionaries and strings in the output, Value must be a string')
+            # use the value provided by the user on any non dictionary elements
+            value = [value if isinstance(values, str) else list(values.values())[0] for values in output]
+        
+        output = [list(x.keys())[0] if isinstance(x, dict) else x for x in output]
+
+    
     # Get list of existing columns
     existing_column = df.columns
     

--- a/wrangles/recipe_wrangles/create.py
+++ b/wrangles/recipe_wrangles/create.py
@@ -88,20 +88,24 @@ def column(df: _pd.DataFrame, output: _Union[str, list], value = None) -> _pd.Da
           - string
           - array
           - object
-        description: Name or list of names of new columns or column_name: value pairs
+        description: Name or list of names of new columns or column_name: value pairs.
       value:
-        type: string
-        description: (Optional) Value to add in the new column(s). If omitted, defaults to None.
+        type:
+          - string
+          - array
+        description: (Optional) Value(s) to add in the new column(s). If using a dictionary in output, value can only be a string.
     """    
     
     # check if the output is a list and if there are any dictionaries in the list
     if isinstance(output, list) and any(isinstance(x, dict) for x in output):
+        
+        # if value is a list then raise and error
+        if isinstance(value, list):
+            raise ValueError('When using mix dictionaries and strings in the output, Value must be a string')
 
         if value == None:
-            if any(isinstance(x, str) for x in output):
-                raise ValueError('Cannot mix dictionaries and strings in the output list with no value provided.')
-            # use all of the values in the dictionary (output dictionary)
-            value = [list(values.values())[0] for values in output]
+            # Get values from dictionaries and use '' if no value provided
+            value = [list(x.values())[0] if isinstance(x, dict) else "" for x in output ]
         else:
             # check that value is not a list, if it is, raise an error to avoid confusion
             if isinstance(value, list):


### PR DESCRIPTION
#294 

Dictionaries can now used in the output of `create.column` for a more succinct recipe.

```yaml
- create.column:
     output:
        col2: val2
        col3: val3
```

A value can be set that applies to any not defined directly within the output

```yaml
- create.column:
     output:
        - col2: val2
        - col3
        - col4
     value: This is a test
```