### PR TITLE
update error handling

### DIFF
--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -953,7 +953,7 @@ class TestTrainLookup:
             'Key': ['K1'],
             'Value': ['V1']
         })
-        with pytest.raises(ValueError, match="MatchingColumns.*Not City"):
+        with pytest.raises(ValueError, match="The following columns are not present in the existing model: City, Country"):
             wrangles.recipe.run(recipe, dataframe=data)
 
     def test_overwrite_matchingcolumns_missing(self):
@@ -974,8 +974,8 @@ class TestTrainLookup:
                 'City': ['A', 'B'],
                 'Country': ['X', 'Y']
         })
-        with pytest.raises(ValueError, match=r"MatchingColumns are not present in the provided data: NotKey, NotValue"):
-            wrangles.recipe.run(recipe, dataframe=data)
+        with pytest.raises(ValueError, match="The following MatchingColumns are not present in the provided data: NotKey, NotValue"):
+                wrangles.recipe.run(recipe, dataframe=data)
 
     def test_upsert_new_matchingcolumns_missing(self):
         """

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -953,7 +953,7 @@ class TestTrainLookup:
             'Key': ['K1'],
             'Value': ['V1']
         })
-        with pytest.raises(ValueError, match="The following columns are not present in the existing model: City, Country"):
+        with pytest.raises(ValueError, match=r"The following MatchingColumns are not present in the provided data: Not City"):
             wrangles.recipe.run(recipe, dataframe=data)
 
     def test_overwrite_matchingcolumns_missing(self):

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -908,7 +908,7 @@ class TestTrainLookup:
             'City': ['Seattle', 'Portland'],
             'Country': ['USA', 'USA'],
         })
-        with pytest.raises(ValueError, match="he following MatchingColumns are not present in the provided data: Not City, Not Country"):
+        with pytest.raises(ValueError, match=r"The following MatchingColumns are not present in the provided data: Not City, Not Country"):
             wrangles.recipe.run(recipe, dataframe=data)
 
     def test_lookup_matchingcolumns_missing_raises_new_model_name(self):

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -887,7 +887,7 @@ class TestTrainLookup:
             'NotKey': ['A', 'B'],
             'Value': ['X', 'Y']
         })
-        with pytest.raises(ValueError, match=r"UPDATE requires 'Key' or 'MatchingColumns' for non-key variants"):
+        with pytest.raises(ValueError, match="Lookup: The following columns are not present in the existing model: NotKey"):
             wrangles.recipe.run(recipe, dataframe=data)
 
     def test_lookup_matchingcolumns_missing_raises(self):
@@ -908,7 +908,7 @@ class TestTrainLookup:
             'City': ['Seattle', 'Portland'],
             'Country': ['USA', 'USA'],
         })
-        with pytest.raises(ValueError, match="MatchingColumns.*Not City, Not Country"):
+        with pytest.raises(ValueError, match="he following MatchingColumns are not present in the provided data: Not City, Not Country"):
             wrangles.recipe.run(recipe, dataframe=data)
 
     def test_lookup_matchingcolumns_missing_raises_new_model_name(self):
@@ -929,7 +929,7 @@ class TestTrainLookup:
             'City': ['Seattle', 'Portland'],
             'Country': ['USA', 'USA'],
         })
-        with pytest.raises(ValueError, match="MatchingColumns.*Not City, Not Country"):
+        with pytest.raises(ValueError, match="Lookup: The following MatchingColumns are not present in the provided data: Not City, Not Country"):
             wrangles.recipe.run(recipe, dataframe=data)
 
     def test_lookup_matchingcolumns_missing_raises_insert_existing_model(self):
@@ -1318,6 +1318,33 @@ class TestTrainLookup:
         df = wrangles.recipe.run(recipe, dataframe=data)
         assert 'Blade Runner Upsert' in df['City'].values
         assert 'New Value' in df['City'].values
+    
+    def test_missing_columns_error_message(self):  
+        """  
+        Verify that INSERT/UPSERT/UPDATE raise the expected error  
+        when incoming columns are not present in the existing model.  
+        """  
+
+        df = pd.DataFrame({  
+            "Key": ["k3"],  
+            "Value": ["v3"],  
+            "ExtraCol": ["x"]  # This column does not exist in the model  
+        })  
+
+    
+        # Test each action that performs the column-alignment check  
+        for action in ("insert", "upsert", "update"):  
+            recipe = f"""
+                write:
+                    - train.lookup:
+                        model_id: bc3ee6a0-e104-4700
+                        action: {action}
+                        variant: key
+
+                """
+            with pytest.raises(ValueError, match="Lookup: The following columns are not present in the existing model: ExtraCol"):
+                wrangles.recipe.run(recipe, dataframe=df)
+    
             
 def test_lookup_write_logs_new_model_id(caplog):  
     """  

