### PR TITLE
Generate ai

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ simple-salesforce
 numexpr
 boto3
 jinja2
+pydantic

--- a/tests/recipes/wrangles/test_generate.py
+++ b/tests/recipes/wrangles/test_generate.py
@@ -1,0 +1,6 @@
+import os 
+import pandas as pd 
+import pytest 
+import wrangles
+@pytest.mark.skipif("OPENAI_API_KEY" not in os.environ,
+                    reason="needs live OpenAI access")

--- a/tests/recipes/wrangles/test_generate.py
+++ b/tests/recipes/wrangles/test_generate.py
@@ -4,3 +4,30 @@ import pytest
 import wrangles
 @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ,
                     reason="needs live OpenAI access")
+
+def test_generate_ai_recipe_without_web_search_real_call():
+    data = pd.DataFrame({
+        "product_name": ["Widget One"],
+        "features": ["Lightweight; durable"]
+    })
+
+    df = wrangles.recipe.run(
+        recipe="""
+        wrangles:
+          - generate.ai:
+              input:
+                - product_name
+                - features
+              output:
+                short_description:
+                  type: string
+                  description: Short marketing copy.
+                category:
+                  type: string
+                  description: Suggested category.
+              api_key: ${OPENAI_API_KEY}
+              model: gpt-5-nano
+              web_search: false
+        """,
+        dataframe=data
+    )

