### PR TITLE
Copy multi column (Wildcard Bug)

### DIFF
--- a/tests/recipes/wrangles/test_pandas.py
+++ b/tests/recipes/wrangles/test_pandas.py
@@ -272,6 +272,54 @@ class TestCopy:
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
         assert list(df.columns) == ['col', 'col2', 'col1-copy', 'col2-copy']
+        
+    def test_pd_copy_repeated_column(self):
+        """
+        Test copying one column multiple times
+        """
+        data = pd.DataFrame({
+            'col': ['Mario'],
+            'col2': ['Luigi']
+        })
+        recipe = """
+        wrangles:
+        - copy:
+            input:
+                - col
+                - col
+                - col
+                - col
+            output:
+                - col1-copy1
+                - col1-copy2
+                - col1-copy3
+                - col1-copy4
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert list(df.columns) == ['col', 'col2', 'col1-copy1', 'col1-copy2', 'col1-copy3', 'col1-copy4']
+        
+    def test_pd_copy_multi_cols_with_repetition(self):
+        """
+        Test multiple inputs and outputs where one column is repeated
+        """
+        data = pd.DataFrame({
+            'col': ['Mario'],
+            'col2': ['Luigi']
+        })
+        recipe = """
+        wrangles:
+        - copy:
+            input:
+                - col
+                - col2
+                - col
+            output:
+                - col1-copy
+                - col2-copy
+                - not-col1-copy
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert list(df.columns) == ['col', 'col2', 'col1-copy', 'col2-copy', 'not-col1-copy']
 
     def test_pd_copy_where(self):
         """

--- a/wrangles/utils.py
+++ b/wrangles/utils.py
@@ -299,10 +299,14 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
     for column in selected_columns:
         # If the column is already in all_columns, add it
         if column in all_columns:
+            # Check to see if column + gibbrish exists in result_columns
             if column + 'zsdhgfahkjh' in result_columns:
-                result_columns[column + 'zsdhgfahkjh' + str(counter)] = None
+                # Add counter if it exists
+                result_columns[column + 'zsdhgfahkjh' + str(counter)] = None 
                 counter += 1
+            # Check to see if column exists in result_columns
             elif column in result_columns:
+                # Add gibbrish if it does
                 result_columns[column + 'zsdhgfahkjh'] = None
                 counter += 1
             else:
@@ -354,10 +358,14 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
             optional_column = True
 
         if column in all_columns:
+            # Check to see if column + gibbrish exists in result_columns
             if column + 'zsdhgfahkjh' in result_columns:
-                result_columns[column + 'zsdhgfahkjh' + str(counter)] = None
+                # Add counter if it exists
+                result_columns[column + 'zsdhgfahkjh' + str(counter)] = None 
                 counter += 1
+            # Check to see if column exists in result_columns
             elif column in result_columns:
+                # Add gibbrish if it does
                 result_columns[column + 'zsdhgfahkjh'] = None
                 counter += 1
             else:

--- a/wrangles/utils.py
+++ b/wrangles/utils.py
@@ -294,11 +294,19 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
         # Otherwise initialize with no columns
         result_columns = {}
 
+    counter = 1
     # Identify any matching columns using regex within the list
     for column in selected_columns:
         # If the column is already in all_columns, add it
         if column in all_columns:
-            result_columns[column] = None
+            if column + 'zsdhgfahkjh' in result_columns:
+                result_columns[column + 'zsdhgfahkjh' + str(counter)] = None
+                counter += 1
+            elif column in result_columns:
+                result_columns[column + 'zsdhgfahkjh'] = None
+                counter += 1
+            else:
+                result_columns[column] = None
             continue
 
         # Rearrange -regex: to regex:- to allow either to work
@@ -346,13 +354,22 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
             optional_column = True
 
         if column in all_columns:
-            result_columns[column] = None
+            if column + 'zsdhgfahkjh' in result_columns:
+                result_columns[column + 'zsdhgfahkjh' + str(counter)] = None
+                counter += 1
+            elif column in result_columns:
+                result_columns[column + 'zsdhgfahkjh'] = None
+                counter += 1
+            else:
+                result_columns[column] = None
+            continue
         else:
             if not optional_column:
                 raise KeyError(f'Column {column} does not exist')
     
     # Return, preserving original order
-    return list(result_columns.keys())
+    return [key.split('zsdhgfahkjh')[0] for key in result_columns.keys()]
+    # return list(result_columns.keys())
 
 
 def evaluate_conditional(statement, variables: dict = {}):

--- a/wrangles/utils.py
+++ b/wrangles/utils.py
@@ -295,19 +295,20 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
         result_columns = {}
 
     counter = 1
+    gibberish = 'zsdhgfahkjh'
     # Identify any matching columns using regex within the list
     for column in selected_columns:
         # If the column is already in all_columns, add it
         if column in all_columns:
             # Check to see if column + gibberish exists in result_columns
-            if column + 'zsdhgfahkjh' in result_columns:
+            if column + gibberish in result_columns:
                 # Add counter if it exists
-                result_columns[column + 'zsdhgfahkjh' + str(counter)] = None 
+                result_columns[column + gibberish + str(counter)] = None 
                 counter += 1
             # Check to see if column exists in result_columns
             elif column in result_columns:
                 # Add gibberish if it does
-                result_columns[column + 'zsdhgfahkjh'] = None
+                result_columns[column + gibberish] = None
                 counter += 1
             else:
                 result_columns[column] = None
@@ -359,14 +360,14 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
 
         if column in all_columns:
             # Check to see if column + gibberish exists in result_columns
-            if column + 'zsdhgfahkjh' in result_columns:
+            if column + gibberish in result_columns:
                 # Add counter if it exists
-                result_columns[column + 'zsdhgfahkjh' + str(counter)] = None 
+                result_columns[column + gibberish + str(counter)] = None
                 counter += 1
             # Check to see if column exists in result_columns
             elif column in result_columns:
                 # Add gibberish if it does
-                result_columns[column + 'zsdhgfahkjh'] = None
+                result_columns[column + gibberish] = None
                 counter += 1
             else:
                 result_columns[column] = None
@@ -376,7 +377,7 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
                 raise KeyError(f'Column {column} does not exist')
     
     # Return, preserving original order
-    return [key.split('zsdhgfahkjh')[0] for key in result_columns.keys()]
+    return [key.split(gibberish)[0] for key in result_columns.keys()]
     # return list(result_columns.keys())
 
 

--- a/wrangles/utils.py
+++ b/wrangles/utils.py
@@ -299,14 +299,14 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
     for column in selected_columns:
         # If the column is already in all_columns, add it
         if column in all_columns:
-            # Check to see if column + gibbrish exists in result_columns
+            # Check to see if column + gibberish exists in result_columns
             if column + 'zsdhgfahkjh' in result_columns:
                 # Add counter if it exists
                 result_columns[column + 'zsdhgfahkjh' + str(counter)] = None 
                 counter += 1
             # Check to see if column exists in result_columns
             elif column in result_columns:
-                # Add gibbrish if it does
+                # Add gibberish if it does
                 result_columns[column + 'zsdhgfahkjh'] = None
                 counter += 1
             else:
@@ -358,14 +358,14 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
             optional_column = True
 
         if column in all_columns:
-            # Check to see if column + gibbrish exists in result_columns
+            # Check to see if column + gibberish exists in result_columns
             if column + 'zsdhgfahkjh' in result_columns:
                 # Add counter if it exists
                 result_columns[column + 'zsdhgfahkjh' + str(counter)] = None 
                 counter += 1
             # Check to see if column exists in result_columns
             elif column in result_columns:
-                # Add gibbrish if it does
+                # Add gibberish if it does
                 result_columns[column + 'zsdhgfahkjh'] = None
                 counter += 1
             else:

--- a/wrangles/utils.py
+++ b/wrangles/utils.py
@@ -294,24 +294,29 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
         # Otherwise initialize with no columns
         result_columns = {}
 
-    counter = 1
+    counter = 0
     gibberish = 'zsdhgfahkjh'
+    
+    # Function that checks to see if columns exist in result_columns,
+    # adds a known suffix for preservation if so
+    def column_checker(col, result_cols):
+        # Check to see if column + gibberish exists in result_columns
+        if col + gibberish in result_cols:
+            # Add counter if it exists
+            result_cols[col + gibberish + str(counter)] = None
+        # Check to see if column exists in result_columns
+        elif col in result_columns:
+            # Add gibberish if it does
+            result_cols[col + gibberish] = None
+        else:
+            result_cols[col] = None
+        return result_cols
     # Identify any matching columns using regex within the list
     for column in selected_columns:
         # If the column is already in all_columns, add it
         if column in all_columns:
-            # Check to see if column + gibberish exists in result_columns
-            if column + gibberish in result_columns:
-                # Add counter if it exists
-                result_columns[column + gibberish + str(counter)] = None 
-                counter += 1
-            # Check to see if column exists in result_columns
-            elif column in result_columns:
-                # Add gibberish if it does
-                result_columns[column + gibberish] = None
-                counter += 1
-            else:
-                result_columns[column] = None
+            column_checker(column, result_columns)
+            counter += 1
             continue
 
         # Rearrange -regex: to regex:- to allow either to work
@@ -359,18 +364,8 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
             optional_column = True
 
         if column in all_columns:
-            # Check to see if column + gibberish exists in result_columns
-            if column + gibberish in result_columns:
-                # Add counter if it exists
-                result_columns[column + gibberish + str(counter)] = None
-                counter += 1
-            # Check to see if column exists in result_columns
-            elif column in result_columns:
-                # Add gibberish if it does
-                result_columns[column + gibberish] = None
-                counter += 1
-            else:
-                result_columns[column] = None
+            column_checker(column, result_columns)
+            counter += 1
             continue
         else:
             if not optional_column:
@@ -378,7 +373,6 @@ def wildcard_expansion(all_columns: list, selected_columns: _Union[str, list]) -
     
     # Return, preserving original order
     return [key.split(gibberish)[0] for key in result_columns.keys()]
-    # return list(result_columns.keys())
 
 
 def evaluate_conditional(statement, variables: dict = {}):


### PR DESCRIPTION
This actually ended up being a wildcard expansion issue, not a copy issue. Essentially added gibberish to the column name if it already exists, gibberish plus a counter if that exists, then split on gibberish on the return.

To me, having the same column input multiple times only makes sense on the copy wrangle. Therefore, I only made tests for copy. I can add tests for other wrangles if needed. 

This pr will close issue #695 