### PR TITLE
Create Column should NOT error if column exists

### DIFF
--- a/tests/recipes/wrangles/test_create.py
+++ b/tests/recipes/wrangles/test_create.py
@@ -92,44 +92,83 @@ class TestCreateColumn:
         df = wrangles.recipe.run(recipe, dataframe=data)
         assert df.iloc[0]['column3'] in [True, False]
         
-    def test_column_exists(self):
+    def test_column_exists_no_error(self):
         """
-        Check error if trying to create a column that already exists
+        Default behaviour: creating a column that already exists should not raise
+        an error — the existing column is left unchanged.
         """
-        data = pd.DataFrame({
-        'col': ['data1']
-        })
+        data = pd.DataFrame({'col': ['data1']})
         recipe = """
         wrangles:
         - create.column:
             output: col
+            value: new_value
         """
-        with pytest.raises(ValueError) as info:
-            wrangles.recipe.run(recipe, dataframe=data)
-        assert (
-            info.typename == 'ValueError' and
-            '"col" column already exists in dataFrame.' in info.value.args[0]
-        )
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df['col'][0] == 'data1'
 
-    def test_column_exists_list(self):
+    def test_column_exists_list_no_error(self):
         """
-        Check error if trying to create a list of columns where one already exists
+        Default behaviour: creating a list of columns where one already exists
+        should not raise an error — the existing column is left unchanged.
         """
-        data = pd.DataFrame({
-        'col': ['data1']
-        })
+        data = pd.DataFrame({'col': ['data1']})
         recipe = """
         wrangles:
         - create.column:
             output:
                 - col
+                - col2
+            value: new_value
         """
-        with pytest.raises(ValueError) as info:
-            wrangles.recipe.run(recipe, dataframe=data)
-        assert (
-            info.typename == 'ValueError' and
-            "['col'] column(s)" in info.value.args[0]
-        )
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df['col'][0] == 'data1' and df['col2'][0] == 'new_value'
+
+    def test_column_exists_value_if_exists_existing(self):
+        """
+        Explicit value_if_exists: existing leaves the column unchanged.
+        """
+        data = pd.DataFrame({'col': ['data1']})
+        recipe = """
+        wrangles:
+        - create.column:
+            output: col
+            value: new_value
+            value_if_exists: existing
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df['col'][0] == 'data1'
+
+    def test_column_exists_value_if_exists_new(self):
+        """
+        value_if_exists: new overwrites the entire existing column.
+        """
+        data = pd.DataFrame({'col': ['data1', 'data2']})
+        recipe = """
+        wrangles:
+        - create.column:
+            output: col
+            value: replaced
+            value_if_exists: new
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert list(df['col']) == ['replaced', 'replaced']
+
+    def test_column_exists_value_if_exists_coalesce(self):
+        """
+        value_if_exists: coalesce fills only null/empty cells, leaving non-null
+        cells intact.
+        """
+        data = pd.DataFrame({'col': ['keep', None, '']})
+        recipe = """
+        wrangles:
+        - create.column:
+            output: col
+            value: filled
+            value_if_exists: coalesce
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert list(df['col']) == ['keep', 'filled', 'filled']
 
     def test_create_column_value_number(self):
         """

--- a/tests/recipes/wrangles/test_create.py
+++ b/tests/recipes/wrangles/test_create.py
@@ -170,6 +170,71 @@ class TestCreateColumn:
         df = wrangles.recipe.run(recipe, dataframe=data)
         assert list(df['col']) == ['keep', 'filled', 'filled']
 
