### PR TITLE
accordion support empty dfs

### DIFF
--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -5093,6 +5093,26 @@ class TestAccordion:
             len(df) == 5 and
             df["list_column"][0] == ["A","B","C"]
         )
+        
+    def test_accordion_empty_dataframe(self):  
+        """  
+        Test accordion with an empty dataframe  
+        """  
+        df = wrangles.recipe.run(  
+            """  
+            wrangles:  
+            - accordion:  
+                input: list_column  
+                wrangles:  
+                    - convert.case:  
+                        input: list_column  
+                        case: upper  
+            """,  
+            dataframe=pd.DataFrame({  
+                "list_column": []  
+            })  
+        )  
+        assert df.empty and df.columns.tolist() == ["list_column"]
 
 
 class TestBatch:

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -92,6 +92,10 @@ def accordion(
     if propagate is None: propagate = [item for item in df.columns.tolist() if item not in input]
     if not isinstance(propagate, list): propagate = [propagate]
     
+    # Pass through empty DataFrames unchanged (like other wrangles)
+    if df.empty:
+      return df
+    
     if not df.index.is_unique:
         raise ValueError("The dataframe index must be unique for the accordion wrangle to work.")
 


### PR DESCRIPTION
This pull request adds improved handling for empty DataFrames in the `accordion` wrangle, ensuring consistent behavior with other wrangles. It also introduces a new test to verify this functionality.

Handling of empty DataFrames:

* [`wrangles/recipe_wrangles/main.py`](diffhunk://#diff-f4895dbe47c229fb4c5c3e4a8bf87d25226dcc92bef72b2550327b5891f63cb5R95-R98): Updated the `accordion` function to return empty DataFrames unchanged, aligning its behavior with other wrangles.

Testing improvements:

* [`tests/recipes/wrangles/test_main.py`](diffhunk://#diff-038ffc684db5868831d34d2f81409e1788475ea1b64a27101f8879ea4768f4f8R5097-R5116): Added a new test, `test_accordion_empty_dataframe`, to confirm that the `accordion` wrangle passes through empty DataFrames without modification.