--- a/tests/recipes/wrangles/test_generate.py
+++ b/tests/recipes/wrangles/test_generate.py
@@ -31,3 +31,8 @@ def test_generate_ai_recipe_without_web_search_real_call():
         """,
         dataframe=data
     )
+
+
+    assert df.at[0, "short_description"]  # non-empty
+    assert df.at[0, "category"]
+    assert df.at[0, "source"] == "internally generated"

--- a/wrangles/__init__.py
+++ b/wrangles/__init__.py
@@ -28,7 +28,7 @@ from . import data
 from .train import train
 from . import select
 from . import compare
-
+from . import generate
 
 
 

--- a/wrangles/generate.py
+++ b/wrangles/generate.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+import concurrent.futures
+import copy
+import json
+from typing import Any,Dict,List,Literal,Union,Optional
+
+import requests
+try:
+    from bs4 import BeautifulSoup
+
+except ImportError:
+    BeautifulSoup = None 
+
+from pydantic import BaseModel
+

--- a/wrangles/generate.py
+++ b/wrangles/generate.py
@@ -43,3 +43,14 @@ def _perform_web_search(query: str) -> str:
         return " ".join(snippets[:5]) 
     except requests.RequestException: 
         return "Web search failed." 
+
+
+def _stringify_query(record: Any) -> str:
+    """Create a search query string from an arbitrary record."""
+    if isinstance(record, dict):
+        return " ".join(str(v) for v in record.values() if v not in (None, ""))
+    if isinstance(record, list):
+        return " ".join(str(v) for v in record if v not in (None, ""))
+    if record in (None, ""):
+        return ""
+    return str(record)

--- a/wrangles/generate.py
+++ b/wrangles/generate.py
@@ -25,3 +25,21 @@ class PropertyDefinition(BaseModel):
 
 PropertyDefinition.model_rebuild()
 
+def _perform_web_search(query: str) -> str: 
+    """Perform a simple web search to get context via DuckDuckGo."""
+    if BeautifulSoup is None:
+        return "Web search unavailable because beautifulsoup4 is not installed."
+
+    search_url = f"https://html.duckduckgo.com/html/?q={requests.utils.quote(query)}" 
+    headers = { 
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36' 
+    } 
+    try: 
+        response = requests.get(search_url, headers=headers, timeout=10) 
+        response.raise_for_status() 
+        soup = BeautifulSoup(response.text, 'html.parser') 
+        snippets = [p.get_text(strip=True) for p in soup.find_all('a', class_='result__a')] 
+        if not snippets: return "No web search results found." 
+        return " ".join(snippets[:5]) 
+    except requests.RequestException: 
+        return "Web search failed." 

--- a/wrangles/generate.py
+++ b/wrangles/generate.py
@@ -22,3 +22,6 @@ class PropertyDefinition(BaseModel):
     default: Optional[Any] = None 
     examples: Optional[List[Any]] = None 
     items: Optional[PropertyDefinition] = None 
+
+PropertyDefinition.model_rebuild()
+

--- a/wrangles/generate.py
+++ b/wrangles/generate.py
@@ -13,3 +13,4 @@ except ImportError:
 
 from pydantic import BaseModel
 
+JsonSchemaType = Literal["string", "number", "integer", "boolean", "null", "object", "array"] 

--- a/wrangles/generate.py
+++ b/wrangles/generate.py
@@ -14,3 +14,11 @@ except ImportError:
 from pydantic import BaseModel
 
 JsonSchemaType = Literal["string", "number", "integer", "boolean", "null", "object", "array"] 
+
+class PropertyDefinition(BaseModel):
+    type: JsonSchemaType = "string"
+    desccriptions: str
+    enum: Optional[List[Any]] = None 
+    default: Optional[Any] = None 
+    examples: Optional[List[Any]] = None 
+    items: Optional[PropertyDefinition] = None 

--- a/wrangles/recipe_wrangles/__init__.py
+++ b/wrangles/recipe_wrangles/__init__.py
@@ -25,3 +25,4 @@ from . import merge
 from . import select
 from . import split
 from . import compare
+from . import generate

--- a/wrangles/recipe_wrangles/generate.py
+++ b/wrangles/recipe_wrangles/generate.py
@@ -64,3 +64,21 @@ def ai(
     reasoning=reasoning,
     **kwargs
 )
+    
+    try:
+       
+        exploded_df = _pd.json_normalize(results, max_level=0).fillna('').set_index(df.index)
+
+        for col in target_columns:
+            if col not in exploded_df.columns:
+                exploded_df[col] = ""
+
+        if 'source' in exploded_df.columns and 'source' not in df.columns:
+            df['source'] = exploded_df['source']
+            
+        df[target_columns] = exploded_df[target_columns]
+
+    except Exception as e:
+        raise RuntimeError(f"Unable to parse the response from the AI model. Error: {e}")
+
+    return df    

--- a/wrangles/recipe_wrangles/generate.py
+++ b/wrangles/recipe_wrangles/generate.py
@@ -28,3 +28,14 @@ def ai(
         df_temp = df[input]
     else:
         df_temp = df
+
+    output_schema = output
+    if isinstance(output_schema, str):
+        output_schema = {output_schema: {"description": f"Generated content for {output_schema}"}}
+    elif isinstance(output_schema, list):
+        temp_dict = {}
+        for item in output_schema:
+            temp_dict[str(item)] = {"description": f"Generated content for {str(item)}"}
+        output_schema = temp_dict
+
+    target_columns = list(output_schema.keys())

--- a/wrangles/recipe_wrangles/generate.py
+++ b/wrangles/recipe_wrangles/generate.py
@@ -2,3 +2,23 @@
 from typing import Union as _Union, Dict as _Dict, List as _List, Optional as _Optional
 import pandas as _pd
 import wrangles.generate as _generate
+
+
+
+def ai(
+    df: _pd.DataFrame,
+    api_key: str,
+    output: _Union[_Dict, str, _List],
+    input: _Union[str, _List] = None,
+    model: str = "gpt-5",
+    threads: int = 20,
+    timeout: int = 90,
+    retries: int = 0,
+    messages: _Optional[_List[dict]] = None,
+    url: str = "https://api.openai.com/v1/responses",
+    strict: bool = False,
+    web_search: bool = False,
+    reasoning: _Dict[str, str] = {"effort": "low"},
+    **kwargs
+) -> _pd.DataFrame:
+

--- a/wrangles/recipe_wrangles/generate.py
+++ b/wrangles/recipe_wrangles/generate.py
@@ -22,3 +22,9 @@ def ai(
     **kwargs
 ) -> _pd.DataFrame:
 
+    if input is not None:
+        if not isinstance(input, list):
+            input = [input]
+        df_temp = df[input]
+    else:
+        df_temp = df

--- a/wrangles/recipe_wrangles/generate.py
+++ b/wrangles/recipe_wrangles/generate.py
@@ -46,3 +46,21 @@ def ai(
         "required": target_columns,
         "additionalProperties": False 
     }    
+
+
+
+    results = _generate.ai(
+    input=df_temp.to_dict(orient='records'),
+    api_key=api_key,
+    output=final_schema,
+    model=model,
+    threads=threads,
+    timeout=timeout,
+    retries=retries,
+    messages=messages,
+    url=url,
+    strict=strict,
+    web_search=web_search,
+    reasoning=reasoning,
+    **kwargs
+)

--- a/wrangles/recipe_wrangles/generate.py
+++ b/wrangles/recipe_wrangles/generate.py
@@ -39,3 +39,10 @@ def ai(
         output_schema = temp_dict
 
     target_columns = list(output_schema.keys())
+
+    final_schema = {
+        "type": "object",
+        "properties": output_schema,
+        "required": target_columns,
+        "additionalProperties": False 
+    }    

--- a/wrangles/recipe_wrangles/generate.py
+++ b/wrangles/recipe_wrangles/generate.py
@@ -1,0 +1,4 @@
+
+from typing import Union as _Union, Dict as _Dict, List as _List, Optional as _Optional
+import pandas as _pd
+import wrangles.generate as _generate

--- a/wrangles/recipe_wrangles/generate.py
+++ b/wrangles/recipe_wrangles/generate.py
@@ -21,6 +21,62 @@ def ai(
     reasoning: _Dict[str, str] = {"effort": "low"},
     **kwargs
 ) -> _pd.DataFrame:
+    """
+    Generate one or more structured outputs from every row using the inner `wrangles.generate.ai` helper.
+
+    Recipe:
+    ---
+    ```yaml
+    wrangles:
+      - generate.ai:
+          input:
+            - product_name
+            - features
+          output:
+            short_description:
+              type: string
+              description: Short marketing copy.
+            category:
+              type: string
+              description: Product category.
+          api_key: ${OPENAI_API_KEY}
+          model: gpt-5-nano
+          web_search: false
+          strict: true
+    ```
+
+    python:
+    ```python
+    import wrangles
+    import pandas as pd
+
+    data = pd.DataFrame({
+        "product_name": ["Widget One"],
+        "features": ["Lightweight; durable"]
+    })
+
+    df = wrangles.recipe.run(
+        recipe_path="recipe.wrgl.yml",
+        dataframe=data
+    )
+    ```
+
+    :param df: Source DataFrame passed from the recipe runner.
+    :param api_key: OpenAI-compatible API key used by the inner generate function.
+    :param output: Schema describing the keys to create (string/list/dict mirroring recipe syntax).
+    :param input: Optional list of column names to combine into the prompt payload (defaults to all columns).
+    :param model: Name of the OpenAI Responses model to call.
+    :param threads: Maximum concurrent requests to issue (fan-out via ThreadPoolExecutor).
+    :param timeout: Seconds to wait on each request before timing out.
+    :param retries: Number of retries on non-success responses.
+    :param messages: Optional system/user message list forwarded to the inner AI call.
+    :param url: Override of the OpenAI-compatible endpoint.
+    :param strict: Forwarded to the JSON schema formatter to enforce strict validation.
+    :param web_search: When true, fetches supplemental DuckDuckGo context per row before calling the model.
+    :param reasoning: Optional reasoning configuration forwarded to the OpenAI Responses API.
+    :param kwargs: Any additional keyword arguments supported by `wrangles.generate.ai`.
+    :return: The original DataFrame with new columns injected (and `source` when present).
+    """
 
     if input is not None:
         if not isinstance(input, list):


### PR DESCRIPTION
New generate.ai wrangle is added to the Wrangles py

- with this new wrangle we can now generate informations from the given descriptions and the names
- can make Web Searches for the products
- can enforce a strict output format with the 
```yaml
strict:true
```
- we can determine the reasoning level of the model we want to use
- we can choose the model we want to use 
-  this is our first wrangle that uses responses api
- this is our first wrangle  that uses pydantic for  format and data validation

Example Recipe:

```yaml
read:
  - file:
      name: products.csv

wrangles:
  - generate.ai:
      input:
        - product_name
        - features
      output:
        description:
          type: string
          description: "A short, exciting, one-sentence marketing description."
        category:
          type: string
          description: "The most appropriate product category for the item."
      api_key: ${OPENAI_API_KEY}
      model: gpt-5-nano
      web_search: false
      reasoning:
        effort: low
      strict: true
write:
  - file:
      name: products_generated.csv
```