### PR TITLE
split.text wrangle fails if a string is passed without ":" #443

### DIFF
--- a/tests/recipes/wrangles/test_split.py
+++ b/tests/recipes/wrangles/test_split.py
@@ -211,6 +211,60 @@ def test_split_text_where():
     df = wrangles.recipe.run(recipe, dataframe=data)
     assert df.iloc[2]['output'] == ['Hola', 'Mundo!'] and df.iloc[0]['output'] == ''
 
+def test_split_text_string():
+    """
+    Test a string passed into the element parameter
+    """
+    data = pd.DataFrame({
+        'col1': ['Wrangles are very cool']
+    })
+    recipe="""
+    wrangles:
+      - split.text:
+          input: col1
+          output: Out
+          char: ' '
+          element: '1'
+    """
+    df = wrangles.recipe.run(recipe, dataframe=data)
+    assert df['Out'].iloc[0] == 'are'
+
+def test_split_text_slice_start():
+    """
+    Test a string slice passed into the element parameter
+    """
+    data = pd.DataFrame({
+        'col1': ['Wrangles are very cool and super fun to work with']
+    })
+    recipe="""
+    wrangles:
+      - split.text:
+          input: col1
+          output: Out
+          char: ' '
+          element: ':3'
+    """
+    df = wrangles.recipe.run(recipe, dataframe=data)
+    assert df['Out'].iloc[0] == ['Wrangles', 'are','very']
+
+def test_split_text_slice_end():
+    """
+    Test a string slice passed into the element parameter
+    """
+    data = pd.DataFrame({
+        'col1': ['Wrangles are very cool and super fun to work with']
+    })
+    recipe="""
+    wrangles:
+      - split.text:
+          input: col1
+          output: Out
+          char: ' '
+          element: '3:'
+    """
+    df = wrangles.recipe.run(recipe, dataframe=data)
+    assert df['Out'].iloc[0] == ['cool', 'and', 'super', 'fun', 'to', 'work', 'with']
+
 #
 # Split from List
 #

--- a/tests/recipes/wrangles/test_split.py
+++ b/tests/recipes/wrangles/test_split.py
@@ -506,6 +506,27 @@ def test_split_text_pad_mismatch_error():
             """
         )
 
+def test_split_text_regex_case_insensitive():
+    """
+    Tests split.text using regex with
+    the case insensitive flag
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+            - split.text:
+                input: col1
+                char: 'regex:(?i)x'
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['1x2', "1X2"]
+        })
+    )
+    assert (
+        df['col1'][0] == ["1","2"] and
+        df['col1'][1] == ["1","2"]
+    )
+
 #
 # Split from List
 #

--- a/tests/recipes/wrangles/test_split.py
+++ b/tests/recipes/wrangles/test_split.py
@@ -5,265 +5,506 @@ import pytest
 #
 # Split From Text
 #
-
-# Text Split - text to a list separated by char
-def test_split_text_1():
-    data = pd.DataFrame({
-    'Col1': ['Hello, Wrangles!']
-    })
-    recipe = """
-    wrangles:
-        - split.text:
-            input: Col1
-            output: Col2
-            char: ', '
+def test_split_text_no_output():
     """
