### PR TITLE
Train extract.ai

### DIFF
--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -159,7 +159,7 @@ def test_extract_ai_write():
     recipe = """
     write:
       - train.extract:
-          name: Let's add variant now again
+          model_id: d188e7a7-9de8-4565
           variant: ai
     """
     data = pd.DataFrame({
@@ -172,7 +172,95 @@ def test_extract_ai_write():
         'Notes': ['Notes here', 'and here', 'and also here']
     })
     df = wrangles.recipe.run(recipe, dataframe=data)
-    assert df.iloc[0]['Entity to Find'] == 'Rachel'
+    assert df.iloc[0]['Find'] == 'Finish'
+
+def test_extract_ai_write_no_variant():
+    """
+    Writing data to an extract.ai wrangle without specifying the variant
+    """
+    with pytest.raises(ValueError, match="must be provided for train.extract."):
+        wrangles.recipe.run(
+            """
+            write:
+              - train.extract:
+                  model_id: d188e7a7-9de8-4565
+            """,
+            dataframe=pd.DataFrame({
+                'Find': ['Finish', 'Length', 'Product Type'],
+                'Description': ['The finish of the product', 'The length of the item in inches', 'The type of product'],
+                'Type': ['string', 'string', 'string'],
+                'Default': ['None', 'None', 'None'],
+                'Examples': [['Chrome', 'Matte', 'Gloss'], ['12', '24', '36'], ['Furniture', 'Electronics', 'Clothing']],
+                'Enum': [[], [], []],
+                'Notes': ['Notes here', 'and here', 'and also here']
+            })
+        )
+
+def test_extract_ai_write_name_and_model_id():
+    """
+    Writing data to an extract.ai wrangle with both name and model_id
+    """
+    with pytest.raises(ValueError, match="Name and model_id cannot both be provided, please use name to create a new model or model_id to update an existing model"):
+        wrangles.recipe.run(
+            """
+            write:
+              - train.extract:
+                  model_id: d188e7a7-9de8-4565
+                  name: My Wrangle Has a First Name, It's O-S-C-A-R
+            """,
+            dataframe=pd.DataFrame({
+                'Find': ['Finish', 'Length', 'Product Type'],
+                'Description': ['The finish of the product', 'The length of the item in inches', 'The type of product'],
+                'Type': ['string', 'string', 'string'],
+                'Default': ['None', 'None', 'None'],
+                'Examples': [['Chrome', 'Matte', 'Gloss'], ['12', '24', '36'], ['Furniture', 'Electronics', 'Clothing']],
+                'Enum': [[], [], []],
+                'Notes': ['Notes here', 'and here', 'and also here']
+            })
+        )
+
+def test_extract_ai_write_wrong_variant():
+    """
+    Writing data to an extract.ai wrangle with the wrong variant
+    """
+    with pytest.raises(ValueError, match="The variant must be either 'pattern matching' or 'ai'"):
+        wrangles.recipe.run(
+            """
+            write:
+              - train.extract:
+                  model_id: d188e7a7-9de8-4565
+                  variant: WRONG
+            """,
+            dataframe=pd.DataFrame({
+                'Find': ['Finish', 'Length', 'Product Type'],
+                'Description': ['The finish of the product', 'The length of the item in inches', 'The type of product'],
+                'Type': ['string', 'string', 'string'],
+                'Default': ['None', 'None', 'None'],
+                'Examples': [['Chrome', 'Matte', 'Gloss'], ['12', '24', '36'], ['Furniture', 'Electronics', 'Clothing']],
+                'Enum': [[], [], []],
+                'Notes': ['Notes here', 'and here', 'and also here']
+            })
+        )
+
+def test_extract_ai_write_wrong_columns():
+    """
+    Writing data to an extract.ai wrangle with the wrong variant
+    """
+    with pytest.raises(ValueError, match="The columns Find, Description, Type, Default, Examples, Enum, Notes must be provided for train.extract"):
+        wrangles.recipe.run(
+            """
+            write:
+              - train.extract:
+                  model_id: d188e7a7-9de8-4565
+                  variant: ai
+            """,
+            dataframe=pd.DataFrame({
+                'Default': ['None', 'None', 'None'],
+                'Examples': [['Chrome', 'Matte', 'Gloss'], ['12', '24', '36'], ['Furniture', 'Electronics', 'Clothing']],
+                'Enum': [[], [], []],
+                'Notes': ['Notes here', 'and here', 'and also here']
+            })
+        )
 
 def test_extract_write_2():
     """

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -152,6 +152,28 @@ def test_extract_write():
     df = wrangles.recipe.run(recipe, dataframe=data)
     assert df.iloc[0]['Entity to Find'] == 'Rachel'
 
+def test_extract_ai_write():
+    """
+    Writing data to a wrangle (re-training)
+    """
+    recipe = """
+    write:
+      - train.extract:
+          name: Let's add variant now again
+          variant: ai
+    """
+    data = pd.DataFrame({
+        'Find': ['Finish', 'Length', 'Product Type'],
+        'Description': ['The finish of the product', 'The length of the item in inches', 'The type of product'],
+        'Type': ['string', 'string', 'string'],
+        'Default': ['None', 'None', 'None'],
+        'Examples': [['Chrome', 'Matte', 'Gloss'], ['12', '24', '36'], ['Furniture', 'Electronics', 'Clothing']],
+        'Enum': [[], [], []],
+        'Notes': ['Notes here', 'and here', 'and also here']
+    })
+    df = wrangles.recipe.run(recipe, dataframe=data)
+    assert df.iloc[0]['Entity to Find'] == 'Rachel'
+
 def test_extract_write_2():
     """
     Incorrect columns for extract read

