### PR TITLE
844-lookup-run-mode-reduce-api-calls

### DIFF
--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -5534,10 +5534,7 @@ class TestLookup:
                     lookup_mode: by_row  
                 """  
             )  
-    
-            api_calls_by_row.clear()  
-            by_row()  
-            calls_by_row = len(api_calls_by_row)  
+
         
         def by_dataframe():  
             return wrangles.recipe.run(  

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -5454,56 +5454,6 @@ class TestLookup:
         # we'd still get correct results, but the optimization ensures only 2 API calls)  
         unique_values = df['Col1'].unique()  
         assert len(unique_values) == 2, "Test data should have exactly 2 unique values"
-
-    def test_lookup_mode_by_matrix_performance_optimization(self):  
-        """  
-        Test that by_matrix mode reduces API calls by using matrix permutations  
-        """          
-        # Create test data with matrix structure  
-        df = pd.DataFrame({  
-            'product_code': ['a'] * 300 + ['b'] * 200 + ['c'] * 100,  
-            'region': ['north'] * 300 + ['south'] * 200 + ['north'] * 100,  
-            'category': ['electronics'] * 300 + ['clothing'] * 200 + ['electronics'] * 100  
-        })  
-        
-        # Track API calls  
-        api_calls_by_matrix = []  
-        
-        def track_api_calls_by_matrix(input_list, *args, **kwargs):  
-            api_calls_by_matrix.append(len(input_list))  
-            # Return mock data  
-            result = []  
-            for item in input_list:  
-                if item == 'a':  
-                    result.append([1])  
-                elif item == 'b':  
-                    result.append([2])  
-                elif item == 'c':  
-                    result.append([3])  
-                else:  
-                    result.append([""])  
-            return result  
-        
-        # Test by_matrix mode  
-        with patch('wrangles.recipe_wrangles.main._lookup', side_effect=track_api_calls_by_matrix):  
-            result = lookup(  
-                df.copy(),   
-                input='product_code',   
-                output='Value',   
-                model_id='fe730444-1bda-4fcd',  
-                lookup_mode='by_matrix',  
-                matrix_variables=['region', 'category']  
-            )  
-        
-        # Should make 4 API calls (one per matrix permutation)  
-        # Permutations: (north, electronics), (south, clothing), (north, electronics)  
-        assert len(api_calls_by_matrix) <= 4, f"Expected <= 4 API calls, got {len(api_calls_by_matrix)}"  
-        
-        # Verify results are correct  
-        assert result['Value'].tolist()[:300] == [1] * 300  # a values  
-        assert result['Value'].tolist()[300:500] == [2] * 200  # b values  
-        assert result['Value'].tolist()[500:] == [3] * 100  # c values  
-
     
     def test_lookup_mode_by_matrix_performance_optimization(self):  
         """  

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -5571,9 +5571,124 @@ class TestLookup:
         print(f'by_dataframe: {t_df:.3f}s total ({avg_df:.3f}s per run)')  
         print(f'Speedup: {speedup:.2f}x')  
     
