### PR TITLE
Added better error handling to round function

### DIFF
--- a/tests/recipes/wrangles/test_pandas.py
+++ b/tests/recipes/wrangles/test_pandas.py
@@ -438,11 +438,62 @@ class TestRound:
                 decimals: 1
             """,
             dataframe=pd.DataFrame({
-                'col': [3.13, "Something else", 1.16, None]
+                'col': [3.13, "Something else", 1.16, None, "2.5555"]
             })
         )
-        assert df['col'].to_list() == [3.1, '', 1.2, '']
+        assert df['col'].to_list() == [3.1, '', 1.2, '', 2.6]
 
+    def test_round_string(self):
+        """
+        test round with strings
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - round:
+                input: col
+                decimals: 1
+            """,
+            dataframe=pd.DataFrame({
+                'col': ["3.13", "1.16", "2.5555", "3.15"]
+            })
+        )
+        assert df['col'].to_list() == [3.1, 1.2, 2.6, 3.2]
+
+    def test_round_floatinf(self):
+        """
+        test infinity
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - round:
+                input: col
+                decimals: 1
+            """,
+            dataframe=pd.DataFrame({
+                'col': [float('inf'), float('-inf')]
+            })
+        )
+        assert df['col'].to_list() == [float('inf'), float('-inf')]
+
+    def test_round_int(self):
+        """
+        test int values
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - round:
+                input: col
+                decimals: 1
+            """,
+            dataframe=pd.DataFrame({
+                'col': [3, 1, 2, 3]
+            })
+        )
+        assert df['col'].to_list() == [3.0, 1.0, 2.0, 3.0]
+        
 
 class TestReindex:
     """

--- a/tests/recipes/wrangles/test_pandas.py
+++ b/tests/recipes/wrangles/test_pandas.py
@@ -425,6 +425,24 @@ class TestRound:
         )
         assert df['col'].to_list() == [3.1, 1.16, 2.6, 3.2]
 
+    def test_round_mixed(self):
+        """
+        Test round with mixed inputs and outputs
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - round:
+                input:
+                    - col
+                decimals: 1
+            """,
+            dataframe=pd.DataFrame({
+                'col': [3.13, "Something else", 1.16, None]
+            })
+        )
+        assert df['col'].to_list() == [3.1, '', 1.2, '']
+
 
 class TestReindex:
     """

--- a/tests/recipes/wrangles/test_pandas.py
+++ b/tests/recipes/wrangles/test_pandas.py
@@ -4,7 +4,7 @@ Tests for passthrough pandas capabilities
 import wrangles
 import pandas as pd
 import pytest
-
+from numpy import float128, float64, float32, float16
 
 class TestPandasHead:
     """
@@ -493,6 +493,23 @@ class TestRound:
             })
         )
         assert df['col'].to_list() == [3.0, 1.0, 2.0, 3.0]
+
+    def test_round_float(self):
+        """
+        test float values
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - round:
+                input: col
+                decimals: 1
+            """,
+            dataframe=pd.DataFrame({
+                'col': [float16(3.333), float32(1003.22), float64(489324.2343), float128(8948293423.23455)]
+            })
+        )
+        assert df['col'].to_list() == [3.3, 1003.2, 489324.2, 8948293423.2]
         
 
 class TestReindex:

--- a/tests/recipes/wrangles/test_pandas.py
+++ b/tests/recipes/wrangles/test_pandas.py
@@ -4,7 +4,7 @@ Tests for passthrough pandas capabilities
 import wrangles
 import pandas as pd
 import pytest
-from numpy import float128, float64, float32, float16
+from numpy import half, single, double, longdouble
 
 class TestPandasHead:
     """
@@ -506,7 +506,7 @@ class TestRound:
                 decimals: 1
             """,
             dataframe=pd.DataFrame({
-                'col': [float16(3.333), float32(1003.22), float64(489324.2343), float128(8948293423.23455)]
+                'col': [half(3.333), single(1003.22), double(489324.2343), longdouble(8948293423.23455)]
             })
         )
         assert df['col'].to_list() == [3.3, 1003.2, 489324.2, 8948293423.2]

--- a/wrangles/recipe_wrangles/pandas.py
+++ b/wrangles/recipe_wrangles/pandas.py
@@ -128,7 +128,7 @@ def round(df: _pd.DataFrame, input: _Union[str, list], decimals: int = 0, output
     for input_column, output_column in zip(input, output):
         # coerce input column to floats (nan on error)
         # replace nan with empty string
-        df[output_column] = _pd.to_numeric(df[input_column], errors='coerce').round(decimals=decimals).replace(_nan, '')
+        df[output_column] = _pd.to_numeric(df[input_column], errors='coerce').round(decimals=decimals).map(float).replace(_nan, '')
         
     return df
     

--- a/wrangles/recipe_wrangles/pandas.py
+++ b/wrangles/recipe_wrangles/pandas.py
@@ -1,6 +1,6 @@
 import pandas as _pd
 from typing import Union as _Union
-from numpy import nan
+from numpy import nan as _nan
 
 
 def copy(df: _pd.DataFrame, input: _Union[str, list], output: _Union[str, list]) -> _pd.DataFrame:
@@ -128,7 +128,7 @@ def round(df: _pd.DataFrame, input: _Union[str, list], decimals: int = 0, output
     for input_column, output_column in zip(input, output):
         # coerce input column to floats (nan on error)
         # replace nan with empty string
-        df[output_column] = _pd.to_numeric(df[input_column], errors='coerce').round(decimals=decimals).replace(nan, '')
+        df[output_column] = _pd.to_numeric(df[input_column], errors='coerce').round(decimals=decimals).replace(_nan, '')
         
     return df
     

--- a/wrangles/recipe_wrangles/pandas.py
+++ b/wrangles/recipe_wrangles/pandas.py
@@ -1,5 +1,6 @@
 import pandas as _pd
 from typing import Union as _Union
+from numpy import nan
 
 
 def copy(df: _pd.DataFrame, input: _Union[str, list], output: _Union[str, list]) -> _pd.DataFrame:
@@ -125,7 +126,9 @@ def round(df: _pd.DataFrame, input: _Union[str, list], decimals: int = 0, output
     if not isinstance(output, list): output = [output]
     
     for input_column, output_column in zip(input, output):
-        df[output_column] = df[input_column].round(decimals=decimals)
+        # coerce input column to floats (nan on error)
+        # replace nan with empty string
+        df[output_column] = _pd.to_numeric(df[input_column], errors='coerce').round(decimals=decimals).replace(nan, '')
         
     return df
     


### PR DESCRIPTION
Added better error handling to fix an issue that was occurring with the rounding recipe.  

The recipe used the default behavior of the pandas `round` function, returning the original column if any of the row types were incompatible.  

Added the `to_numeric` function, which allows coercion to a float and returns `nan` if the datatype is incompatible.  Then the pandas `round` function is applied as normal and any remaining `nan` is replaced with an empty string to play nice with the front end