### PR TITLE
skip empty param for suffix and prefix

### DIFF
--- a/tests/recipes/wrangles/test_format.py
+++ b/tests/recipes/wrangles/test_format.py
@@ -270,6 +270,117 @@ def test_prefix_where():
     df = wrangles.recipe.run(recipe, dataframe=data)
     assert df.iloc[0]['pre-col'] == '' and df.iloc[2]['pre-col'] == 'extra-califragilisticexpialidocious'
     
+def test_prefix_skip_mult_empty_false():
+    """
+    Testing format.prefix with skip_empty false
+    """
+    data = pd.DataFrame({
+        'col1': ['terrestrial','','ordinary'],
+        'col2': ['soft','','cripsy'],
+    })
+    recipe = """
+    wrangles:
+        - format.prefix:
+            input:
+                - col1
+                - col2
+            output: 
+                - out1
+                - out2
+            value: extra-
+    """   
+    df = wrangles.recipe.run(recipe, dataframe=data)
+    assert df.iloc[0]['out1'] == 'extra-terrestrial'
+    assert df.iloc[1]['out1'] == 'extra-'
+    assert df.iloc[2]['out1'] == 'extra-ordinary'
+    assert df.iloc[0]['out2'] == 'extra-soft'
+    assert df.iloc[1]['out2'] == 'extra-'
+    assert df.iloc[2]['out2'] == 'extra-cripsy'
+
+
+def test_prefix_skip_mult_empty_true():
+    """
+    Testing format.prefix with skip_empty false
+    """
+    data = pd.DataFrame({
+        'col1': ['terrestrial','','ordinary'],
+        'col2': ['soft','','cripsy'],
+    })
+    recipe = """
+    wrangles:
+        - format.prefix:
+            input:
+                - col1
+                - col2
+            output: 
+                - out1
+                - out2
+            value: extra-
+            skip_empty: true
+    """   
+    df = wrangles.recipe.run(recipe, dataframe=data)
+    assert df.iloc[0]['out1'] == 'extra-terrestrial'
+    assert df.iloc[1]['out1'] == ''
+    assert df.iloc[2]['out1'] == 'extra-ordinary'
+    assert df.iloc[0]['out2'] == 'extra-soft'
+    assert df.iloc[1]['out2'] == ''
+    assert df.iloc[2]['out2'] == 'extra-cripsy'
+
+def test_prefix_skip_empty_false():
+    """
+    Testing format.prefix with skip_empty false
+    """
+    data = pd.DataFrame(
+        [['Red White Blue Round Titanium Shield'],
+        ['300V 1/2" Drive Impact Wrench'],
+        [''],
+        ['400 torque 1/2" Drive Impact Wrench'],
+        [''],
+        ['Hard Hat 30in w/ Light'],
+        ],
+        columns=['Tools']
+    )
+    recipe = """
+    wrangles:
+        - format.prefix:
+            input: Tools
+            output: Tool Output
+            value: OSHA approved-
+            skip_empty: false
+    """   
+    df = wrangles.recipe.run(recipe, dataframe=data)
+    assert df.iloc[0]['Tool Output'] == 'OSHA approved-Red White Blue Round Titanium Shield' 
+    assert df.iloc[1]['Tool Output'] == 'OSHA approved-300V 1/2" Drive Impact Wrench'
+    assert df.iloc[2]['Tool Output'] == 'OSHA approved-'
+
+def test_prefix_skip_empty_true():
+    """
+    Testing format.prefix with skip_empty true
+    """
+    data = pd.DataFrame(
+        [['Red White Blue Round Titanium Shield'],
+        ['300V 1/2" Drive Impact Wrench'],
+        [''],
+        ['400 torque 1/2" Drive Impact Wrench'],
+        [''],
+        ['Hard Hat 30in w/ Light'],
+        ],
+        columns=['Tools']
+    )
+    recipe = """
+    wrangles:
+      - format.prefix:
+          input: Tools
+          output: Tool Output
+          value: OSHA approved-
+          skip_empty: true
+    """   
+    df = wrangles.recipe.run(recipe, dataframe=data)
+    assert df.iloc[0]['Tool Output'] == 'OSHA approved-Red White Blue Round Titanium Shield' 
+    assert df.iloc[1]['Tool Output'] == 'OSHA approved-300V 1/2" Drive Impact Wrench'
+    assert df.iloc[2]['Tool Output'] == ''
+
+
 #    
 # Suffix
 #