+    def test_column_exists_value_if_exists_coalesce_numeric(self):
+        """
+        value_if_exists: coalesce on a numeric column only fills NaN cells,
+        without comparing values to an empty string.
+        """
+        data = pd.DataFrame({'col': [1, None, 3]})
+        recipe = """
+        wrangles:
+        - create.column:
+            output: col
+            value: 99
+            value_if_exists: coalesce
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert list(df['col']) == [1, 99, 3]
+
+    def test_column_exists_coalesce_value_new(self):
+        """
+        coalesce_value: new prefers the new value over a non-empty existing
+        value, only falling back to the existing value where the new value
+        is empty/null.
+        """
+        data = pd.DataFrame({'col': ['keep1', 'keep2']})
+        recipe = """
+        wrangles:
+        - create.column:
+            output: col
+            value: new_value
+            value_if_exists: coalesce
+            coalesce_value: new
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert list(df['col']) == ['new_value', 'new_value']
+
+    def test_column_exists_coalesce_value_invalid(self):
+        """
+        An invalid coalesce_value option raises a ValueError.
+        """
+        data = pd.DataFrame({'col': ['data1']})
+        recipe = """
+        wrangles:
+        - create.column:
+            output: col
+            value: new_value
+            value_if_exists: coalesce
+            coalesce_value: not_a_real_option
+        """
+        with pytest.raises(ValueError, match="coalesce_value"):
+            wrangles.recipe.run(recipe, dataframe=data)
+
+    def test_column_exists_value_if_exists_invalid(self):
+        """
+        An invalid value_if_exists option raises a ValueError.
+        """
+        data = pd.DataFrame({'col': ['data1']})
+        recipe = """
+        wrangles:
+        - create.column:
+            output: col
+            value: new_value
+            value_if_exists: existng
+        """
+        with pytest.raises(ValueError, match="value_if_exists"):
+            wrangles.recipe.run(recipe, dataframe=data)
+
     def test_create_column_value_number(self):
         """
         Test create.column using a number as the value

--- a/tests/recipes/wrangles/test_create.py
+++ b/tests/recipes/wrangles/test_create.py
@@ -204,6 +204,23 @@ class TestCreateColumn:
         df = wrangles.recipe.run(recipe, dataframe=data)
         assert list(df['col']) == ['new_value', 'new_value']
 
+    def test_column_exists_coalesce_value_new_fallback(self):
+        """
+        coalesce_value: new falls back to the existing value when the new
+        value is empty/null.
+        """
+        data = pd.DataFrame({'col': ['keep1', 'keep2']})
+        recipe = """
+        wrangles:
+        - create.column:
+            output: col
+            value:
+            value_if_exists: coalesce
+            coalesce_value: new
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert list(df['col']) == ['keep1', 'keep2']
+
     def test_column_exists_coalesce_value_invalid(self):
         """
         An invalid coalesce_value option raises a ValueError.

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -3487,7 +3487,7 @@ class TestTranslate:
                 target_language: EN-GB
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['English'] == 'Hello World!'
+        assert df.iloc[0]['English'] == 'Hello, world!'
 
     def test_translate_2(self):
         """
@@ -3505,7 +3505,7 @@ class TestTranslate:
                 target_language: English
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['English'] == 'Hello World!'
+        assert df.iloc[0]['English'] == 'Hello, world!'
 
     def test_translate_3(self):
         """

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -3487,7 +3487,7 @@ class TestTranslate:
                 target_language: EN-GB
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['English'] == 'Hello, world!'
+        assert df.iloc[0]['English'] == 'Hello World!'
 
     def test_translate_2(self):
         """
@@ -3505,7 +3505,7 @@ class TestTranslate:
                 target_language: English
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['English'] == 'Hello, world!'
+        assert df.iloc[0]['English'] == 'Hello World!'
 
     def test_translate_3(self):
         """

--- a/wrangles/recipe_wrangles/create.py
+++ b/wrangles/recipe_wrangles/create.py
@@ -85,7 +85,12 @@ def bins(
     return df
 
 
-def column(df: _pd.DataFrame, output: _Union[str, list], value = None) -> _pd.DataFrame:
+def column(
+    df: _pd.DataFrame,
+    output: _Union[str, list],
+    value = None,
+    value_if_exists: str = 'existing'
+) -> _pd.DataFrame:
     """
     type: object
     description: Create column(s) with a user defined value. Defaults to None (empty).
@@ -106,13 +111,22 @@ def column(df: _pd.DataFrame, output: _Union[str, list], value = None) -> _pd.Da
           - array
           - boolean
         description: (Optional) Value(s) to add in the new column(s). If using a dictionary in output, value can only be a string.
+      value_if_exists:
+        type: string
+        description: >-
+          Determines behaviour when the output column already exists.
+          existing (default): leave the column unchanged.
+          coalesce: fill empty/null cells with the new value, keeping non-null cells.
+          new: overwrite the entire column with the new value.
+        enum:
+          - existing
+          - coalesce
+          - new
     """
     _logging.debug(f": Creating column(s) :: output :: {output}")
     # If a string provided, convert to list
     if isinstance(output, str):
-      if output in df.columns:
-        raise ValueError(f'"{output}" column already exists in dataFrame.')
-      output = [output]
+        output = [output]
 
     # gather the columns and values in a dictionary, if not a dict then use value as the value of dictionary
     output_dict = {}
@@ -124,18 +138,30 @@ def column(df: _pd.DataFrame, output: _Union[str, list], value = None) -> _pd.Da
         else:
             output_dict.update({out: value})
 
-    # Check if the list of outputs exist in dataFrame
-    check_list = [x for x in (output_dict.keys()) if x in df.columns]
-    if len(check_list) > 0:
-      raise ValueError(f'{check_list} column(s) already exists in the dataFrame') 
-
     for output_column, values_list in zip(output_dict.keys(), output_dict.values()):
+        column_exists = output_column in df.columns
+
+        if column_exists and value_if_exists == 'existing':
+            continue
+
         # Data to generate
-        data = _pd.DataFrame({
-            output_column: _generate_cell_values(values_list, len(df))
-        }).set_index(df.index)  # use the same index as original to match rows
-        # Merging existing dataframe with values created
-        df = _pd.concat([df, data], axis=1)
+        new_values = _pd.Series(
+            _generate_cell_values(values_list, len(df)),
+            index=df.index
+        )
+
+        if column_exists and value_if_exists == 'coalesce':
+            df[output_column] = df[output_column].where(
+                df[output_column].notna() & (df[output_column] != ''),
+                new_values
+            )
+        else:
+            # new or column doesn't exist — write/overwrite directly
+            if not column_exists:
+                data = _pd.DataFrame({output_column: new_values})
+                df = _pd.concat([df, data], axis=1)
+            else:
+                df[output_column] = new_values
 
     return df
 

--- a/wrangles/recipe_wrangles/create.py
+++ b/wrangles/recipe_wrangles/create.py
@@ -89,7 +89,8 @@ def column(
     df: _pd.DataFrame,
     output: _Union[str, list],
     value = None,
-    value_if_exists: str = 'existing'
+    value_if_exists: str = 'existing',
+    coalesce_value: str = 'existing'
 ) -> _pd.DataFrame:
     """
     type: object