-        # Assertions  
-        assert avg_df < avg_row, f"Expected by_dataframe ({avg_df:.3f}s) faster than by_row ({avg_row:.3f}s)"  
-        assert speedup > 1.0, f"Expected speedup > 1.0x, got {speedup:.2f}x"  
+        # Assertions
+        assert avg_df < avg_row, f"Expected by_dataframe ({avg_df:.3f}s) faster than by_row ({avg_row:.3f}s)"
+        assert speedup > 1.0, f"Expected speedup > 1.0x, got {speedup:.2f}x"
+
+    def test_lookup_semantic_multi_col_by_row(self):
+        """
+        Baseline: semantic lookup with merged multi-column YAML input using by_row.
+        Duplicate inputs (Austin+USA at rows 1 & 3, Berlin+Germany at rows 2 & 4)
+        must produce identical outputs.
+        """
+        df = wrangles.recipe.run(
+            dataframe=pd.DataFrame({
+                'City': ['London', 'Austin', 'Berlin', 'Austin', 'Berlin'],
+                'Country': ['UK', 'USA', 'Germany', 'USA', 'Germany']
+            }),
+            recipe="""
+            wrangles:
+            - merge.to_dict:
+                input: [City, Country]
+                output: Col1
+            - convert.to_yaml:
+                input: Col1
+                output: Col1
+            - lookup:
+                input: Col1
+                output: Value
+                model_id: 1ac1dddb-fcb5-45f3
+                lookup_mode: by_row
+            """
+        )
+        print(df['Value'].to_list())
+        assert df['Value'].iloc[1] == df['Value'].iloc[3]
+        assert df['Value'].iloc[2] == df['Value'].iloc[4]
+
+    def test_lookup_semantic_multi_col_by_dataframe(self):
+        """
+        Test that by_dataframe produces identical results to by_row for a semantic
+        lookup with merged multi-column YAML input.
+        """
+        df = pd.DataFrame({
+            'City': ['London', 'Austin', 'Berlin', 'Austin', 'Berlin'],
+            'Country': ['UK', 'USA', 'Germany', 'USA', 'Germany']
+        })
+
+        result_by_row = wrangles.recipe.run(
+            dataframe=df.copy(),
+            recipe="""
+            wrangles:
+            - merge.to_dict:
+                input: [City, Country]
+                output: Col1
+            - convert.to_yaml:
+                input: Col1
+                output: Col1
+            - lookup:
+                input: Col1
+                output: Value
+                model_id: 1ac1dddb-fcb5-45f3
+                lookup_mode: by_row
+            """
+        )
+
+        result_by_df = wrangles.recipe.run(
+            dataframe=df.copy(),
+            recipe="""
+            wrangles:
+            - merge.to_dict:
+                input: [City, Country]
+                output: Col1
+            - convert.to_yaml:
+                input: Col1
+                output: Col1
+            - lookup:
+                input: Col1
+                output: Value
+                model_id: 1ac1dddb-fcb5-45f3
+                lookup_mode: by_dataframe
+            """
+        )
+
+        assert result_by_row['Value'].tolist() == result_by_df['Value'].tolist()
+
+    def test_lookup_semantic_multi_col_by_dataframe_in_matrix(self):
+        """
+        Test that by_dataframe inside a matrix wrangle works with a semantic
+        lookup using merged multi-column YAML input.
+        """
+        df = pd.DataFrame({
+            'City': ['London', 'Austin', 'Berlin', 'Austin', 'Berlin'],
+            'Country': ['UK', 'USA', 'Germany', 'USA', 'Germany'],
+            'region': ['north', 'south', 'north', 'south', 'south']
+        })
+
+        result = wrangles.recipe.run(
+            dataframe=df.copy(),
+            recipe="""
+            wrangles:
+            - merge.to_dict:
+                input: [City, Country]
+                output: Col1
+            - convert.to_yaml:
+                input: Col1
+                output: Col1
+            - matrix:
+                variables:
+                    region: [north, south]
+                wrangles:
+                - lookup:
+                    input: Col1
+                    output: Value
+                    model_id: 1ac1dddb-fcb5-45f3
+                    lookup_mode: by_dataframe
+                    matrix_variables: [region]
+            """
+        )
+
+        assert result['Value'].iloc[1] == result['Value'].iloc[3]
+        assert result['Value'].iloc[2] == result['Value'].iloc[4]
 
     # def test_lookup(self):
     #     """

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -1010,21 +1010,19 @@ def lookup(
                         )  
                         
             elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):  
-                # User specified no columns from the wrangle  
-                unique_data = _lookup(  
-                    unique_values.tolist(),  
-                    model_id,  
-                    **kwargs  
-                )  
-                
-                # Create mapping from values to results  
-                value_to_result = dict(zip(unique_values, unique_data))  
-                
-                # Map results back to all rows - extract correct values  
-                for out in output:  
-                    df[out] = df[input].map(  
-                        lambda x: value_to_result.get(x, {}).get(out, "") if x in value_to_result and isinstance(value_to_result[x], dict) else ""  
-                    )  
+              # User specified no columns from the wrangle  
+              unique_data = _lookup(  
+                unique_values.tolist(),  
+                model_id, 
+                **kwargs
+              )  
+
+              # Create mapping from values to results (preserve full dict as in by_row)
+              value_to_result = dict(zip(unique_values, unique_data))
+
+              # Map results back to all rows - output is the full dict as in by_row
+              for out in output:
+                df[out] = df[input].map(lambda x: value_to_result.get(x, {}))
             else:  
                 # User specified a mixture of unrecognized columns and columns from the wrangle  
                 raise ValueError('Lookup may only contain all named or unnamed columns.')