-    df = wrangles.recipe.run(recipe, dataframe=data)
-    assert df.iloc[0]['Col2'] == ['Hello', 'Wrangles!']
-    
-# using a wild card - text to columns
-def test_split_text_2():
-    data = pd.DataFrame({
-    'Col': ['Hello, Wrangles!']
-    })
-    recipe = """
-    wrangles:
+    Test overwriting the input
+    if the output isn't set
+    """
+    df = wrangles.recipe.run(
+        """
+        read:
+          - test:
+              rows: 1
+              values:
+                col1: Wrangles,are,cool
+
+        wrangles:
+        - split.text:
+            input: col1
+        """
+    )
+    assert df['col1'][0] == ["Wrangles", "are", "cool"]
+
+def test_split_text_char():
+    """
+    Test setting the character to split on
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+            - split.text:
+                input: Col1
+                char: ', '
+        """,
+        dataframe=pd.DataFrame({
+            'Col1': ['Hello, Wrangles!']
+        })
+    )
+    assert df.iloc[0]['Col1'] == ['Hello', 'Wrangles!']
+
+def test_split_text_wildcard_output():
+    """
+    Using a wildcard for output columns
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+            - split.text:
+                input: Col
+                output: Col*
+                char: ', '
+        """,
+        dataframe=pd.DataFrame({
+            'Col': ['Hello, Wrangles!']
+        })
+    )
+    assert df.iloc[0]['Col2'] == 'Wrangles!'
+
+def test_split_text_named_columns():
+    """
+    Multiple named columns as outputs - text to columns
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
         - split.text:
             input: Col
-            output: Col*
-            char: ', '
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
-    assert df.iloc[0]['Col2'] == 'Wrangles!'
-    
-# Multiple named columns as outputs - text to columns
-def test_split_text_3():
-    data = pd.DataFrame({
-    'Col': ['Hello Wrangles! Other']
-    })
-    recipe = """
-    wrangles:
-      - split.text:
-          input: Col
-          output:
-            - Col 1
-            - Col 2
-            - Col 3
-          char: ' '
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
+            output:
+              - Col 1
+              - Col 2
+              - Col 3
+        """,
+        dataframe=pd.DataFrame({
+            'Col': ['Hello,Wrangles!,Other']
+        })
+    )
     assert df.iloc[0]['Col 2'] == 'Wrangles!'
-    
-# Multiple character split
-def test_split_text_4():
-    data = pd.DataFrame({
-    'col1': ['Wrangles@are&very$cool']
-    })
-    recipe = r"""
-      wrangles:
-        - split.text:
-            input: col1
-            output: out1
-            char: 'regex: @|&|\$'
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
-    assert df.iloc[0]['out1'] == ['Wrangles', 'are', 'very', 'cool']
-    
-# Multiple character split using wildcard (*)
-def test_split_text_5():
-    data = pd.DataFrame({
-    'col1': ['Wrangles@are&very$cool']
-    })
-    recipe = r"""
-      wrangles:
-        - split.text:
-            input: col1
-            output: out*
-            char: 'regex: @|&|\$'
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
-    assert df.iloc[0]['out4'] == 'cool'
-    
-# Select element from the output list
-def test_split_text_6():
-    data = pd.DataFrame({
-    'col1': ['Wrangles are very cool']
-    })
-    recipe = """
-    wrangles:
-        - split.text:
-            input: col1
-            output: Out
-            char: ' '
-            element: 0
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
-    assert df.iloc[0]['Out'] == 'Wrangles'
 
-# Select element from the output list, index error
-# Number of index greater than Out list size
-def test_split_text_7():
-    data = pd.DataFrame({
-    'col1': ['Wrangles are very cool']
-    })
-    recipe = """
-    wrangles:
-        - split.text:
-            input: col1
-            output: Out
-            char: ' '
-            element: 100
+def test_split_text__regex_multichar():
     """
-    df = wrangles.recipe.run(recipe, dataframe=data)
-    assert df.iloc[0]['Out'] == ''
-    
-# Select element from the output list, using list slice
-def test_split_text_8():
-    data = pd.DataFrame({
-    'col1': ['Wrangles are very cool']
-    })
-    recipe = """
-    wrangles:
-        - split.text:
-            input: col1
-            output: Out
-            char: ' '
-            element: '0:3'
+    Multiple character split
     """