--- a/wrangles/connectors/train.py
+++ b/wrangles/connectors/train.py
@@ -125,13 +125,27 @@ class extract():
         """
         _logging.info(f": Training Extract Wrangle")
 
+        # Error handling for variant
+        if variant == 'ai':
+            variant = 'extract-ai'
+
+        if variant not in ['pattern matching', 'extract-ai']:
+            raise ValueError("The variant must be either 'pattern matching' or 'ai'")
+        
+        # Error handling for name, model_id and settings
+        if name and model_id:
+            raise ValueError("Extract: Name and model_id cannot both be provided, please use name to create a new model or model_id to update an existing model.")
+        
+        if name is None and model_id is None:
+            raise ValueError("Extract: Either a name or a model id must be provided. Use name to create a new model or model_id to update an existing model.")
+
         # Select only specific columns if user requests them
         if columns is not None: df = df[columns]
 
         if variant == 'pattern matching':
             required_columns = ['Entity to Find', 'Variation (Optional)', 'Notes']
             col_len = 3
-        elif variant == 'ai':
+        elif variant == 'extract-ai':
             required_columns = ['Find', 'Description', 'Type', 'Default', 'Examples', 'Enum', 'Notes']
             col_len = 7
         if not required_columns == list(df.columns[:col_len]):

--- a/wrangles/connectors/train.py
+++ b/wrangles/connectors/train.py
@@ -114,7 +114,7 @@ class extract():
             description: Specific model to read
         """
 
-    def write(df: _pd.DataFrame, columns: list = None, name: str = None, model_id: str = None) -> None:
+    def write(df: _pd.DataFrame, columns: list = None, name: str = None, model_id: str = None, variant: str = 'pattern matching') -> None:
         """
         Train a new or existing extract wrangle
 
@@ -128,11 +128,16 @@ class extract():
         # Select only specific columns if user requests them
         if columns is not None: df = df[columns]
 
-        required_columns = ['Entity to Find', 'Variation (Optional)', 'Notes']
-        if not required_columns == list(df.columns[:3]):
+        if variant == 'pattern matching':
+            required_columns = ['Entity to Find', 'Variation (Optional)', 'Notes']
+            col_len = 3
+        elif variant == 'ai':
+            required_columns = ['Find', 'Description', 'Type', 'Default', 'Examples', 'Enum', 'Notes']
+            col_len = 7
+        if not required_columns == list(df.columns[:col_len]):
             raise ValueError(f"The columns {', '.join(required_columns)} must be provided for train.extract.")
 
-        _train.extract(df[required_columns].values.tolist(), name, model_id)
+        _train.extract(df[required_columns].values.tolist(), name, model_id, variant)
 
     _schema["write"] = """
         type: object

--- a/wrangles/train.py
+++ b/wrangles/train.py
@@ -59,12 +59,12 @@ class train():
             if training_data[0] != ['Entity to Find', 'Variation (Optional)', 'Notes']:
                 training_data = [['Entity to Find', 'Variation (Optional)', 'Notes']] + training_data
         
-        # If input is a list, check to make sure that all sublists are length of 2
-        # Must have both values filled ('' counts as filled, None does not count)
-        if isinstance(training_data, list) and variant == 'ai':
+        # If input is a list, check to make sure that all sublists are length of 7
+        # Must have all values filled ('' counts as filled, None does not count)
+        if isinstance(training_data, list) and variant == 'extract-ai':
             check_index = [training_data.index(x) for x in training_data if len(x) != 7]