@@ -1091,10 +1089,8 @@ def lookup(
                         value_to_result = dict(zip(perm_values, perm_data))  
                         
                         # Apply results to matching rows - extract correct values  
-                        for out in output:  
-                            df.loc[mask, out] = df.loc[mask, input].map(  
-                                lambda x: value_to_result.get(x, {}).get(out, "") if x in value_to_result and isinstance(value_to_result[x], dict) else ""  
-                            )  
+                        for out in output:
+                            df.loc[mask, out] = df.loc[mask, input].map(lambda x: value_to_result.get(x, {}))
                     else:  
                         # User specified a mixture of unrecognized columns and columns from the wrangle  
                         raise ValueError('Lookup may only contain all named or unnamed columns.')

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -957,145 +957,152 @@ def lookup(
             for val in output    
         ]
   
+        # Remove matrix_variables from kwargs if present before passing to _lookup
+        def _clean_kwargs(kwargs):
+          if 'matrix_variables' in kwargs:
+            kwargs = dict(kwargs)  # shallow copy to avoid mutating caller
+            kwargs.pop('matrix_variables')
+          return kwargs
+
         # Perform lookup based on lookup_mode
         if lookup_mode == 'by_row':
-            # Current behavior - process all rows
-            if all([col in metadata["settings"]["columns"] for col in wrangle_output]):
-                # User specified all columns from the wrangle
-                data = _lookup(
-                    df[input].values.tolist(),
-                    model_id,
-                    columns=wrangle_output,
-                    **kwargs
-                )
-                df[output] = data
-            elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):
-                # User specified no columns from the wrangle
-                data = _lookup(
-                    df[input].values.tolist(),
-                    model_id,
-                    **kwargs
-                )
-                for out in output:
-                    df[out] = data
-            else:
-                # User specified a mixture of unrecognized columns and columns from the wrangle 
-                raise ValueError('Lookup may only contain all named or unnamed columns.')
+          # Current behavior - process all rows
+          if all([col in metadata["settings"]["columns"] for col in wrangle_output]):
+            # User specified all columns from the wrangle
+            data = _lookup(
+              df[input].values.tolist(),
+              model_id,
+              columns=wrangle_output,
+              **_clean_kwargs(kwargs)
+            )
+            df[output] = data
+          elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):
+            # User specified no columns from the wrangle
+            data = _lookup(
+              df[input].values.tolist(),
+              model_id,
+              **_clean_kwargs(kwargs)
+            )
+            for out in output:
+              df[out] = data
+          else:
+            # User specified a mixture of unrecognized columns and columns from the wrangle 
+            raise ValueError('Lookup may only contain all named or unnamed columns.')
                   
         elif lookup_mode == 'by_dataframe':
-            # Optimized - lookup unique values once, then map to all rows  
-            unique_values = df[input].unique()  
+          # Optimized - lookup unique values once, then map to all rows  
+          unique_values = df[input].unique()  
             
-            if all([col in metadata["settings"]["columns"] for col in wrangle_output]):  
-                # User specified all columns from the wrangle  
-                unique_data = _lookup(  
-                    unique_values.tolist(),  
-                    model_id,  
-                    columns=wrangle_output,  
-                    **kwargs  
-                )  
+          if all([col in metadata["settings"]["columns"] for col in wrangle_output]):  
+            # User specified all columns from the wrangle  
+            unique_data = _lookup(  
+              unique_values.tolist(),  
+              model_id,  
+              columns=wrangle_output,  
+              **_clean_kwargs(kwargs)  
+            )  
                 
-                # Create mapping from values to results  
-                value_to_result = dict(zip(unique_values, unique_data))  
+            # Create mapping from values to results  
+            value_to_result = dict(zip(unique_values, unique_data))  
                 