-    df = wrangles.recipe.run(recipe, dataframe=data)
-    assert df.iloc[0]['Out'] == ['Wrangles', 'are', 'very']  
-    
-    
-# If more columns than number of splits
-def test_split_text_9():
-    data = pd.DataFrame({
-    'col1': ['Wrangles are very cool']
-    })
-    recipe = """
-    wrangles:
-        - split.text:
-            input: col1
-            output: 
-              - Out1
-              - Out2
-              - Out3
-              - Out4
-              - Out5
-            char: ' '
-            pad: True
+    df = wrangles.recipe.run(
+        r"""
+        wrangles:
+            - split.text:
+                input: col1
+                output: out1
+                char: 'regex: @|&|\$'
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles@are&very$cool']
+        })
+    )
+    assert df.iloc[0]['out1'] == ['Wrangles', 'are', 'very', 'cool']
+
+def test_split_text_wildcard_multichar():
     """
-    df = wrangles.recipe.run(recipe, dataframe=data)
+    Multiple character split using wildcard (*)
+    """
+    df = wrangles.recipe.run(
+        r"""
+        wrangles:
+            - split.text:
+                input: col1
+                output: out*
+                char: 'regex: @|&|\$'
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles@are&very$cool']
+        })
+    )
+    assert df.iloc[0]['out4'] == 'cool'
+
+def test_split_text_excess_columns():
+    """
+    If more columns than number of splits
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+            - split.text:
+                input: col1
+                output: 
+                  - Out1
+                  - Out2
+                  - Out3
+                  - Out4
+                  - Out5
+                char: ' '
+                pad: True
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool']
+        })
+    )
     assert df['Out5'].iloc[0] == ''
     
 def test_split_text_more_splits_than_output():
     """
-    Test split.text with more splits than output columns
+    Test split.text with more values after splitting than output columns
     """
-    data = pd.DataFrame({
-    'col1': ['Wrangles are very cool, I tell you whut!']
-    })
-    recipe = """
-    wrangles:
-        - split.text:
-            input: col1
-            output: 
-              - Out1
-              - Out2
-              - Out3
-            char: ' '
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+            - split.text:
+                input: col1
+                output: 
+                - Out1
+                - Out2
+                - Out3
+                char: ' '
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool, I tell you whut!']
+        })
+    )
     assert list(df.columns) == ['col1', 'Out1', 'Out2', 'Out3'] and df['Out3'].iloc[0] == 'very'
 
 def test_split_text_uneven_lengths():
     """
     Test split.text with uneven split/output lengths
     """
-    data = pd.DataFrame({
-    'col1': ['Wrangles, are, very, cool', 'There, is, a, wrangle, for, that']
-    })
-    recipe = """
-    wrangles:
-        - split.text:
-            input: col1
-            output: output*
-            char: ', '
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+            - split.text:
+                input: col1
+                output: output*
+                char: ', '
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles, are, very, cool', 'There, is, a, wrangle, for, that']
+        })
+    )
     assert df['output6'].iloc[0] == '' and df['output6'].iloc[1] == 'that'
 
 def test_split_text_where():
     """
     Test split.text using where
     """
-    data = pd.DataFrame({
-        'Col1': ['Hello, Wrangles!', 'Hello, World!', 'Hola, Mundo!'],
-        'numbers': [4, 5, 6]
-    })
-    recipe = """
-    wrangles:
-        - split.text:
-            input: Col1
-            output: output
-            char: ', '
-            where: numbers > 4
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+            - split.text:
+                input: Col1
+                output: output
+                char: ', '
+                where: numbers > 4
+        """,
+        dataframe=pd.DataFrame({
+            'Col1': ['Hello, Wrangles!', 'Hello, World!', 'Hola, Mundo!'],
+            'numbers': [4, 5, 6]
+        })
+    )
     assert df.iloc[2]['output'] == ['Hola', 'Mundo!'] and df.iloc[0]['output'] == ''
 
-def test_split_text_string():
+def test_split_text_element_string():
     """
     Test a string passed into the element parameter
     """
