### PR TITLE
replace default dict from {} to None

### DIFF
--- a/wrangles/connectors/akeneo.py
+++ b/wrangles/connectors/akeneo.py
@@ -23,7 +23,7 @@ def read(
     client_secret: str,
     source: str,
     columns: list = None,
-    parameters: dict = {}
+    parameters: dict = None
 ):
     """
     Read data from an Akeneo PIM
@@ -49,7 +49,8 @@ def read(
     :return: A Pandas dataframe of the returned results
     """
     _logging.info(f": Reading data from Akeneo :: {host} / {source}")
-
+    if parameters is None:
+        parameters = {}
     # Set to max temporarily
     parameters['limit'] = 100
 

--- a/wrangles/connectors/concurrent.py
+++ b/wrangles/connectors/concurrent.py
@@ -14,7 +14,7 @@ _schema = {}
 def run(
     run: list,
     max_concurrency: int = 10,
-    variables: dict = {},
+    variables: dict = None,
     functions: _Union[_types.FunctionType, list] = [],
     use_multiprocessing: bool = False
 ):
@@ -27,6 +27,8 @@ def run(
     :param functions: Custom functions to pass to any downstream recipes
     :param use_multiprocessing: Use multiprocessing instead of threading. Default is False.
     """
+    if variables is None:
+        variables = {}
     if use_multiprocessing:
         # Not publicly documented. Use at your own risk.
         pool_executor = _futures.ProcessPoolExecutor
@@ -75,7 +77,7 @@ def read(
     max_concurrency: int = 10,
     use_multiprocessing: bool = False,
     functions: _Union[_types.FunctionType, list, dict] = {},
-    variables: dict = {}
+    variables: dict = None
 ):
     """
     Run multiple reads simulatenously.
@@ -86,6 +88,8 @@ def read(
     :param functions: Custom functions to make available downstream.
     :param variables: Variables to make available downstream.
     """
+    if variables is None:
+      variables = {}
     if use_multiprocessing:
         # Not publicly documented. Use at your own risk.
         pool_executor = _futures.ProcessPoolExecutor
@@ -131,7 +135,7 @@ def write(
     df: _pd.DataFrame,
     write: list,
     max_concurrency: int = 10,
-    variables: dict = {},
+    variables: dict = None,
     functions: _Union[_types.FunctionType, list] = [],
     use_multiprocessing: bool = False
 ):
@@ -145,6 +149,8 @@ def write(
     :param functions: Custom functions to pass to any downstream recipes
     :param use_multiprocessing: Use multiprocessing instead of threading. Default is False.
     """
+    if variables is None:
+        variables = {}
     if use_multiprocessing:
         # Not publicly documented. Use at your own risk.
         pool_executor = _futures.ProcessPoolExecutor

--- a/wrangles/connectors/http.py
+++ b/wrangles/connectors/http.py
@@ -28,10 +28,10 @@ _schema = {}
 def run(
     url: str,
     method: str = "GET",
-    headers: dict = {},
+    headers: dict = None,
     params: dict = None,
     json: _Union[dict, list] = None,
-    oauth: dict = {},
+    oauth: dict = None,
     **kwargs
 ) -> None:
     """
@@ -46,7 +46,10 @@ def run(
       to sending the main request
     """
     _logging.info(f": Making http request :: {url}")
-
+    if headers is None:
+        headers = {}
+    if oauth is None:
+      oauth = {}
     if oauth:
         headers["Authorization"] = f"Bearer {_get_oauth_token(**oauth)}"
     
@@ -129,11 +132,11 @@ properties:
 def read(
     url: str,
     method: str = "GET",
-    headers: dict = {},
+    headers: dict = None,
     params: dict = None,
     json: _Union[dict, list] = None,
     json_key: str = None,
-    oauth: dict = {},
+    oauth: dict = None,
     orient: str = "records",
     **kwargs
 ) -> _pd.DataFrame:
@@ -152,6 +155,11 @@ def read(
     :return: A pandas DataFrame
     """
     _logging.info(f": Reading data from http :: {url}")
+
+    if headers is None:
+        headers = {}
+    if oauth is None:
+        oauth = {}
 
     if oauth:
         headers["Authorization"] = f"Bearer {_get_oauth_token(**oauth)}"
@@ -270,10 +278,10 @@ def write(
     df: _pd.DataFrame,
     url: str,
     method: str = "POST",
-    headers: dict = {},
+    headers: dict = None,
     orient: str = "records",
     batch: bool = True,
-    oauth: dict = {},
+    oauth: dict = None,
     **kwargs
 ) -> None:
     """
@@ -288,7 +296,10 @@ def write(
         If an integer, send the DataFrame in batches of that size.
     """
     _logging.info(f": Writing data to http :: {url}")
-
+    if headers is None:
+        headers = {}
+    if oauth is None:
+        oauth = {}
     if oauth:
         headers["Authorization"] = f"Bearer {_get_oauth_token(**oauth)}"
 

--- a/wrangles/connectors/matrix.py
+++ b/wrangles/connectors/matrix.py
@@ -19,7 +19,7 @@ _schema = {}
 def _define_permutations(
     variables: dict,
     strategy: str = "loop",
-    functions: dict = {},
+    functions: dict = None,
     df: _pd.DataFrame = None
 ):
 
@@ -29,6 +29,8 @@ def _define_permutations(
             yield dict(_chainmap(*[next(i, empty_default) for i in cycles]))
 
     permutations = []
+    if functions is None:
+        functions = {}
 
     for key, val in variables.items():
         # User provided a list
@@ -103,7 +105,7 @@ def _define_permutations(
 def run(
     variables: dict,
     run: list,
-    functions: dict = {},
+    functions: dict = None,
     strategy: str = "loop",
     use_multiprocessing: bool = False,
     max_concurrency: int = 10
@@ -124,6 +126,8 @@ def run(
     :param use_multiprocessing: Use multiprocessing instead of threading
     :param max_concurrency: The maximum number to execute in parallel. If there are more than this, the rest will be queued.
     """    
+    if functions is None:
+        functions = {}
     if use_multiprocessing:
         # Not publicly documented. Use at your own risk.
         pool_executor = _futures.ProcessPoolExecutor
@@ -192,7 +196,7 @@ properties:
 def read(
     variables: dict,
     read: list,
-    functions: dict = {},
+    functions: dict = None,
     strategy: str = "loop",
     use_multiprocessing: bool = False,
     max_concurrency: int = 10
@@ -212,6 +216,8 @@ def read(
     :param use_multiprocessing: Use multiprocessing instead of threading
     :param max_concurrency: The maximum number to execute in parallel. If there are more than this, the rest will be queued.
     """    
+    if functions is None:
+        functions = {}
     if use_multiprocessing:
         # Not publicly documented. Use at your own risk.
         pool_executor = _futures.ProcessPoolExecutor

--- a/wrangles/connectors/mongodb.py
+++ b/wrangles/connectors/mongodb.py
@@ -13,7 +13,7 @@ _pymongo = _LazyLoader('pymongo')
 
 _schema = {}
 
-def read(user: str, password: str, database: str, collection: str, host: str, query: dict = {}, projection: dict = {}) -> _pd.DataFrame:
+def read(user: str, password: str, database: str, collection: str, host: str, query: dict = None, projection: dict = None) -> _pd.DataFrame:
     """
     Import data from a MongoDB database
     
@@ -30,6 +30,10 @@ def read(user: str, password: str, database: str, collection: str, host: str, qu
     """
     _logging.info(f": Reading data from MongoDB :: {host} / {database} / {collection}")
 
+    if query is None:
+        query = {}
+    if projection is None:
+        projection = {}
     # Encoding password and username using percent encoding
     user = _quote_plus(user)
     password = _quote_plus(password)

--- a/wrangles/connectors/recipe.py
+++ b/wrangles/connectors/recipe.py
@@ -15,7 +15,7 @@ _schema = {}
 
 def run(
     name: str = None,
-    variables: dict = {},
+    variables: dict = None,
     functions: _Union[_types.FunctionType, list] = [],
     **kwargs
 ) -> None:
@@ -29,6 +29,8 @@ def run(
     :param variables: (Optional) A dictionary of custom variables to override placeholders in the recipe. Variables can be indicated as ${MY_VARIABLE}. Variables can also be overwritten by Environment Variables.
     :param functions: Pass in a custom function or list of custom functions that can be called in the recipe.
     """
+    if variables is None:
+        variables = {}
     if not name: name = kwargs
     _recipe.run(name, variables=variables, functions=functions)
 
@@ -50,7 +52,7 @@ anyOf:
 
 def read(
     name: str = None,
-    variables: dict = {},
+    variables: dict = None,
     columns: list = None,
     functions: _Union[_types.FunctionType, list] = [],
     **kwargs
@@ -66,6 +68,8 @@ def read(
     :param columns: (Optional) Subset of the columns to include from the output of the recipe. If not provided, all columns will be included.
     :param functions: Pass in a custom function or list of custom functions that can be called in the recipe.
     """
+    if variables is None:
+        variables = {}
     if not name: name = kwargs
     df = _recipe.run(name, variables=variables, functions=functions)
 
@@ -101,7 +105,7 @@ anyOf:
 def write(
     df: _pd.DataFrame,
     name: str = None,
-    variables: dict = {},
+    variables: dict = None,
     columns: list = None,
     functions: _Union[_types.FunctionType, list] = [],
     **kwargs
@@ -118,6 +122,8 @@ def write(
     :param columns: (Optional) A list of the columns to pass to the recipe. If omitted, all columns will be included.
     :param functions: Pass in a custom function or list of custom functions that can be called in the recipe.
     """
+    if variables is None:
+        variables = {}
     if not name: name = kwargs
     # Select only specific columns if user requests them
     if columns is not None:

--- a/wrangles/connectors/salesforce.py
+++ b/wrangles/connectors/salesforce.py
@@ -42,7 +42,7 @@ def read(
     object: str,
     command: str,
     columns: list = None,
-    params: dict = {},
+    params: dict = None,
     domain: str = None
 ) -> _pd.DataFrame:
     """
@@ -63,7 +63,8 @@ def read(
     :return: A Pandas dataframe of the imported data.
     """
     _logging.info(f": Reading data from Salesforce :: {instance} /  {object}")
-
+    if params is None:
+      params = {}
     sf = _salesforce.Salesforce(
         instance=instance,
         username=user,

--- a/wrangles/connectors/test.py
+++ b/wrangles/connectors/test.py
@@ -107,7 +107,7 @@ def _generate_cell_values(data_type: _Union[str, list], rows: int):
         return [data_type for _ in range(rows)]
 
 
-def read(rows: int, values: dict = {}) -> _pd.DataFrame:
+def read(rows: int, values: dict = None) -> _pd.DataFrame:
     """
     Create a test dataframe
 
@@ -129,7 +129,8 @@ def read(rows: int, values: dict = {}) -> _pd.DataFrame:
     :return: Pandas Dataframe of the created data
     """
     _logging.info(f": Generating test data :: {rows} row{'s' if rows > 1 else ''}")
-
+    if values is None:
+        values = {}
     data = {}
     for key, val in values.items():
         data[key] = _generate_cell_values(val, rows)

--- a/wrangles/connectors/train.py
+++ b/wrangles/connectors/train.py
@@ -234,7 +234,7 @@ class lookup():
             description: Specific model to read
         """
 
-    def write(df: _pd.DataFrame, name: str = None, model_id: str = None, settings: dict = {}, variant: str = 'key', action: str = 'overwrite') -> None:
+    def write(df: _pd.DataFrame, name: str = None, model_id: str = None, settings: dict = None, variant: str = 'key', action: str = 'overwrite') -> None:
         """
         Train a new or existing lookup wrangle
 
@@ -246,7 +246,8 @@ class lookup():
         :param action: Action to take when training the lookup wrangle (insert, update, upsert)
         """
         _logging.info(f": Training Lookup Wrangle")
-
+        if settings is None:
+            settings = {}
         # Error handling for name, model_id and settings
         if name and model_id:
             raise ValueError("Lookup: Name and model_id cannot both be provided, please use name to create a new model or model_id to update an existing model.")

--- a/wrangles/openai.py
+++ b/wrangles/openai.py
@@ -139,7 +139,7 @@ def _embedding_thread(
     model: str,
     url: str,
     retries: int = 0,
-    request_params: dict = {},
+    request_params: dict = None,
     precision: str = "float32"
 ):
     """
@@ -153,6 +153,8 @@ def _embedding_thread(
     :param request_params: Additional request parameters to pass to the backend.
     :param precision: The precision of the embeddings. Default is float32.
     """
+    if request_params is None:
+        request_params = {}
     response = None
     backoff_time = 1
     while (retries + 1):

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -167,7 +167,7 @@ def _replace_templated_values(
 
 def _load_recipe(
     recipe: str,
-    variables: dict = {},
+    variables: dict = None,
     functions: _Union[_types.FunctionType, list, dict, str] = []
 ) -> dict:
     """
@@ -179,6 +179,8 @@ def _load_recipe(
 
     :return: YAML Recipe converted to a dictionary
     """
+    if variables is None:
+        variables = {}
     if isinstance(recipe, str) and "\n" not in recipe:
         _logging.info(f": Reading Recipe :: {recipe}")
     
@@ -323,8 +325,8 @@ def _load_recipe(
 
 def _run_actions(
     recipe: _Union[dict, list],
-    functions: dict = {},
-    variables: dict = {},
+    functions: dict = None,
+    variables: dict = None,
     error: Exception = None
 ) -> None:
     """
@@ -335,6 +337,10 @@ def _run_actions(
     :param variables: (Optional) A dictionary of variables to pass to the recipe
     :param error: (Optional) If the action is triggered by an exception, this contains the error object
     """
+    if functions is None:
+        functions = {}
+    if variables is None:
+        variables = {}
     # Ensure recipe object is a list
     if not isinstance(recipe, list):
         recipe = [recipe]
@@ -378,8 +384,8 @@ def _run_actions(
 
 def _read_data(
     recipe: _Union[dict, list],
-    functions: dict = {},
-    variables: dict = {},
+    functions: dict = None,
+    variables: dict = None,
     input_dataframe: _pandas.DataFrame = None
 ) -> _pandas.DataFrame:
     """
@@ -389,6 +395,10 @@ def _read_data(
     :param functions: (Optional) A dictionary of named custom functions passed in by the user
     :return: Dataframe of imported data
     """
+    if functions is None:
+        functions = {}
+    if variables is None:
+        variables = {}
     # Ensure recipe is a list
     if not isinstance(recipe, list):
         recipe = [recipe]
@@ -490,7 +500,7 @@ def _read_data(
 def _execute_wrangles(
     df: _pandas.DataFrame,
     wrangles_list: list,
-    functions: dict = {},
+    functions: dict = None,
     variables: dict = None
 ) -> _pandas.DataFrame:
     """
@@ -504,6 +514,8 @@ def _execute_wrangles(
     """
     if variables is None:
         variables = {}
+    if functions is None:
+        functions = {}
 
     # Ensure wrangles are defined as a list
     if not isinstance(wrangles_list, list):
@@ -946,8 +958,8 @@ def _filter_dataframe(
 def _write_data(
     df: _pandas.DataFrame,
     recipe: dict,
-    functions: dict = {},
-    variables: dict = {}
+    functions: dict = None,
+    variables: dict = None
 ) -> _pandas.DataFrame:
     """
     Export data to the requested targets as defined by the recipe
@@ -958,6 +970,10 @@ def _write_data(
     :param variables: (Optional) A dictionary of variables passed to the recipe
     :return: Dataframe, a subset if the 'dataframe' write type is set with specific columns
     """
+    if variables is None:
+        variables = {}
+    if functions is None:
+        functions = {}
     # Initialize returned df as df to start
     df_return = df
 

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -2005,10 +2005,6 @@ def Try(
   retries: int = 0,
   **kwargs
 ):
-  if functions is None:
-    functions = {}
-  if variables is None:
-    variables = {}
     """
     type: object
     description: Try a list of wrangles and catch any errors that occur
@@ -2036,6 +2032,10 @@ def Try(
         description: Number of times to retry the wrangles if an error occurs. Default 0.
         minimum: 0
     """
+    if functions is None:
+      functions = {}
+    if variables is None:
+      variables = {}
     for attempt in range(retries + 1):
         try:
             df = _wrangles.recipe.run(

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -39,7 +39,7 @@ def accordion(
     output: _Union[str, list] = None,
     propagate: _Union[str, list] = None,
     functions: _Union[_types.FunctionType, list] = [],
-    variables: dict = {}
+    variables: dict = None
 ) -> _pd.DataFrame:
     """
     type: object
@@ -84,7 +84,7 @@ def accordion(
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
-
+    if variables is None: variables = {}
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
@@ -170,13 +170,15 @@ def _batch_thread(
     batch_num: int,
     wrangles: list,
     functions: _Union[_types.FunctionType, list] = [],
-    variables: dict = {},
+    variables: dict = None,
     timeout: float = None,
     on_error: dict = None
 ):
     """
     Function called by batch
     """
+    if variables is None:
+        variables = {}
     try:
         return _wrangles.recipe.run(
             {"wrangles": wrangles},
@@ -200,7 +202,7 @@ def batch(
     df,
     wrangles: list,
     functions: _Union[_types.FunctionType, list] = [],
-    variables: dict = {},
+    variables: dict = None,
     batch_size: int = 1000,
     threads: int = 1,
     on_error: dict = None,
@@ -240,6 +242,8 @@ def batch(
         type: number
         description: The number of seconds to wait for a batch to complete before raising an error
     """
+    if variables is None:
+        variables = {}
     if not isinstance(df, _pd.DataFrame):
         raise ValueError('Input must be a pandas DataFrame')
 
@@ -409,7 +413,7 @@ def concurrent(
     max_concurrency: int = 10,
     use_multiprocessing: bool = False,
     functions: _Union[_types.FunctionType, list] = [],
-    variables: dict = {}
+    variables: dict = None
 ) -> _pd.DataFrame:
     """
     type: object
@@ -435,6 +439,8 @@ def concurrent(
         description: The maximum number of wrangles to execute in parallel
         minimum: 1
     """
+    if variables is None:
+        variables = {}
     if use_multiprocessing:
         # Not publicly documented. Use at your own risk.
         pool_executor = _futures.ProcessPoolExecutor
@@ -1992,13 +1998,17 @@ def translate(
 
 
 def Try(
-    df: _pd.DataFrame,
-    wrangles: list,
-    functions: _Union[_types.FunctionType, list, dict] = {},
-    variables: dict = {},
-    retries: int = 0,
-    **kwargs
+  df: _pd.DataFrame,
+  wrangles: list,
+  functions: _Union[_types.FunctionType, list, dict] = None,
+  variables: dict = None,
+  retries: int = 0,
+  **kwargs
 ):
+  if functions is None:
+    functions = {}
+  if variables is None:
+    variables = {}
     """
     type: object
     description: Try a list of wrangles and catch any errors that occur

--- a/wrangles/recipe_wrangles/split.py
+++ b/wrangles/recipe_wrangles/split.py
@@ -16,7 +16,7 @@ def dictionary(
     df: _pd.DataFrame,
     input: _Union[str, int, _list],
     output: _Union[str, _list] = None,
-    default: dict = {}
+    default: dict = None
 ) -> _pd.DataFrame:
     """
     type: object
@@ -54,6 +54,8 @@ def dictionary(
           Provide a set of default headings and values
           if they are not found within the input
     """ 
+    if default is None:
+        default = {}
     # Ensure input is passed as a list
     if not isinstance(input, _list):
         input = [input]
@@ -270,7 +272,7 @@ def tokenize(
     input: _Union[str, int, _list],
     output: _Union[str, _list] = None,
     method: str = 'space',
-    functions: dict = {}
+    functions: dict = None
 ) -> _pd.DataFrame:
     """
     type: object
@@ -311,6 +313,7 @@ def tokenize(
               or use a custom function with custom.<function>
               or use a regex pattern with regex:<pattern>
     """
+    if functions is None: functions = {}
     if output is None: output = input
     
     # Ensure input and outputs are lists

--- a/wrangles/train.py
+++ b/wrangles/train.py
@@ -147,7 +147,7 @@ class train():
         data: _Union[dict, list],
         name: str = None,
         model_id: str = None,
-        settings: dict = {}
+        settings: dict = None
     ):
         """
         Train a lookup model. This can be used as reference data to look values up from.
@@ -159,6 +159,8 @@ class train():
         :param model_id: If provided, will update this model.
         :param settings: Specific settings to apply to the lookup wrangle.
         """
+        if settings is None:
+            settings = {}
         # Read in variant
         if name:
             variant = settings.get("variant", "key")

--- a/wrangles/utils.py
+++ b/wrangles/utils.py
@@ -177,10 +177,10 @@ def validate_function_args(
 def add_special_parameters(
     params: dict,
     fn: _types.FunctionType,
-    functions: dict = {},
-    variables: dict = {},
+    functions: dict = None,
+    variables: dict = None,
     error: Exception = None,
-    common_params: dict = {}
+    common_params: dict = None
 ):
     """
     Add special parameters to the params dictionary if they are required by the function
@@ -193,6 +193,12 @@ def add_special_parameters(
     :param common_params: These are parameters that are common to all functions. \
         They will only be passed as a parameter if the function requests them.
     """
+    if functions is None:
+        functions = {}
+    if variables is None:
+        variables = {}
+    if common_params is None:
+        common_params = {}
     # Check args and pass on special parameters if requested
     argspec = _inspect.getfullargspec(fn).args
     if ("functions" not in params and "functions" in argspec):
@@ -390,7 +396,7 @@ def statement_modifier(statement):
     return _re.sub(r'\$\{([A-Za-z0-9_]+)\}', r'\1', str(statement))
 
 
-def evaluate_conditional(statement, variables: dict = {}):
+def evaluate_conditional(statement, variables: dict = None):
     """
     Evaluate a conditional statement using the variables provided
     to determine if the statement is true or false
@@ -400,6 +406,8 @@ def evaluate_conditional(statement, variables: dict = {}):
     :param statement: Python style statement
     :param variables: Dictionary of variables to use in the statement
     """
+    if variables is None:
+        variables = {}
     statement_modified = statement_modifier(statement)
 
     if _re.match(r'\$\{(.+)\}', statement_modified):


### PR DESCRIPTION
This pull request standardizes the handling of mutable default arguments across multiple connector modules. Specifically, it replaces default dictionary arguments (e.g., `dict = {}`) with `None`, and adds logic to initialize them as empty dictionaries within the function. This prevents unexpected behavior caused by mutable defaults and improves code reliability and maintainability.

Key changes by theme:

**Mutable Default Argument Fixes**

* Replaced default dictionary arguments with `None` and added checks to initialize them as empty dictionaries in functions throughout the following modules: `akeneo.py`, `concurrent.py`, `http.py`, `matrix.py`, `mongodb.py`, `recipe.py`, `salesforce.py`, `test.py`, `train.py`, and `openai.py`. This ensures that each function call gets a fresh dictionary and avoids issues with shared state.

**Initialization Logic**

* Added checks at the start of affected functions to initialize dictionary arguments to `{}` if they are `None`, ensuring consistent behavior and preventing errors.
These changes collectively make the codebase safer and more predictable, especially when functions are called multiple times or concurrently.