-                # Map results back to all rows - extract correct values  
-                if len(output) == 1:  
-                    df[output[0]] = df[input].map(  
-                        lambda x: value_to_result.get(x, [])[0] if x in value_to_result and value_to_result[x] else ""  
-                    )  
-                else:  
-                    for i, out_col in enumerate(output):  
-                        df[out_col] = df[input].map(  
-                            lambda x: value_to_result.get(x, [])[i] if x in value_to_result and len(value_to_result[x]) > i else ""  
-                        )  
-                        
-            elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):  
-              # User specified no columns from the wrangle  
-              unique_data = _lookup(  
-                unique_values.tolist(),  
-                model_id, 
-                **kwargs
+            # Map results back to all rows - extract correct values  
+            if len(output) == 1:  
+              df[output[0]] = df[input].map(  
+                lambda x: value_to_result.get(x, [])[0] if x in value_to_result and value_to_result[x] else ""  
               )  
-
-              # Create mapping from values to results (preserve full dict as in by_row)
-              value_to_result = dict(zip(unique_values, unique_data))
-
-              # Map results back to all rows - output is the full dict as in by_row
-              for out in output:
-                df[out] = df[input].map(lambda x: value_to_result.get(x, {}))
             else:  
-                # User specified a mixture of unrecognized columns and columns from the wrangle  
-                raise ValueError('Lookup may only contain all named or unnamed columns.')
+              for i, out_col in enumerate(output):  
+                df[out_col] = df[input].map(  
+                  lambda x: value_to_result.get(x, [])[i] if x in value_to_result and len(value_to_result[x]) > i else ""  
+                )  
+                        
+          elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):  
+            # User specified no columns from the wrangle  
+            unique_data = _lookup(  
+            unique_values.tolist(),  
+            model_id, 
+            **_clean_kwargs(kwargs)
+            )  
+
+            # Create mapping from values to results (preserve full dict as in by_row)
+            value_to_result = dict(zip(unique_values, unique_data))
+
+            # Map results back to all rows - output is the full dict as in by_row
+            for out in output:
+              df[out] = df[input].map(lambda x: value_to_result.get(x, {}))
+          else:  
+            # User specified a mixture of unrecognized columns and columns from the wrangle  
+            raise ValueError('Lookup may only contain all named or unnamed columns.')
             
         elif lookup_mode == 'by_matrix':   
-            # Get matrix variables and permutations  
-            matrix_vars = kwargs.get('matrix_variables', [])  
-            if not matrix_vars:  
-                raise ValueError('matrix_variables required for by_matrix mode')  
+          # Get matrix variables and permutations  
+          matrix_vars = kwargs.get('matrix_variables', [])  
+          if not matrix_vars:  
+            raise ValueError('matrix_variables required for by_matrix mode')  
             
-            # Convert list of variable names to proper variables dictionary  
-            variables_dict = {var: f"set({var})" for var in matrix_vars}  
+          # Convert list of variable names to proper variables dictionary  
+          variables_dict = {var: f"set({var})" for var in matrix_vars}  
             
-            permutations = _define_permutations(  
-                variables_dict,  # Proper variables dictionary  
-                "loop",          # Strategy  
-                {},              # Functions  
-                df               # DataFrame  
-            )  
+          permutations = _define_permutations(  
+            variables_dict,  # Proper variables dictionary  
+            "loop",          # Strategy  
+            {},              # Functions  
+            df               # DataFrame  
+          )  
             
-            # Perform lookup once per permutation  
-            for perm in permutations:  
-                # Create mask for rows matching this permutation  
-                mask = _pd.Series([True] * len(df))  
-                for var, value in perm.items():  
-                    mask = mask & (df[var] == value)  
+          # Perform lookup once per permutation  
+          for perm in permutations:  
+            # Create mask for rows matching this permutation  
+            mask = _pd.Series([True] * len(df))  
+            for var, value in perm.items():  
+              mask = mask & (df[var] == value)  
                 
-                if mask.any():  
-                    # Get unique values for this permutation  
-                    perm_values = df.loc[mask, input].unique()  
+            if mask.any():  
+              # Get unique values for this permutation  
+              perm_values = df.loc[mask, input].unique()  
                     
-                    if all([col in metadata["settings"]["columns"] for col in wrangle_output]):  
-                        # User specified all columns from the wrangle  
-                        perm_data = _lookup(  
-                            perm_values.tolist(),  
-                            model_id,  
-                            columns=wrangle_output,  
-                            **kwargs  
-                        )  
+              if all([col in metadata["settings"]["columns"] for col in wrangle_output]):  
+                # User specified all columns from the wrangle  
+                perm_data = _lookup(  
+                  perm_values.tolist(),  
+                  model_id,  
+                  columns=wrangle_output,  
+                  **_clean_kwargs(kwargs)  
+                )  
                         
-                        # Create mapping for this permutation  
-                        value_to_result = dict(zip(perm_values, perm_data))  
+                # Create mapping for this permutation  
+                value_to_result = dict(zip(perm_values, perm_data))  
                         
