### PR TITLE
952-matrix-broken

### DIFF
--- a/tests/connectors/test_matrix.py
+++ b/tests/connectors/test_matrix.py
@@ -589,37 +589,3 @@ class TestWrite:
         # but that's acceptable since numpy array equality is complex)
         actual_ids = [key for key in memory.dataframes.keys() if key.startswith("test_non_hashable_arrays_")]
         assert len(actual_ids) >= 3  # May be 3 or 4 depending on how pandas handles numpy array deduplication
-
-    def test_matrix_non_string_variable_conversion(self):  
-        """  
-        Test that non-string values in matrix variables are properly converted to strings  
-        This covers the code path: if not isinstance(val, str): val = str(val)  
-        """  
-        recipe = '''
-            wrangles:
-            - matrix:
-                variables:
-                    var: set(col2)
-                wrangles:
-                    - convert.case:
-                        input: col1
-                        case: ${var}
-                        where: col2 = ?
-                        where_params:
-                        - ${var}
-                    '''
-
-        variables = {
-            "batch_number": 1,                     
-            "batch_total": 1,                      
-            "row_count": 3                         
-        }
-
-        data = pd.DataFrame({
-            'col1': ['aaa', 'bbb', 'ccc'],
-            'col2': ['upper', 'lower', 'title']
-        })
-
-        result = wrangles.recipe.run(recipe, dataframe=data, variables=variables)
-
-        assert list(result['col1']) == ['AAA', 'bbb', 'Ccc']

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -5906,6 +5906,39 @@ class TestMatrix:
         )
         assert df['What is for lunch?'][0] == "we are having hamburgers"
 
+    def test_matrix_non_string_variable_conversion(self):  
+        """  
+        Test that non-string values in matrix variables are properly converted to strings  
+        This covers the code path: if not isinstance(val, str): val = str(val)  
+        """  
+        recipe = '''
+            wrangles:
+            - matrix:
+                variables:
+                    var: set(col2)
+                wrangles:
+                    - convert.case:
+                        input: col1
+                        case: ${var}
+                        where: col2 = ?
+                        where_params:
+                        - ${var}
+                    '''
+
+        variables = {
+            "batch_number": 1,                     
+            "batch_total": 1,                      
+            "row_count": 3                         
+        }
+
+        data = pd.DataFrame({
+            'col1': ['aaa', 'bbb', 'ccc'],
+            'col2': ['upper', 'lower', 'title']
+        })
+
+        result = wrangles.recipe.run(recipe, dataframe=data, variables=variables)
+
+        assert list(result['col1']) == ['AAA', 'bbb', 'Ccc']
 
 def wait_then_update(df, duration, input, output, value):
     """


### PR DESCRIPTION
### Matrix broken fix
PR fixed cases when input variables are not string 
<img width="459" height="178" alt="image" src="https://github.com/user-attachments/assets/1bc98eb7-d6b5-4ea0-a042-33959d0733ab" />
## Test recipe:
```
wrangles:
  - matrix:
      variables:
        var: set(col2)
      wrangles:
        - convert.case:
            input: col1
            case: ${var}
            where: col2 = ?
            where_params:
              - ${var}
```

[WranfgleXL isssue link](https://github.com/wrangleworks/WranglesXL/issues/952)