-            if len(check_index) != 0: # If an index does not have len() of 2 then raise error
-                raise ValueError(f"Training_data list must contain a list of two elements, plus optional Notes. Check element(s) {check_index} in training_list.\nFormat:\nFirst element is 'Entity to Find'\nSecond Element is 'Variation', If no variation, use \'\'\n"
+            if len(check_index) != 0: # If an index does not have len() of 6 then raise error
+                raise ValueError(f"Training_data list must contain a list of six elements, plus optional Notes. Check element(s) {check_index} in training_list.\nFormat:\nFirst element is 'Find'\nSecond Element is 'Description', If no variation, use \'\'\n"
                 # This example needs to be updated with the 5 other columns
                 "Example:[['Colour', 'The colour of the item']]")
             # checking the first element in training list
@@ -74,7 +74,7 @@ class train():
         if name:
             response = _requests.post(f'{_config.api_host}/model/content', params={'type':'extract', 'name': name, 'variant': variant}, headers={'Authorization': f'Bearer {_auth.get_access_token()}'}, json=training_data)
         elif model_id:
-            response = _requests.put(f'{_config.api_host}/model/content', params={'type':'extract', 'model_id': model_id}, headers={'Authorization': f'Bearer {_auth.get_access_token()}'}, json=training_data)
+            response = _requests.put(f'{_config.api_host}/model/content', params={'type':'extract', 'model_id': model_id, 'variant': variant}, headers={'Authorization': f'Bearer {_auth.get_access_token()}'}, json=training_data)
         else:
             raise ValueError('Either a name or a model id must be provided')
 

--- a/wrangles/train.py
+++ b/wrangles/train.py
@@ -39,7 +39,7 @@ class train():
 
         return response
 
-    def extract(training_data: list, name: str = None, model_id: str = None):
+    def extract(training_data: list, name: str = None, model_id: str = None, variant: str = 'pattern matching'):
         """
         Train an extraction model. This can extract custom entities from the input.
         Requires WrangleWorks Account and Subscription.
@@ -50,7 +50,7 @@ class train():
         """
         # If input is a list, check to make sure that all sublists are length of 2
         # Must have both values filled ('' counts as filled, None does not count)
-        if isinstance(training_data, list):
+        if isinstance(training_data, list) and variant == 'pattern matching':
             check_index = [training_data.index(x) for x in training_data if len(x) != 3]
             if len(check_index) != 0: # If an index does not have len() of 2 then raise error
                 raise ValueError(f"Training_data list must contain a list of two elements, plus optional Notes. Check element(s) {check_index} in training_list.\nFormat:\nFirst element is 'Entity to Find'\nSecond Element is 'Variation', If no variation, use \'\'\n"
@@ -59,8 +59,20 @@ class train():
             if training_data[0] != ['Entity to Find', 'Variation (Optional)', 'Notes']:
                 training_data = [['Entity to Find', 'Variation (Optional)', 'Notes']] + training_data
         
+        # If input is a list, check to make sure that all sublists are length of 2
+        # Must have both values filled ('' counts as filled, None does not count)
+        if isinstance(training_data, list) and variant == 'ai':
+            check_index = [training_data.index(x) for x in training_data if len(x) != 7]
+            if len(check_index) != 0: # If an index does not have len() of 2 then raise error
+                raise ValueError(f"Training_data list must contain a list of two elements, plus optional Notes. Check element(s) {check_index} in training_list.\nFormat:\nFirst element is 'Entity to Find'\nSecond Element is 'Variation', If no variation, use \'\'\n"
+                # This example needs to be updated with the 5 other columns
+                "Example:[['Colour', 'The colour of the item']]")
+            # checking the first element in training list
+            if training_data[0] != ['Find', 'Description', 'Type', 'Default', 'Examples', 'Enum', 'Notes']:
+                training_data = [['Find', 'Description', 'Type', 'Default', 'Examples', 'Enum', 'Notes']] + training_data
+        
         if name:
-            response = _requests.post(f'{_config.api_host}/model/content', params={'type':'extract', 'name': name}, headers={'Authorization': f'Bearer {_auth.get_access_token()}'}, json=training_data)
+            response = _requests.post(f'{_config.api_host}/model/content', params={'type':'extract', 'name': name, 'variant': variant}, headers={'Authorization': f'Bearer {_auth.get_access_token()}'}, json=training_data)
         elif model_id:
             response = _requests.put(f'{_config.api_host}/model/content', params={'type':'extract', 'model_id': model_id}, headers={'Authorization': f'Bearer {_auth.get_access_token()}'}, json=training_data)
         else:


### PR DESCRIPTION
There is some redundancy with check_index in the train.py wrangle, not sure of a nice way to reduce this.

I also noticed that all columns (including Notes) are required to train a pattern matching extract, so therefore extract.ai is the same. Would be nice to not have to include these, but that is another thing that I am not sure how to go about.