### PR TITLE
train.lookup does not fail when using non-existent MatchingColumns

### DIFF
--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -977,69 +977,87 @@ class TestTrainLookup:
                 wrangles.recipe.run(recipe, dataframe=data)
 
     def test_upsert_new_matchingcolumns_missing(self):
-            """
-            UPSERT (new model) should raise ValueError if MatchingColumns are missing in the new data
-            """
-            recipe = """
-            write:
-                - train.lookup:
-                        name: 083ed6fe-a073-4b1a
-                        action: UPSERT
-                        settings:
-                            MatchingColumns:
-                                - NotKey
-                                - NotValue
-            """
-            data = pd.DataFrame({
-                    'City': ['A', 'B'],
-                    'Country': ['X', 'Y']
-            })
-            with pytest.raises(ValueError, match="MatchingColumns.*NotKey, NotValue"):
+        """
+        UPSERT (new model) should raise ValueError if MatchingColumns are missing in the new data
+        """
+        recipe = """
+        write:
+            - train.lookup:
+                    name: 083ed6fe-a073-4b1a
+                    action: UPSERT
+                    settings:
+                        MatchingColumns:
+                            - NotKey
+                            - NotValue
+        """
+        data = pd.DataFrame({
+                'City': ['A', 'B'],
+                'Country': ['X', 'Y']
+        })
+        with pytest.raises(ValueError, match="MatchingColumns.*NotKey, NotValue"):
                     wrangles.recipe.run(recipe, dataframe=data)
 
     def test_upsert_existing_matchingcolumns_missing(self):
-            """
-            UPSERT (existing model, after merge) should raise ValueError if MatchingColumns are missing in the merged data
-            """
-            recipe = """
-            write:
-                - train.lookup:
-                        model_id: 083ed6fe-a073-4b1a
-                        action: UPSERT
-                        settings:
-                            MatchingColumns:
-                                - NotKey
-                                - NotValue
-            """
-            # Simulate existing model with only City/Country
-            data = pd.DataFrame({
-                    'City': ['A', 'B'],
-                    'Country': ['X', 'Y']
-            })
-            with pytest.raises(ValueError, match="MatchingColumns.*NotKey, NotValue"):
-                    wrangles.recipe.run(recipe, dataframe=data)
+        """
+        UPSERT (existing model, after merge) should raise ValueError if MatchingColumns are missing in the merged data
+        """
+        recipe = """
+        write:
+            - train.lookup:
+                    model_id: 083ed6fe-a073-4b1a
+                    action: UPSERT
+                    settings:
+                        MatchingColumns:
+                            - NotKey
+                            - NotValue
+        """
+        # Simulate existing model with only City/Country
+        data = pd.DataFrame({
+                'City': ['A', 'B'],
+                'Country': ['X', 'Y']
+        })
+        with pytest.raises(ValueError, match="MatchingColumns.*NotKey, NotValue"):
+                wrangles.recipe.run(recipe, dataframe=data)
 
     def test_insert_matchingcolumns_missing(self):
