### PR TITLE
807-add-recipe-to-schema

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 			],
 			"settings": {
 				"yaml.schemas": {
-					"https://public.wrangle.works/schema/recipes/schema.json": ["*.wrgl.yml", "*.wrgl.yaml"]
+					"https://public.wrangle.works/schema/recipes/schema.json": ["*.wrgl.yml", "*.wrgl.yaml", "*.recipe"]
 				},
 				"python.testing.pytestArgs": ["tests"],
 				"python.testing.unittestEnabled": false,

--- a/tests/recipes/test_recipes.py
+++ b/tests/recipes/test_recipes.py
@@ -24,6 +24,19 @@ def test_recipe_from_file():
     )
     assert df.columns.tolist() == ['ID', 'Find2']
 
+def test_recipe_from__recipe_file():
+    """
+    Testing recipe passed as a filename with .recipe extension
+    """
+    df = wrangles.recipe.run(
+        "tests/samples/recipe_sample.recipe",
+        variables= {
+            "inputFile": 'tests/samples/data.csv',
+            "outputFile": 'tests/temp/write_data.xlsx'
+        }
+    )
+    assert df.columns.tolist() == ['ID', 'Find2']
+
 def test_recipe_from_url():
     """
     Testing reading a recipe from an https:// source

--- a/tests/samples/recipe_sample.recipe
+++ b/tests/samples/recipe_sample.recipe
@@ -1,0 +1,18 @@
+read:
+  - file:
+      name: "${inputFile}"
+      header: 0
+      
+wrangles:
+  - create.index:
+      output: ID
+      
+  - convert.case:
+      input: Find
+      output: Find2
+      case: lower
+write:
+  - dataframe:
+      columns:
+        - ID
+        - Find2


### PR DESCRIPTION
# Recipe extension
Overview
This pull request adds support for handling recipe files with the .recipe extension throughout the codebase and test suite. It updates configuration, adds a new test case for .recipe files, and provides a sample .recipe file for testing.

# Usage example
```
df = wrangles.recipe.run(
        "tests/samples/recipe_sample.recipe",
        variables= {
            "inputFile": 'tests/samples/data.csv',
            "outputFile": 'tests/temp/write_data.xlsx'
        }
    )
```
# Configuration update:

Updated the yaml.schemas setting in .devcontainer/devcontainer.json to associate the schema with files ending in .recipe, in addition to existing YAML extensions.
Testing and sample files:

Added a new test test_recipe_from__recipe_file in tests/recipes/test_recipes.py to verify that recipes with the .recipe extension are correctly processed.
Added a sample recipe file tests/samples/recipe_sample.recipe for use in the new test, demonstrating read, wrangle, and write steps.