### PR TITLE
Added a new option for suffix and prefix, split text wrangles to skip empy cells

### DIFF
--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -1932,3 +1932,72 @@ def Try(
                         raise ValueError('except must be a dictionary of column names and values or a list of wrangles')
     
     return df
+
+
+def case_when(
+    df: _pd.DataFrame,  
+    output: str,  
+    cases: list,  
+    default: str = None,  
+    **kwargs
+):
+    """
+    type: object
+    description: Try a list of wrangles and catch any errors that occur
+    required:
+      - wrangles
+    properties:
+      wrangles:
+        type: array
+        description: List of wrangles to apply
+        minItems: 1
+        items:
+          "$ref": "#/$defs/wrangles/items"
+      except:
+        type:
+          - object
+        description: |-
+          An action to take if the wrangles encounter an error.
+          This can contain a list of wrangles or a dictionary of column names and values.
+          If except is not provided, the error will be logged and the recipe will continue.
+        minItems: 1
+        items:
+          "$ref": "#/$defs/wrangles/items"
+      retries:
+        type: integer
+        description: Number of times to retry the wrangles if an error occurs. Default 0.
+        minimum: 0
+    """
+    for attempt in range(retries + 1):
+        try:
+            df = _wrangles.recipe.run(
+                recipe={'wrangles': wrangles},
+                dataframe=df,
+                variables=variables,
+                functions=functions
+            )
+            break
+        except Exception as e:
+            _logging.error(f"Try caught error: {e}")
+            if attempt < retries:
+                _time.sleep(1.5 ** attempt)  # Exponential backoff
+            else:
+                if "except" in kwargs:
+                    if isinstance(kwargs["except"], dict):
+                        # Except contains a dict of columns and values
+                        df = df.assign(**{
+                            k: [v] * len(df)
+                            for k, v in kwargs["except"].items()
+                        })
+                    elif isinstance(kwargs["except"], list):
+                        # Except contains a list of wrangles to run
+                        df = _wrangles.recipe.run(
+                            recipe={'wrangles': kwargs['except']},
+                            dataframe=df,
+                            variables=variables,
+                            functions=functions
+                        )
+                    else:
+                        raise ValueError('except must be a dictionary of column names and values or a list of wrangles')
+    
+    return df


### PR DESCRIPTION
This pull request adds support for a new `skip_empty` parameter to the `format.prefix`, `format.suffix`, and `split.text` wrangles, allowing users to control whether empty elements are included in the output. The change is fully tested with new test cases covering both enabled and disabled scenarios for this parameter.

**Enhancements to wrangle functions:**

* Added a `skip_empty` parameter to `format.prefix` and `format.suffix`, allowing users to skip empty input values when adding prefixes or suffixes. When `skip_empty` is true, empty or whitespace-only values are left unchanged instead of being prefixed/suffixed. [[1]](diffhunk://#diff-eac0b569dc298a12a2a51c9d3b50ac98daf38a5ba345086346bc6e7b27234235L107-R107) [[2]](diffhunk://#diff-eac0b569dc298a12a2a51c9d3b50ac98daf38a5ba345086346bc6e7b27234235R132-R135) [[3]](diffhunk://#diff-eac0b569dc298a12a2a51c9d3b50ac98daf38a5ba345086346bc6e7b27234235R150-R154) [[4]](diffhunk://#diff-eac0b569dc298a12a2a51c9d3b50ac98daf38a5ba345086346bc6e7b27234235L233-R242) [[5]](diffhunk://#diff-eac0b569dc298a12a2a51c9d3b50ac98daf38a5ba345086346bc6e7b27234235R267-R270) [[6]](diffhunk://#diff-eac0b569dc298a12a2a51c9d3b50ac98daf38a5ba345086346bc6e7b27234235R285-R288)
* Added a `skip_empty` parameter to the `split` function in `wrangles/format.py` and to the `split.text` wrangle, enabling the option to exclude empty tokens from the output of string splitting operations. [[1]](diffhunk://#diff-2fc9bf98ff6758989d5664bc7887d4560829efd3343d221cb406b2bd6925affdL34-R35) [[2]](diffhunk://#diff-2fc9bf98ff6758989d5664bc7887d4560829efd3343d221cb406b2bd6925affdR46) [[3]](diffhunk://#diff-2fc9bf98ff6758989d5664bc7887d4560829efd3343d221cb406b2bd6925affdR55-R59) [[4]](diffhunk://#diff-cdcdb44cd2f799a6e4ca15f7b4b2af2930a72566dea535e945fadd5707dbe2a0L167-R168) [[5]](diffhunk://#diff-cdcdb44cd2f799a6e4ca15f7b4b2af2930a72566dea535e945fadd5707dbe2a0L212-R218) [[6]](diffhunk://#diff-cdcdb44cd2f799a6e4ca15f7b4b2af2930a72566dea535e945fadd5707dbe2a0L246-R253)

**Test coverage improvements:**

* Added comprehensive tests for `format.prefix` and `format.suffix` with both single and multiple columns, covering cases where `skip_empty` is set to `true` and `false`. [[1]](diffhunk://#diff-d3b5b937a62c2bdd2f180bb9d7dc8d555f914eb5afba0795d47a1c614d775346R439-R535) [[2]](diffhunk://#diff-d3b5b937a62c2bdd2f180bb9d7dc8d555f914eb5afba0795d47a1c614d775346R687-R734)
* Added tests for `split.text` to verify behavior with and without the `skip_empty` parameter, ensuring correct handling of empty tokens.

These changes provide users with more control over how empty values are handled in formatting and splitting operations, and ensure the new functionality is robustly tested.