### PR TITLE
Accordion broken when using recipe where

### DIFF
--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -5094,6 +5094,33 @@ class TestAccordion:
             df["list_column"][0] == ["A","B","C"]
         )
 
+    def test_accordion_filter_out_first_row(self):
+        """
+        Test accordion when we filter first rows
+        """
+        df = wrangles.recipe.run(  
+            """  
+            wrangles:  
+            - accordion:  
+                input: list_column  
+                where: numbers > 1  # This filters out the first row (index 0)  
+                wrangles:  
+                    - convert.case:  
+                        input: list_column  
+                        case: upper  
+            """,  
+            dataframe = pd.DataFrame({  
+                "list_column": [["a","b","c"], ["d","e","f"], ["g","h","i"]],  
+                "numbers": [1, 2, 3]  
+            })) 
+        
+        assert (
+            len(df) == 3 and
+            df["list_column"][0] == ["a","b","c"] and
+            df["list_column"][1] == ["D","E","F"] and
+            df["list_column"][2] == ["G","H","I"]
+        )
+
 
 class TestBatch:
     """

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -100,7 +100,7 @@ def accordion(
 
     # Convert any columns containing JSON arrays to lists
     for col in input:
-        if not isinstance(df_temp[col][0], list):
+        if not df_temp.empty and not isinstance(df_temp[col].iloc[0], list):
             try:
                 df_temp[col] = df_temp[col].apply(_json.loads)
             except:


### PR DESCRIPTION
This pull request introduces improvements to the `accordion` wrangle and adds a new test to ensure correct behavior when filtering rows. The main focus is on handling empty DataFrames safely and verifying the `accordion` functionality when a filter is applied.

Enhancements to error handling and robustness:

* Updated the `accordion` function in `wrangles/recipe_wrangles/main.py` to check for empty DataFrames before processing columns, preventing errors when accessing the first element.

Testing improvements:

* Added a new test `test_accordion_filter_out_first_row` in `tests/recipes/wrangles/test_main.py` to verify that the `accordion` wrangle correctly filters out the first row and applies transformations only to the remaining rows.

```
        df = wrangles.recipe.run(  
            """  
            wrangles:  
            - accordion:  
                input: list_column  
                where: numbers > 1  # This filters out the first row (index 0)  
                wrangles:  
                    - convert.case:  
                        input: list_column  
                        case: upper  
            """,  
            dataframe = pd.DataFrame({  
                "list_column": [["a","b","c"], ["d","e","f"], ["g","h","i"]],  
                "numbers": [1, 2, 3]  
            }))
```