-    data = pd.DataFrame({
-        'col1': ['Wrangles are very cool']
-    })
-    recipe="""
-    wrangles:
-      - split.text:
-          input: col1
-          output: Out
-          char: ' '
-          element: '1'
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+        - split.text:
+            input: col1
+            output: Out
+            char: ' '
+            element: '1'
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool']
+        })
+    )
     assert df['Out'].iloc[0] == 'are'
 
-def test_split_text_slice_start():
+def test_split_text_element_integer():
+    """
+    Select element from the output list
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+            - split.text:
+                input: col1
+                output: Out
+                char: ' '
+                element: 0
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool']
+        })
+    )
+    assert df.iloc[0]['Out'] == 'Wrangles'
+
+def test_split_text_index_out_of_range():
+    """
+    Select element from the output that beyond the range
+    Should give an empty value
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+            - split.text:
+                input: col1
+                output: Out
+                char: ' '
+                element: 100
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool']
+        })
+    )
+    assert df.iloc[0]['Out'] == ''
+
+def test_split_text_slice():
+    """
+    Select element from the output list, using list slice
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+            - split.text:
+                input: col1
+                output: Out
+                char: ' '
+                element: '0:3'
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool']
+        })
+    )
+    assert df.iloc[0]['Out'] == ['Wrangles', 'are', 'very']  
+
+def test_split_text_slice_start_only():
     """
     Test a string slice passed into the element parameter
     """
-    data = pd.DataFrame({
-        'col1': ['Wrangles are very cool and super fun to work with']
-    })
-    recipe="""
-    wrangles:
-      - split.text:
-          input: col1
-          output: Out
-          char: ' '
-          element: ':3'
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+        - split.text:
+            input: col1
+            output: Out
+            char: ' '
+            element: ':3'
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool and super fun to work with']
+        })
+    )
     assert df['Out'].iloc[0] == ['Wrangles', 'are','very']
 
-def test_split_text_slice_end():
+def test_split_text_slice_end_only():
     """
     Test a string slice passed into the element parameter
     """
-    data = pd.DataFrame({
-        'col1': ['Wrangles are very cool and super fun to work with']
-    })
-    recipe="""
-    wrangles:
-      - split.text:
-          input: col1
-          output: Out
-          char: ' '
-          element: '3:'
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+        - split.text:
+            input: col1
+            output: Out
+            char: ' '
+            element: '3:'
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool and super fun to work with']
+        })
+    )
     assert df['Out'].iloc[0] == ['cool', 'and', 'super', 'fun', 'to', 'work', 'with']
+
+def test_split_text_slice_step():
+    """
+    Test a string slice passed into
+    the element parameter with a step
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+        - split.text:
+            input: col1
+            output: Out
+            char: ' '
+            element: '1:5:2'
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool and super fun to work with']
+        })
+    )
+    assert df['Out'][0] == ['are', 'cool']
+
+def test_split_text_slice_columns_output():
+    """
+    Test a string slice passed into
+    the element parameter with the output
+    to columns
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+        - split.text:
+            input: col1
+            output:
+              - Out1
+              - Out2
+            char: ' '
+            element: '2:4'
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool and super fun to work with']
+        })
+    )
+    assert (
+        df['Out1'][0] == "very" and
+        df['Out2'][0] == "cool"
+    )
+
+def test_split_text_slice_columns_pad():
+    """
+    Test a string slice passed into
+    the element parameter with pad True
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+        - split.text:
+            input: col1
+            output:
+              - Out1
+              - Out2
+              - Out3
+            char: ' '
+            element: '2:4'
+            pad: True
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool and super fun to work with']
+        })
+    )
+    assert (
+        df['Out1'][0] == "very" and
+        df['Out2'][0] == "cool" and
+        df['Out3'][0] == ""
+    )
+
+def test_split_text_slice_reverse():
+    """
+    Test slicing the results using -1 step
+    to give the results in reverse order
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+        - split.text:
+            input: col1
+            output:
+              - Out1
+              - Out2
+              - Out3
+            char: ' '
+            element: '::-1'
+            pad: True
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool and super fun to work with']
+        })
+    )
+    assert (
+        df['Out1'][0] == "with" and
+        df['Out2'][0] == "work" and
+        df['Out3'][0] == "to"
+    )
+
+def test_split_text_slice_last_n():
+    """
+    Test slicing the last 2 values
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+        - split.text:
+            input: col1
+            output:
+              - Out1
+              - Out2
+            char: ' '
+            element: '-2:'
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Wrangles are very cool and super fun to work with']
+        })
+    )
+    assert (
+        df['Out1'][0] == "work" and
+        df['Out2'][0] == "with"
+    )
+
+def test_split_text_inclusive():
+    """
+    Tests split.text with inclusive set to True
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+            - split.text:
+                input: col1
+                output: out1
+                char: 'ga'
+                inclusive: True
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['80ga 90ga 100ga']
+        })
+    )
+    assert df['out1'].iloc[0] == ['80', 'ga', ' 90', 'ga', ' 100', 'ga', '']
+
+def test_split_text_regex():
+    """
+    Tests split.text using regex
+    """
+    df = wrangles.recipe.run(
+        """
+        wrangles:
+            - split.text:
+                input: col1
+                output: out1
+                char: 'regex: (,|!)'
+        """,
+        dataframe=pd.DataFrame({
+            'col1': ['Hello, Wrangles!']
+        })
+    )
+    assert (
+        df['out1'].iloc[0][1] == ',' and
+        len(df['out1'].iloc[0]) == 5
+    )
+
+def test_split_text_pad_mismatch_error():
+    """
+    Test that an appropriate error is given to the user
+    if the user sets pad: false and the length of the output
+    does not match the number of columns.
+    """
+    with pytest.raises(ValueError, match="same length"):
+        wrangles.recipe.run(
+            """
+            read:
+            - test:
+                rows: 1
+                values:
+                  col1: "wrangles,are,cool"
+            wrangles:
+                - split.text:
+                    input: col1
+                    output:
+                      - out1
+                      - out2
+                      - out3
+                      - out4
+                    pad: False
+            """
+        )
 
 #
 # Split from List