-            """
-            INSERT should raise ValueError if MatchingColumns are missing in the merged data
-            """
-            recipe = """
-            write:
-                - train.lookup:
-                        model_id: 083ed6fe-a073-4b1a
-                        action: INSERT
-                        settings:
-                            MatchingColumns:
-                                - NotKey
-                                - NotValue
-            """
-            # Simulate existing model with only City/Country
-            data = pd.DataFrame({
-                    'City': ['A', 'B'],
-                    'Country': ['X', 'Y']
-            })
-            with pytest.raises(ValueError, match="MatchingColumns.*NotKey, NotValue"):
-                    wrangles.recipe.run(recipe, dataframe=data)
+        """
+        INSERT should raise ValueError if MatchingColumns are missing in the merged data
+        """
+        recipe = """
+        write:
+            - train.lookup:
+                    model_id: 083ed6fe-a073-4b1a
+                    action: INSERT
+                    settings:
+                        MatchingColumns:
+                            - NotKey
+                            - NotValue
+        """
+        # Simulate existing model with only City/Country
+        data = pd.DataFrame({
+                'City': ['A', 'B'],
+                'Country': ['X', 'Y']
+        })
+        with pytest.raises(ValueError, match="MatchingColumns.*NotKey, NotValue"):
+                wrangles.recipe.run(recipe, dataframe=data)
+    
+    def test_lookup_matchingcolumns_string_not_list(self):
+        """
+        MatchingColumns as a string (not a list) should be accepted and validated.
+        """
+        recipe = """
+        write:
+            - train.lookup:
+                model_id: 3c8f6707-2de4-4be3
+                settings:
+                    MatchingColumns: Not City
+        """
+        data = pd.DataFrame({
+            'City': ['Seattle', 'Portland'],
+            'Country': ['USA', 'USA'],
+        })
+        with pytest.raises(ValueError, match="MatchingColumns.*Not City"):
+            wrangles.recipe.run(recipe, dataframe=data)
             
 def test_lookup_write_logs_new_model_id(caplog):  
     """  

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -954,6 +954,92 @@ class TestTrainLookup:
         })
         with pytest.raises(ValueError, match="MatchingColumns.*Not City"):
             wrangles.recipe.run(recipe, dataframe=data)
+
+    def test_overwrite_matchingcolumns_missing(self):
+        """
+        OVERWRITE should raise ValueError if MatchingColumns are missing in the data
+        """
+        recipe = """
+        write:
+            - train.lookup:
+                    model_id: 083ed6fe-a073-4b1a
+                    action: OVERWRITE
+                    settings:
+                        MatchingColumns:
+                            - NotKey
+                            - NotValue
+        """
+        data = pd.DataFrame({
+                'City': ['A', 'B'],
+                'Country': ['X', 'Y']
+        })
+        with pytest.raises(ValueError, match="MatchingColumns.*NotKey, NotValue"):
+                wrangles.recipe.run(recipe, dataframe=data)
+
+    def test_upsert_new_matchingcolumns_missing(self):
+            """
+            UPSERT (new model) should raise ValueError if MatchingColumns are missing in the new data
+            """
+            recipe = """
+            write:
+                - train.lookup:
+                        name: 083ed6fe-a073-4b1a
+                        action: UPSERT
+                        settings:
+                            MatchingColumns:
+                                - NotKey
+                                - NotValue
+            """
+            data = pd.DataFrame({
+                    'City': ['A', 'B'],
+                    'Country': ['X', 'Y']
+            })
+            with pytest.raises(ValueError, match="MatchingColumns.*NotKey, NotValue"):
+                    wrangles.recipe.run(recipe, dataframe=data)
+
+    def test_upsert_existing_matchingcolumns_missing(self):
+            """
+            UPSERT (existing model, after merge) should raise ValueError if MatchingColumns are missing in the merged data
+            """
+            recipe = """
+            write:
+                - train.lookup:
+                        model_id: 083ed6fe-a073-4b1a
+                        action: UPSERT
+                        settings:
+                            MatchingColumns:
+                                - NotKey
+                                - NotValue
+            """
+            # Simulate existing model with only City/Country
+            data = pd.DataFrame({
+                    'City': ['A', 'B'],
+                    'Country': ['X', 'Y']
+            })
+            with pytest.raises(ValueError, match="MatchingColumns.*NotKey, NotValue"):
+                    wrangles.recipe.run(recipe, dataframe=data)
+
+    def test_insert_matchingcolumns_missing(self):
+            """
+            INSERT should raise ValueError if MatchingColumns are missing in the merged data
+            """
+            recipe = """
+            write:
+                - train.lookup:
+                        model_id: 083ed6fe-a073-4b1a
+                        action: INSERT
+                        settings:
+                            MatchingColumns:
+                                - NotKey
+                                - NotValue
+            """
+            # Simulate existing model with only City/Country
+            data = pd.DataFrame({
+                    'City': ['A', 'B'],
+                    'Country': ['X', 'Y']
+            })
+            with pytest.raises(ValueError, match="MatchingColumns.*NotKey, NotValue"):
+                    wrangles.recipe.run(recipe, dataframe=data)
             
 def test_lookup_write_logs_new_model_id(caplog):  
     """  

--- a/wrangles/connectors/train.py
+++ b/wrangles/connectors/train.py
@@ -256,6 +256,27 @@ class lookup():
         act = (action or 'overwrite').upper()
         settings = dict(settings or {})
 