--- a/wrangles/connectors/train.py
+++ b/wrangles/connectors/train.py
@@ -447,10 +447,23 @@ class lookup():
 
             updated = 0
 
-            if 'Key' in df.columns and 'Key' in existing_df.columns:
-                # Only update records that exist in the model
-                existing_keys = set(existing_df['Key'].tolist())
-                df_filtered = df[df['Key'].isin(existing_keys)].copy()
+            # Determine the effective variant for this model (normalize semantic -> embedding)
+            normalized_variant = _normalize_variant(model_id, metadata.get('variant', 'key'))
+
+            # Column alignment check
+            missing_in_existing = [c  for c in df.columns if c not in existing_df.columns]
+            if missing_in_existing:
+                raise ValueError(
+                    "Lookup: The following columns are not present in the existing model: "
+                    + ", ".join(missing_in_existing)
+                )
+
+            if normalized_variant == 'key':
+                # Key-based model: require 'Key' in both DataFrames and perform merge/update
+                if 'Key' in df.columns and 'Key' in existing_df.columns:
+                    # Only update records that exist in the model
+                    existing_keys = set(existing_df['Key'].tolist())
+                    df_filtered = df[df['Key'].isin(existing_keys)].copy()
 
                 if df_filtered.empty:
                     _logging.info("No matching keys found in existing model. No updates performed.")
@@ -540,6 +553,15 @@ class lookup():
                 columns=existing_content['Columns']  
             )  
             
+            # Column alignment check
+            if not 'MatchingColumns' in settings:
+                missing_in_existing = [c for c in df.columns if c not in existing_df.columns]
+                if missing_in_existing:
+                    raise ValueError(
+                        "Lookup: The following columns are not present in the existing model: "
+                        + ", ".join(missing_in_existing)
+                    )
+
             inserted = 0
             # Only add rows with new keys (skip existing keys)  
             if variant == 'key' and 'Key' in existing_df.columns and 'Key' in df.columns:  

--- a/wrangles/connectors/train.py
+++ b/wrangles/connectors/train.py
@@ -451,7 +451,7 @@ class lookup():
             normalized_variant = _normalize_variant(model_id, metadata.get('variant', 'key'))
 
             # Column alignment check
-            missing_in_existing = [c  for c in df.columns if c not in existing_df.columns]
+            missing_in_existing = [c for c in df.columns if c not in existing_df.columns]
             if missing_in_existing:
                 raise ValueError(
                     "Lookup: The following columns are not present in the existing model: "


### PR DESCRIPTION
This pull request adds stricter validation for column alignment when performing `insert`, `upsert`, or `update` actions with the `train.lookup` connector, ensuring that all incoming DataFrame columns exist in the existing model. It also introduces corresponding tests to verify that the correct error is raised when this condition is not met.

**Validation improvements:**

* Added a check in `wrangles/connectors/train.py` to raise a `ValueError` if any columns in the input DataFrame are not present in the existing model during `insert`, `upsert`, or `update` actions, with a clear error message listing the missing columns. [[1]](diffhunk://#diff-0c30a123cca3d796740a7866049685d67cec0b4336d6310d7365cca758557adbR410-R417) [[2]](diffhunk://#diff-0c30a123cca3d796740a7866049685d67cec0b4336d6310d7365cca758557adbR478-R485)

**Testing enhancements:**

* Added a new test `test_missing_columns_error_message` in `tests/connectors/test_train.py` to verify that the appropriate error is raised when extra columns are provided in the DataFrame.This pull request adds stricter validation and clearer error handling for column alignment when performing write operations (`insert`, `upsert`, `update`) in the `train.lookup` connector. Now, if the incoming DataFrame contains columns not present in the existing model, a descriptive error is raised. The changes are covered by new tests to ensure proper behavior.

**Validation and error handling improvements:**

* Added a check in `wrangles/connectors/train.py` to raise a `ValueError` if the DataFrame being written contains columns not present in the existing model, with a clear error message listing the missing columns. [[1]](diffhunk://#diff-0c30a123cca3d796740a7866049685d67cec0b4336d6310d7365cca758557adbR410-R417) [[2]](diffhunk://#diff-0c30a123cca3d796740a7866049685d67cec0b4336d6310d7365cca758557adbR478-R485)

**Testing enhancements:**

* Introduced a new test `test_missing_columns_error_message` in `tests/connectors/test_train.py` to verify that `insert`, `upsert`, and `update` actions correctly raise an error when extra columns are present in the input DataFrame.