@@ -363,6 +474,64 @@ def test_suffix_where():
     """
     df = wrangles.recipe.run(recipe, dataframe=data)
     assert df.iloc[0]['col-suf'] == '' and df.iloc[2]['col-suf'] == 'supercalifragilisticexpialidocious-cy'
+    
+
+def test_suffix_skip_mult_empty_false():
+    """
+    Testing format.suffix with skip_empty false
+    """
+    data = pd.DataFrame({
+        'col1': ['hard','','soft'],
+        'col2': ['quick','','slowly'],
+    })
+    recipe = """
+    wrangles:
+        - format.suffix:
+            input:
+                - col1
+                - col2
+            output: 
+                - out1
+                - out2
+            value: ly
+    """   
+    df = wrangles.recipe.run(recipe, dataframe=data)
+    print()
+    assert df.iloc[0]['out1'] == 'hardly'
+    assert df.iloc[1]['out1'] == 'ly'
+    assert df.iloc[2]['out1'] == 'softly'
+    assert df.iloc[0]['out2'] == 'quickly'
+    assert df.iloc[1]['out2'] == 'ly'
+    assert df.iloc[2]['out2'] == 'slowly'
+
+
+def test_suffix_skip_mult_empty_true():
+    """
+    Testing format.suffix with skip_empty false
+    """
+    data = pd.DataFrame({
+        'col1': ['hard','','soft'],
+        'col2': ['quick','','slowly'],
+    })
+    recipe = """
+    wrangles:
+        - format.suffix:
+            input:
+                - col1
+                - col2
+            output: 
+                - out1
+                - out2
+            value: extra-
+            skip_empty: true
+    """   
+    df = wrangles.recipe.run(recipe, dataframe=data)
+    assert df.iloc[0]['out1'] == 'hardly'
+    assert df.iloc[1]['out1'] == ''
+    assert df.iloc[2]['out1'] == 'softly'
+    assert df.iloc[0]['out2'] == 'quickly'
+    assert df.iloc[1]['out2'] == ''
+    assert df.iloc[2]['out2'] == 'slowly'
     
 #
 # date format

--- a/wrangles/recipe_wrangles/format.py
+++ b/wrangles/recipe_wrangles/format.py
@@ -130,10 +130,10 @@ def prefix(
           - string
           - array
         description: (Optional) Name of the output column
-        skip_empty:
-          type: boolean
-          desription: Whether to skip empty values
-          default: (Optional) false
+      skip_empty:
+        type: boolean
+        desription: Whether to skip empty values
+        default: (Optional) false
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input

--- a/wrangles/recipe_wrangles/format.py
+++ b/wrangles/recipe_wrangles/format.py
@@ -101,7 +101,13 @@ def pad(df: _pd.DataFrame, input: _Union[str, list], pad_length: int, side: str,
     return df
 
 
-def prefix(df: _pd.DataFrame, input: _Union[str, list], value: str, output: _Union[str, list] = None) -> _pd.DataFrame:
+def prefix(
+    df: _pd.DataFrame,
+    input: _Union[str, list], 
+    value: str, 
+    output: _Union[str, list] = None,
+    skip_empty: bool = False
+) -> _pd.DataFrame:
     """
     type: object
     description: Add a prefix to a column
@@ -124,6 +130,10 @@ def prefix(df: _pd.DataFrame, input: _Union[str, list], value: str, output: _Uni
           - string
           - array
         description: (Optional) Name of the output column
+        skip_empty:
+          type: boolean
+          desription: Whether to skip empty values
+          default: (Optional) false
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -138,7 +148,11 @@ def prefix(df: _pd.DataFrame, input: _Union[str, list], value: str, output: _Uni
     
     # Loop through and apply for all columns
     for input_column, output_column in zip(input, output):
-        df[output_column] = value + df[input_column].astype(str)
+        # If boolean is true, skip empty values
+        if skip_empty:
+          df[output_column] = df[input_column].apply(lambda x: value + x if x else x)
+        else:  
+          df[output_column] = value + df[input_column].astype(str)
 
     return df
 
@@ -220,7 +234,13 @@ def significant_figures(df: _pd.DataFrame, input: _Union[str, list], significant
     return df
 
 
-def suffix(df: _pd.DataFrame, input: _Union[str, list], value: _Union[str, list], output: str = None) -> _pd.DataFrame:
+def suffix(
+      df: _pd.DataFrame, 
+      input: _Union[str, list], 
+      value: _Union[str, list], 
+      output: str = None,
+      skip_empty: bool = False
+) -> _pd.DataFrame:
     """
     type: object
     description: Add a suffix to a column
@@ -242,6 +262,10 @@ def suffix(df: _pd.DataFrame, input: _Union[str, list], value: _Union[str, list]
             - string
             - array
           description: (Optional) Name of the output column
+        skip_empty:
+          type: boolean
+          description: Whether to skip empty values
+          default: (Optional) false
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -256,8 +280,10 @@ def suffix(df: _pd.DataFrame, input: _Union[str, list], value: _Union[str, list]
     
     # Loop through and apply for all columns
     for input_column, output_column in zip(input, output):
-        df[output_column] = df[input_column].astype(str) + value
-  
+        if skip_empty:
+            df[output_column] = df[input_column].apply(lambda x: x + value if x else x)
+        else:
+          df[output_column] = df[input_column].astype(str) + value
     return df
 
 


### PR DESCRIPTION
Added a new option for suffix and prefix wrangles to skip empty cells

```
      skip_empty:
        type: boolean
        desription: Whether to skip empty values
        default: (Optional) false
```