-                        # Apply results to matching rows - extract correct values  
-                        if len(output) == 1:  
-                            df.loc[mask, output[0]] = df.loc[mask, input].map(  
-                                lambda x: value_to_result.get(x, [])[0] if x in value_to_result and value_to_result[x] else ""  
-                            )  
-                        else:  
-                            for i, out_col in enumerate(output):  
-                                df.loc[mask, out_col] = df.loc[mask, input].map(  
-                                    lambda x: value_to_result.get(x, [])[i] if x in value_to_result and len(value_to_result[x]) > i else ""  
-                                )  
+                # Apply results to matching rows - extract correct values  
+                if len(output) == 1:  
+                  df.loc[mask, output[0]] = df.loc[mask, input].map(  
+                    lambda x: value_to_result.get(x, [])[0] if x in value_to_result and value_to_result[x] else ""  
+                  )  
+                else:  
+                  for i, out_col in enumerate(output):  
+                    df.loc[mask, out_col] = df.loc[mask, input].map(  
+                      lambda x: value_to_result.get(x, [])[i] if x in value_to_result and len(value_to_result[x]) > i else ""  
+                    )  
                                 
-                    elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):  
-                        # User specified no columns from the wrangle  
-                        perm_data = _lookup(  
-                            perm_values.tolist(),  
-                            model_id,  
-                            **kwargs  
-                        )  
+              elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):  
+                # User specified no columns from the wrangle  
+                perm_data = _lookup(  
+                  perm_values.tolist(),  
+                  model_id,  
+                  **_clean_kwargs(kwargs)  
+                )  
                         
-                        # Create mapping for this permutation  
-                        value_to_result = dict(zip(perm_values, perm_data))  
+                # Create mapping for this permutation  
+                value_to_result = dict(zip(perm_values, perm_data))  
                         
-                        # Apply results to matching rows - extract correct values  
-                        for out in output:
-                            df.loc[mask, out] = df.loc[mask, input].map(lambda x: value_to_result.get(x, {}))
-                    else:  
-                        # User specified a mixture of unrecognized columns and columns from the wrangle  
-                        raise ValueError('Lookup may only contain all named or unnamed columns.')
+                # Apply results to matching rows - extract correct values  
+                for out in output:
+                  df.loc[mask, out] = df.loc[mask, input].map(lambda x: value_to_result.get(x, {}))
+              else:  
+                # User specified a mixture of unrecognized columns and columns from the wrangle  
+                raise ValueError('Lookup may only contain all named or unnamed columns.')
         else:
-            raise ValueError(f"Invalid lookup_mode: {lookup_mode}. Must be 'by_row', 'by_dataframe', or 'by_matrix'")
+          raise ValueError(f"Invalid lookup_mode: {lookup_mode}. Must be 'by_row', 'by_dataframe', or 'by_matrix'")
     else:
         raise ValueError('model_id is required for lookup')
     


### PR DESCRIPTION
# Add lookup_mode Parameter for Lookup Performance Optimization

**Summary**
Introduces a new lookup_mode parameter to the lookup function that provides significant performance improvements by reducing redundant API calls when processing datasets with repeated lookup values.

**Problem**
The current lookup function processes each row individually, making separate API calls even when the same lookup values appear multiple times in a dataset. This is inefficient for large datasets with duplicate values.

**Solution**
Added three lookup modes via the lookup_mode parameter:

by_row (default): Current behavior, processes each row individually
by_dataframe: Optimized mode that looks up unique values once and copies results to all rows
by_matrix: Performs lookups once per matrix permutation for grouped data processing

Key Changes
Enhanced lookup Function
Modified lookup() to support the new parameter with proper value extraction for different response formats.

Performance Optimization
 by_dataframe mode reduces API calls from N rows to U unique values using df[input].unique()

Matrix Integration
The by_matrix mode integrates with the existing matrix connector for efficient grouped lookups.

Comprehensive Testing
Added extensive unit tests in tests/recipes/wrangles/test_main.py test_main.py:5083-5086 covering all modes, error handling, and performance verification.

Usage Examples
```
# Optimized for repeated values  
wrangles:  
  - lookup:  
      input: product_code  
      output: product_name  
      model_id: abc123-def456  
      lookup_mode: by_dataframe  
  
# Within matrix wrangle for grouped lookups  
wrangles:  
  - matrix:  
      variables:  
        region: [north, south]  
      wrangles:  
        - lookup:  
            input: product_code  
            output: product_name  
            model_id: abc123-def456  
            lookup_mode: by_matrix  
            matrix_variables: [region]
```
Performance Impact
by_dataframe mode: Up to 99.7% reduction in API calls for datasets with high duplication
by_matrix mode: Optimized lookups within matrix permutations
Backward compatibility: Default by_row mode maintains existing behavior