### PR TITLE
740 wildcard columns no match error

### DIFF
--- a/tests/recipes/test_recipes.py
+++ b/tests/recipes/test_recipes.py
@@ -741,6 +741,33 @@ class TestColumnWildcards:
             len(df) == 10
         )
 
+    def test_non_matching_wildcard(self):
+        """
+        Test error message - wildcard expansion finds no matches
+        """
+        data = pd.DataFrame({
+            'name': ['hammer', 'wrench', 'cable'],
+            'val1': ['13 kg', '5kg', '1kg'],
+            'val2': ['13cm', '12cm', '30cm'],
+            'val3': ['blue', 'silver', 'orange']
+        })
+        with pytest.raises(ValueError) as info:
+
+            raise wrangles.recipe.run(
+                """
+                wrangles:
+                - format.trim
+                    input: attr*
+                """,
+                dataframe=data
+            )
+        assert (
+            input.typename == 'ValueError' and
+            'Wildcard expansion pattern did not find any matching columns' in info.value.args[0]
+        )
+
+
+
 def test_run_as_string():
     """
     Test a run defined as a string runs correctly assuming there are no parameters.

--- a/tests/recipes/test_recipes.py
+++ b/tests/recipes/test_recipes.py
@@ -751,18 +751,43 @@ class TestColumnWildcards:
             'val2': ['13cm', '12cm', '30cm'],
             'val3': ['blue', 'silver', 'orange']
         })
-        with pytest.raises(ValueError) as info:
-
+        with pytest.raises(KeyError) as info:
             raise wrangles.recipe.run(
                 """
                 wrangles:
-                - format.trim
+                - format.trim:
                     input: attr*
                 """,
                 dataframe=data
             )
         assert (
-            input.typename == 'ValueError' and
+            info.typename == 'KeyError' and
+            'Wildcard expansion pattern did not find any matching columns' in info.value.args[0]
+        )
+
+    def test_non_matching_wildcard_as_list(self):
+        """
+        Test error message - wildcard expansion finds no matches as list
+        """
+        data = pd.DataFrame({
+            'name': ['hammer', 'wrench', 'cable'],
+            'val1': ['13 kg', '5kg', '1kg'],
+            'val2': ['13cm', '12cm', '30cm'],
+            'val3': ['blue', 'silver', 'orange']
+        })
+        with pytest.raises(KeyError) as info:
+
+            raise wrangles.recipe.run(
+                """
+                wrangles:
+                - format.trim:
+                    input:
+                      - attr*
+                """,
+                dataframe=data
+            )
+        assert (
+            info.typename == 'KeyError' and
             'Wildcard expansion pattern did not find any matching columns' in info.value.args[0]
         )
 

--- a/tests/recipes/test_recipes.py
+++ b/tests/recipes/test_recipes.py
@@ -791,6 +791,33 @@ class TestColumnWildcards:
             'Wildcard expansion pattern did not find any matching columns' in info.value.args[0]
         )
 
+    def test_non_matching_wildcard_non_existing_inputs(self):
+        """
+        Test error message - two inputs that do not exists
+        """
+        data = pd.DataFrame({
+            'name': ['hammer', 'wrench', 'cable'],
+            'val1': ['13 kg', '5kg', '1kg'],
+            'val2': ['13cm', '12cm', '30cm'],
+            'val3': ['blue', 'silver', 'orange']
+        })
+        with pytest.raises(KeyError) as info:
+
+            raise wrangles.recipe.run(
+                """
+                wrangles:
+                - format.trim:
+                    input:
+                      - attr*
+                      - nothing
+                """,
+                dataframe=data
+            )
+        assert (
+            info.typename == 'KeyError' and
+            "format.trim - 'Column nothing does not exist'" in info.value.args[0]
+        )
+
 
 
 def test_run_as_string():

--- a/wrangles/utils.py
+++ b/wrangles/utils.py
@@ -350,6 +350,10 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
         else:
             if not optional_column:
                 raise KeyError(f'Column {column} does not exist')
+            
+    # If wildcard expansion is the only input and there are no matches, then raise an error
+    if len(result_columns) == 0 and len(selected_columns) == 1 and str(selected_columns[0]).startswith('regex'):
+        raise KeyError(f'Wildcard expansion pattern did not find any matching columns')
     
     # Return, preserving original order
     return list(result_columns.keys())


### PR DESCRIPTION
When using wildcard expansion as the only input, if there were no matches, the error would be cryptic and non-intuitive.

This is only when input contains only a wildcard. e.g.

```python
wrangles:
   - extract.ai:
         input: Attribute*

# OR

wrangles:
   - extract.ai:
         input:
           - Attribute*

```

I have added an error message that states:

`Wildcard expansion pattern did not find any matching columns`

If input contains an existing column and a NON matching wildcard columns, then the error would not show as this was the existing behavior. e.g.:

```python
wrangles:
  - convert.case:
      input:
         - attr* # will not match anything
         - Name # does exists in the df
```