@@ -510,38 +751,3 @@ def test_tokenize_where():
     """
     df = wrangles.recipe.run(recipe, dataframe=data)
     assert df.iloc[1]['out1'][0] == 'Titanium' and df.iloc[0]['out1'] == ''
-
-def test_split_text_inclusive():
-    """
-    Tests split.text with inclusive set to True
-    """
-    data = pd.DataFrame({
-    'col1': ['80ga 90ga 100ga']
-    })
-    recipe = """
-    wrangles:
-        - split.text:
-            input: col1
-            output: out1
-            char: 'ga'
-            inclusive: True
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
-    assert df['out1'].iloc[0] == ['80', 'ga', ' 90', 'ga', ' 100', 'ga', '']
-
-def test_split_text_regex():
-    """
-    Tests split.text using regex
-    """
-    data = pd.DataFrame({
-    'col1': ['Hello, Wrangles!']
-    })
-    recipe = """
-    wrangles:
-        - split.text:
-            input: col1
-            output: out1
-            char: 'regex: (,|!)'
-    """
-    df = wrangles.recipe.run(recipe, dataframe=data)
-    assert df['out1'].iloc[0][1] == ',' and len(df['out1'].iloc[0]) == 5

--- a/wrangles/recipe_wrangles/split.py
+++ b/wrangles/recipe_wrangles/split.py
@@ -149,20 +149,31 @@ def text(
     else:
         # User has given a single column - return as a list within that column
         df[output] = results
-        
-    # Specific element of the output list
-    if isinstance(element, int):
+
+    def _get_element(values, element):
+        """
+        Get a specific element from a list
+        If the element is not found or list is too short, return an empty string
+        """
         element_list = []
-        for x in df[output]:
+        for x in values:
             try:
                 element_list.append(x[element])
             except(IndexError):
                 element_list.append('')
-        df[output] = element_list
+        return element_list
+        
+    # Specific element of the output list
+    if isinstance(element, int):
+        df[output] = _get_element(df[output].values.tolist(), element)
         
     elif isinstance(element, str):
-        slice_values = [int(x) for x in element.split(':')]
-        df[output] = df[output].apply(lambda x: x[slice_values[0]:slice_values[1]])
+        if ':' in element:
+          start, end = map(lambda x: int(x) if x else None, element.split(':'))
+          df[output] = df[output].apply(lambda x: x[start:end])
+        else:
+          df[output] = _get_element(df[output].values.tolist(), int(element))
+
         
     return df
 


### PR DESCRIPTION
Allow for a string to work in element parameter
also also for slicing like ":3" and "3:" to work. Before it only worked with two numbers "1:3"

This will also help recipes coming from excel in case element param gets passed as a string