+        def _get_columns_from_payload(payload):
+            # payload can be a DataFrame or the 'tight' dict produced by _to_tight
+            if isinstance(payload, dict) and 'Columns' in payload:
+                return payload['Columns']
+            try:
+                return list(payload.columns)
+            except Exception:
+                return []
+
+        def _validate_matching_columns(payload, settings_dict):
+            matching = settings_dict.get('MatchingColumns')
+            if not matching:
+                return
+            cols = _get_columns_from_payload(payload)
+            missing = [c for c in matching if c not in cols]
+            if missing:
+                raise ValueError(
+                    "Lookup: The following MatchingColumns are not present in the provided data: "
+                    + ", ".join(missing)
+                )
+
         def _to_tight(dataframe: _pd.DataFrame) -> dict:
             return {
                 k.title(): v
@@ -287,6 +308,7 @@ class lookup():
 
         elif act == 'OVERWRITE' or name:
             row_count = len(df)
+            _validate_matching_columns(df, settings)
             _train.lookup(
                 _to_tight(df),
                 name,
@@ -358,11 +380,13 @@ class lookup():
                     'Columns': merged_df.columns.tolist(),
                     'Data': merged_df.values.tolist()
                 }
+                _validate_matching_columns(merged_data, settings)
                 total_rows = len(merged_df)
                 _train.lookup(merged_data, None, model_id, settings)
                 _logging.info(f"Lookup UPSERT: {inserted} rows inserted, {updated} rows updated. Total rows: {total_rows}.")
             else:
                 inserted = len(df)
+                _validate_matching_columns(new_data, settings)
                 _train.lookup(new_data, name, None, settings)
                 _logging.info(f"Lookup UPSERT (new): {inserted} rows inserted. Total rows: {inserted}.")
 
@@ -403,6 +427,7 @@ class lookup():
                 else:
                     raise ValueError("Both DataFrames must contain 'Key' column")
                 settings['variant'] = normalized_variant
+                _validate_matching_columns(df, settings)
                 total_rows = len(df)
                 _train.lookup(
                     _to_tight(df),
@@ -414,6 +439,7 @@ class lookup():
             else:
                 # Semantic/embedding model: allow UPDATE without 'Key' and replace model content
                 settings['variant'] = normalized_variant
+                _validate_matching_columns(df, settings)
                 total_rows = len(df)
                 _train.lookup(
                     _to_tight(df),
@@ -455,6 +481,7 @@ class lookup():
                 'Columns': merged_df.columns.tolist(),  
                 'Data': merged_df.values.tolist()  
             }  
+            _validate_matching_columns(merged_data, settings)
             total_rows = len(merged_df)
             _train.lookup(merged_data, None, model_id, settings)
             _logging.info(f"Lookup INSERT: {inserted} rows inserted. Total rows: {total_rows}.")

--- a/wrangles/connectors/train.py
+++ b/wrangles/connectors/train.py
@@ -269,6 +269,11 @@ class lookup():
             matching = settings_dict.get('MatchingColumns')
             if not matching:
                 return
+            # Accept both string and list for MatchingColumns
+            if isinstance(matching, str):
+                matching = [matching]
+            elif not isinstance(matching, list):
+                raise TypeError("MatchingColumns must be a string or a list of strings")
             cols = _get_columns_from_payload(payload)
             missing = [c for c in matching if c not in cols]
             if missing:
@@ -427,7 +432,6 @@ class lookup():
                 else:
                     raise ValueError("Both DataFrames must contain 'Key' column")
                 settings['variant'] = normalized_variant
-                _validate_matching_columns(df, settings)
                 total_rows = len(df)
                 _train.lookup(
                     _to_tight(df),


### PR DESCRIPTION
This pull request adds stricter validation for the `MatchingColumns` setting in the lookup training connector to ensure that all specified columns actually exist in the provided DataFrame before any training, persisting, or inserting actions occur. It introduces a helper function to perform this validation and adds comprehensive tests to guarantee correct error handling when columns are missing.

Validation improvements for MatchingColumns:

* Added a `_validate_matching_columns` helper function in `wrangles/connectors/train.py` to check that all columns listed in `MatchingColumns` are present in the input data, raising a `ValueError` if any are missing. This validation is applied before training, persisting, or inserting data for lookup models.

Testing enhancements:

* Added new tests in `tests/connectors/test_train.py` to verify that a `ValueError` is raised when `MatchingColumns` contains names not present in the DataFrame, covering new model creation, existing model insertion, and other relevant scenarios.