@@ -122,8 +123,31 @@ def column(
           - existing
           - coalesce
           - new
+      coalesce_value:
+        type: string
+        description: >-
+          Only used when value_if_exists is coalesce. Determines which side
+          is preferred when both the existing and new values are non-empty.
+          existing (default): keep the existing value, only fill empty/null cells with the new value.
+          new: keep the new value, only fall back to the existing value where the new value is empty/null.
+        enum:
+          - existing
+          - new
     """
     _logging.debug(f": Creating column(s) :: output :: {output}")
+
+    valid_value_if_exists = ('existing', 'coalesce', 'new')
+    if value_if_exists not in valid_value_if_exists:
+        raise ValueError(
+            f'value_if_exists must be one of {valid_value_if_exists}, got "{value_if_exists}"'
+        )
+
+    valid_coalesce_value = ('existing', 'new')
+    if coalesce_value not in valid_coalesce_value:
+        raise ValueError(
+            f'coalesce_value must be one of {valid_coalesce_value}, got "{coalesce_value}"'
+        )
+
     # If a string provided, convert to list
     if isinstance(output, str):
         output = [output]
@@ -151,10 +175,16 @@ def column(
         )
 
         if column_exists and value_if_exists == 'coalesce':
-            df[output_column] = df[output_column].where(
-                df[output_column].notna() & (df[output_column] != ''),
-                new_values
-            )
+            if coalesce_value == 'existing':
+                primary, fallback = df[output_column], new_values
+            else:
+                primary, fallback = new_values, df[output_column]
+
+            is_empty = primary.isna()
+            if primary.dtype == object:
+                is_empty = is_empty | (primary == '')
+
+            df[output_column] = primary.where(~is_empty, fallback)
         else:
             # new or column doesn't exist — write/overwrite directly
             if not column_exists:


### PR DESCRIPTION
This pull request updates the behavior of the `create.column` wrangle to provide more flexible handling when attempting to create columns that already exist in the DataFrame. Instead of always raising an error, the function now supports a new `value_if_exists` parameter that controls whether to leave the column unchanged, coalesce (fill only empty/null cells), or overwrite the column. The tests have been updated to verify these scenarios.

**Enhancements to `create.column` behavior:**

* Added a new `value_if_exists` parameter to the `column` function in `wrangles/recipe_wrangles/create.py`, allowing users to specify how to handle existing columns: `'existing'` (default, leaves column unchanged), `'coalesce'` (fills only empty/null cells), or `'new'` (overwrites the column).
*  Added new coalesce_value parameter ('existing' default / 'new'), implementing ebhills' decision: when value_if_exists: coalesce, you can now choose whether the
  existing value or the new value takes priority on non-empty conflicts, with the other side only filling in when the primary is empty/null. 
* Updated the implementation of the `column` function to support the new behaviors, removing the previous error-raising logic and handling each mode accordingly.

**Test updates:**

* Modified and added tests in `tests/recipes/wrangles/test_create.py` to check the default behavior (no error, column unchanged), and the new behaviors for `value_if_exists: existing`, `value_if_exists: new`, and `value_if_exists: coalesce`.

**Examples of usage**

* The column already exists — do nothing, raise no error.
This is the default so you can omit the parameter entirely.
```
wrangles.recipe.run(
    recipe="""
    wrangles:
      - create.column:
          output: status
          value: unknown
          # value_if_exists: existing  <-- this is the default
    """,
    dataframe=data.copy()
)
```

```
df = wrangles.recipe.run(
    recipe="""
    wrangles:
      - create.column:
          output:
            - status      # already exists → skipped
            - region      # new → created
          value: EMEA
    """,
    dataframe=data.copy()
)
```
*Fill gaps (`null` and empty string) in the existing column while preserving
rows that already have a value.
```
 wrangles.recipe.run(
    recipe="""
    wrangles:
      - create.column:
          output: status
          value: unknown
          value_if_exists: coalesce
    """,
    dataframe=data.copy()
)
```

*Unconditionally overwrite every cell in the existing column.

```
wrangles.recipe.run(
    recipe="""
    wrangles:
      - create.column:
          output: status
          value: reset
          value_if_exists: new
    """,
    dataframe=data.copy()
)
```