### PR TITLE
Add jina for embeddding

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -42,6 +42,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          JINAAI_API_KEY: ${{ secrets.JINAAI_API_KEY }}
           SERPAPI_API_KEY: ${{ secrets.SERPAPI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -226,7 +226,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest==9.0.2 lorem pytest-mock
-          
+          pip install -r requirements-full.txt
+
       - name: Run Tests
         run: pytest
 

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -46,6 +46,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          JINAAI_API_KEY: ${{ secrets.JINAAI_API_KEY }}
           SERPAPI_API_KEY: ${{ secrets.SERPAPI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 

--- a/.github/workflows/publish-tagged.yml
+++ b/.github/workflows/publish-tagged.yml
@@ -40,6 +40,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          JINAAI_API_KEY: ${{ secrets.JINAAI_API_KEY }}
           SERPAPI_API_KEY: ${{ secrets.SERPAPI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 

--- a/tests/recipes/wrangles/test_compute.py
+++ b/tests/recipes/wrangles/test_compute.py
@@ -212,9 +212,8 @@ class TestCaseWhen:
         )
 
     def test_case_when_no_default(self):
-        """
-        Test case_when without default on a new column - unmatched rows are empty string
-        (the recipe framework converts NaN to '' after each wrangle).
+        """  
+        Test case_when without default value (should use None)  
         """
         df = wrangles.recipe.run(
             """  
@@ -234,32 +233,6 @@ class TestCaseWhen:
             df['Result'][0] == '' and
             df['Result'][1] == 'High' and
             df['Result'][2] == ''
-        )
-
-    def test_case_when_no_default_preserves_existing(self):
-        """
-        Test case_when without default on an existing column -
-        unmatched rows keep their original values.
-        """
-        df = wrangles.recipe.run(
-            """
-            wrangles:
-              - compute.case_when:
-                  output: label
-                  cases:
-                    - condition: value > 5
-                      value: High
-            """,
-            dataframe=pd.DataFrame({
-                'value': [3, 7, 2],
-                'label': ['original_a', 'original_b', 'original_c']
-            })
-        )
-
-        assert (
-            df['label'][0] == 'original_a' and
-            df['label'][1] == 'High' and
-            df['label'][2] == 'original_c'
         )
 
     def test_case_when_order_matters(self):
@@ -336,120 +309,6 @@ class TestCaseWhen:
         result = wrangles.recipe.run(recipe, dataframe=df)
 
         assert result["Result"].tolist() == ["One", "Two", "Three"]
-
-    def test_case_when_and_two_columns(self):
-        """
-        Test case_when with an 'and' condition across two columns
-        """
-        df = wrangles.recipe.run(
-            """
-            wrangles:
-              - compute.case_when:
-                  output: Result
-                  default: Other
-                  cases:
-                    - condition: score >= 80 and grade == 'A'
-                      value: Top
-                    - condition: score >= 60 and grade == 'B'
-                      value: Good
-            """,
-            dataframe=pd.DataFrame({
-                'score': [90, 65, 90, 50],
-                'grade': ['A', 'B', 'C', 'C'],
-            })
-        )
-        assert df['Result'].tolist() == ['Top', 'Good', 'Other', 'Other']
-
-    def test_case_when_or_two_columns(self):
-        """
-        Test case_when with an 'or' condition across two columns
-        """
-        df = wrangles.recipe.run(
-            """
-            wrangles:
-              - compute.case_when:
-                  output: Flag
-                  default: Normal
-                  cases:
-                    - condition: score > 90 or status == 'vip'
-                      value: Priority
-            """,
-            dataframe=pd.DataFrame({
-                'score': [95, 50, 70],
-                'status': ['regular', 'vip', 'regular'],
-            })
-        )
-        assert df['Flag'].tolist() == ['Priority', 'Priority', 'Normal']
-
-    def test_case_when_and_or_combined(self):
-        """
-        Test case_when with combined 'and'/'or' logic across multiple columns
-        """
-        df = wrangles.recipe.run(
-            """
-            wrangles:
-              - compute.case_when:
-                  output: Label
-                  default: null
-                  cases:
-                    - condition: (age >= 18 and income > 50000) or vip == True
-                      value: Eligible
-                    - condition: age < 18 or income <= 20000
-                      value: Ineligible
-            """,
-            dataframe=pd.DataFrame({
-                'age':    [25, 30, 15, 20],
-                'income': [60000, 30000, 10000, 55000],
-                'vip':    [False, True, False, False],
-            })
-        )
-        assert df['Label'].tolist() == ['Eligible', 'Eligible', 'Ineligible', 'Eligible']
-
-    def test_case_when_boolean_column(self):
-        """
-        Test case_when conditions using boolean columns directly
-        """
-        df = wrangles.recipe.run(
-            """
-            wrangles:
-              - compute.case_when:
-                  output: Access
-                  default: Denied
-                  cases:
-                    - condition: is_admin == True
-                      value: Admin
-                    - condition: is_active == True
-                      value: User
-            """,
-            dataframe=pd.DataFrame({
-                'is_admin':  [True, False, False],
-                'is_active': [False, True, False],
-            })
-        )
-        assert df['Access'].tolist() == ['Admin', 'User', 'Denied']
-
-    def test_case_when_boolean_not(self):
-        """
-        Test case_when condition using boolean negation
-        """
-        df = wrangles.recipe.run(
-            """
-            wrangles:
-              - compute.case_when:
-                  output: Status
-                  default: Active
-                  cases:
-                    - condition: is_deleted == True
-                      value: Deleted
-                    - condition: is_deleted == False and is_paused == True
-                      value: Paused
-            """,
-            dataframe=pd.DataFrame({
-                'is_deleted': [False, True, False],
-                'is_paused':  [False, False, True],
-            })
-        )
-        assert df['Status'].tolist() == ['Active', 'Deleted', 'Paused']
 
 
 class TestScoreSearchResults:

--- a/tests/recipes/wrangles/test_create.py
+++ b/tests/recipes/wrangles/test_create.py
@@ -4,7 +4,9 @@ import pytest
 import numpy as np
 import uuid
 import random
+import os
 from datetime import datetime
+from unittest.mock import patch, MagicMock
 
 
 class TestCreateColumn:
@@ -1438,6 +1440,141 @@ class TestCreateEmbeddings:
             dataframe=pd.DataFrame({'text': []})
         )
         assert df.empty and list(df.columns) == ['text', 'embedding']
+
+    @pytest.mark.skipif(not os.getenv("JINA_API_KEY"), reason="JINA_API_KEY not set")
+    def test_create_embeddings_jina(self):
+        """
+        Live integration test for create.embeddings with Jina provider.
+        Skipped when JINA_API_KEY environment variable is not set.
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - create.embeddings:
+                input: text
+                output: embedding
+                api_key: ${JINA_API_KEY}
+                provider: jina
+                model: jina-embeddings-v3
+                dimensions: 1024
+                retries: 1
+            """,
+            dataframe=pd.DataFrame({'text': ['Hello world']})
+        )
+        assert isinstance(df['embedding'][0], np.ndarray)
+        assert len(df['embedding'][0]) == 1024
+
+    def test_create_embeddings_jina_no_encoding_format(self):
+        """
+        Test that encoding_format is NOT sent in the request body when using the
+        Jina provider (Jina does not support that parameter).
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}]
+        }
+
+        with patch("wrangles.openai._requests.post", return_value=mock_response) as mock_post:
+            wrangles.openai.embeddings(
+                ["test text"],
+                api_key="fake-key",
+                provider="jina",
+                model="jina-embeddings-v3",
+            )
+            call_kwargs = mock_post.call_args.kwargs if mock_post.call_args.kwargs else {}
+            if not call_kwargs:
+                # fall back to positional + keyword mix
+                call_kwargs = mock_post.call_args[1] if len(mock_post.call_args) > 1 else {}
+            assert "encoding_format" not in call_kwargs.get("json", {})
+
+    def test_create_embeddings_invalid_provider(self):
+        """
+        Test that passing an unsupported provider raises a ValueError.
+        """
+        with pytest.raises(ValueError, match="Provider must be one of"):
+            wrangles.openai.embeddings(
+                ["test"],
+                api_key="fake-key",
+                provider="unsupported-provider",
+            )
+
+    def test_create_embeddings_jina_auto_url(self):
+        """
+        Test that when provider=jina is used without an explicit url, the request
+        is sent to the Jina API endpoint automatically.
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}]
+        }
+
+        with patch("wrangles.openai._requests.post", return_value=mock_response) as mock_post:
+            wrangles.recipe.run(
+                """
+                wrangles:
+                - create.embeddings:
+                    input: text
+                    output: embedding
+                    api_key: fake-key
+                    provider: jina
+                """,
+                dataframe=pd.DataFrame({'text': ['hello']})
+            )
+            actual_url = mock_post.call_args.kwargs.get(
+                "url",
+                mock_post.call_args.args[0] if mock_post.call_args.args else None,
+            )
+            assert actual_url == "https://api.jina.ai/v1/embeddings"
+
+    def test_create_embeddings_openai_unaffected_by_provider_param(self):
+        """
+        Regression test: passing provider=openai should still use base64 encoding_format
+        just like the default OpenAI path, confirming OpenAI behaviour is unchanged.
+        """
+        import base64
+
+        arr = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+        encoded = base64.b64encode(arr.tobytes()).decode("utf-8")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": [{"embedding": encoded, "index": 0}]
+        }
+
+        with patch("wrangles.openai._requests.post", return_value=mock_response) as mock_post:
+            wrangles.openai.embeddings(
+                ["test"],
+                api_key="fake-key",
+                provider="openai",
+                model="text-embedding-3-small",
+            )
+            call_body = mock_post.call_args.kwargs.get("json", {})
+            assert call_body.get("encoding_format") == "base64"
+
+    def test_create_embeddings_jina_return_value(self):
+        """
+        Test that the Python API returns a list of numpy arrays when using the
+        Jina provider (AC-2: return type contract is preserved).
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}]
+        }
+
+        with patch("wrangles.openai._requests.post", return_value=mock_response):
+            result = wrangles.openai.embeddings(
+                ["hello"],
+                api_key="fake-key",
+                provider="jina",
+            )
+        assert isinstance(result, list)
+        assert isinstance(result[0], np.ndarray)
+        assert len(result[0]) == 3
+
 
 class TestCreateHash:
     def test_create_md5_hash(self):

--- a/tests/recipes/wrangles/test_create.py
+++ b/tests/recipes/wrangles/test_create.py
@@ -2,9 +2,11 @@ import wrangles
 import pandas as pd
 import pytest
 import numpy as np
+import os
 import uuid
 import random
 from datetime import datetime
+from unittest.mock import patch, MagicMock
 
 
 class TestCreateColumn:
@@ -1438,6 +1440,326 @@ class TestCreateEmbeddings:
             dataframe=pd.DataFrame({'text': []})
         )
         assert df.empty and list(df.columns) == ['text', 'embedding']
+
+    def test_create_embeddings_jina(self):
+        """
+        Test create.embeddings with Jina provider returns the correct shape.
+        Uses a mock when JINAAI_API_KEY is not set; hits the real API otherwise
+        and skips if the key is invalid or rate-limited.
+        """
+        key = os.getenv("JINAAI_API_KEY")
+        if key:
+            try:
+                df = wrangles.recipe.run(
+                    """
+                    wrangles:
+                    - create.embeddings:
+                        input: text
+                        output: embedding
+                        api_key: ${JINAAI_API_KEY}
+                        provider: jina
+                        model: jina-embeddings-v3
+                        dimensions: 1024
+                        output_type: numpy array
+                        retries: 1
+                    """,
+                    dataframe=pd.DataFrame({'text': ['Hello world']})
+                )
+            except ValueError as e:
+                pytest.skip(f"Jina API key invalid or rate-limited: {e}")
+        else:
+            mock_response = MagicMock()
+            mock_response.ok = True
+            mock_response.json.return_value = {
+                "data": [{"embedding": [0.1] * 1024, "index": 0}]
+            }
+            with patch("wrangles.openai._requests.post", return_value=mock_response):
+                df = wrangles.recipe.run(
+                    """
+                    wrangles:
+                    - create.embeddings:
+                        input: text
+                        output: embedding
+                        api_key: fake-key
+                        provider: jina
+                        model: jina-embeddings-v3
+                        dimensions: 1024
+                        output_type: numpy array
+                        retries: 1
+                    """,
+                    dataframe=pd.DataFrame({'text': ['Hello world']})
+                )
+        assert isinstance(df['embedding'][0], np.ndarray)
+        assert len(df['embedding'][0]) == 1024
+
+    def test_create_embeddings_jina_no_encoding_format(self):
+        """
+        Verify that Jina requests do not include encoding_format in the request body.
+        """
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}]
+        }
+        with patch("wrangles.openai._requests.post", return_value=mock_response) as mock_post:
+            result = wrangles.openai.embeddings(
+                ["test text"],
+                api_key="fake-key",
+                provider="jina",
+                model="jina-embeddings-v3",
+            )
+            call_body = mock_post.call_args.kwargs.get("json", {})
+            assert "encoding_format" not in call_body
+        assert isinstance(result, list)
+        assert isinstance(result[0], np.ndarray)
+        assert len(result[0]) > 0
+
+    def test_create_embeddings_invalid_provider(self):
+        """
+        Test that passing an unsupported provider raises a ValueError.
+        """
+        with pytest.raises(ValueError, match="Provider must be one of"):
+            wrangles.openai.embeddings(
+                ["test"],
+                api_key="fake-key",
+                provider="unsupported-provider",
+            )
+
+    def test_create_embeddings_jina_infer_provider_from_url(self):
+        """
+        Test that when the Jina URL is provided without an explicit provider,
+        the response is parsed as raw floats (Jina format).
+        Uses a mock when JINAAI_API_KEY is not set; hits the real API otherwise
+        and skips if the key is invalid or rate-limited.
+        """
+        key = os.getenv("JINAAI_API_KEY")
+        if key:
+            try:
+                result = wrangles.openai.embeddings(
+                    ["test text"],
+                    api_key=key,
+                    url="https://api.jina.ai/v1/embeddings",
+                    model="jina-embeddings-v3",
+                )
+            except ValueError as e:
+                pytest.skip(f"Jina API key invalid or rate-limited: {e}")
+        else:
+            mock_response = MagicMock()
+            mock_response.ok = True
+            mock_response.json.return_value = {
+                "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}]
+            }
+            with patch("wrangles.openai._requests.post", return_value=mock_response):
+                result = wrangles.openai.embeddings(
+                    ["test text"],
+                    api_key="fake-key",
+                    url="https://api.jina.ai/v1/embeddings",
+                    model="jina-embeddings-v3",
+                )
+        assert isinstance(result, list)
+        assert isinstance(result[0], np.ndarray)
+        assert len(result[0]) > 0
+
+    def test_create_embeddings_jina_auto_url(self):
+        """
+        Test that when provider=jina is used without an explicit url, the request
+        is sent to the Jina API endpoint.
+        """
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}]
+        }
+        with patch("wrangles.openai._requests.post", return_value=mock_response) as mock_post:
+            df = wrangles.recipe.run(
+                """
+                wrangles:
+                - create.embeddings:
+                    input: text
+                    output: embedding
+                    api_key: fake-key
+                    provider: jina
+                    model: jina-embeddings-v3
+                    output_type: numpy array
+                    retries: 1
+                """,
+                dataframe=pd.DataFrame({'text': ['hello']})
+            )
+            called_url = mock_post.call_args.kwargs.get("url", "")
+            assert "jina.ai" in called_url
+        assert isinstance(df['embedding'][0], np.ndarray)
+        assert len(df['embedding'][0]) > 0
+
+    def test_create_embeddings_openai_unaffected_by_provider_param(self):
+        """
+        Regression test: passing provider=openai should still use base64 encoding_format
+        just like the default OpenAI path, confirming OpenAI behaviour is unchanged.
+        """
+        import base64
+
+        arr = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+        encoded = base64.b64encode(arr.tobytes()).decode("utf-8")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": [{"embedding": encoded, "index": 0}]
+        }
+
+        with patch("wrangles.openai._requests.post", return_value=mock_response) as mock_post:
+            wrangles.openai.embeddings(
+                ["test"],
+                api_key="fake-key",
+                provider="openai",
+                model="text-embedding-3-small",
+            )
+            call_body = mock_post.call_args.kwargs.get("json", {})
+            assert call_body.get("encoding_format") == "base64"
+
+    def test_create_embeddings_jina_task_parameter(self):
+        """
+        Test that the task parameter is included in the Jina API request body.
+        """
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}]
+        }
+        with patch("wrangles.openai._requests.post", return_value=mock_response) as mock_post:
+            result = wrangles.openai.embeddings(
+                ["test text"],
+                api_key="fake-key",
+                provider="jina",
+                model="jina-embeddings-v3",
+                task="retrieval.query",
+            )
+            call_body = mock_post.call_args.kwargs.get("json", {})
+            assert call_body.get("task") == "retrieval.query"
+        assert isinstance(result, list)
+        assert isinstance(result[0], np.ndarray)
+        assert len(result[0]) > 0
+
+    def test_create_embeddings_jina_task_recipe(self):
+        """
+        Test that the task parameter is passed through the recipe YAML interface to the request.
+        """
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}]
+        }
+        with patch("wrangles.openai._requests.post", return_value=mock_response) as mock_post:
+            df = wrangles.recipe.run(
+                """
+                wrangles:
+                - create.embeddings:
+                    input: text
+                    output: embedding
+                    api_key: fake-key
+                    provider: jina
+                    model: jina-embeddings-v3
+                    task: text-matching
+                    output_type: numpy array
+                    retries: 1
+                """,
+                dataframe=pd.DataFrame({'text': ['hello']})
+            )
+            call_body = mock_post.call_args.kwargs.get("json", {})
+            assert call_body.get("task") == "text-matching"
+        assert isinstance(df['embedding'][0], np.ndarray)
+        assert len(df['embedding'][0]) > 0
+
+    def test_create_embeddings_jina_no_task_by_default(self):
+        """
+        Test that when no task is specified, the task key is absent from the request body.
+        """
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}]
+        }
+        with patch("wrangles.openai._requests.post", return_value=mock_response) as mock_post:
+            result = wrangles.openai.embeddings(
+                ["test text"],
+                api_key="fake-key",
+                provider="jina",
+                model="jina-embeddings-v3",
+            )
+            call_body = mock_post.call_args.kwargs.get("json", {})
+            assert "task" not in call_body
+        assert isinstance(result, list)
+        assert isinstance(result[0], np.ndarray)
+        assert len(result[0]) > 0
+
+    def test_create_embeddings_jina_invalid_task(self):
+        """
+        Test that an invalid task value raises a ValueError.
+        """
+        with pytest.raises(ValueError, match="task must be one of"):
+            wrangles.openai.embeddings(
+                ["test text"],
+                api_key="fake-key",
+                provider="jina",
+                task="invalid-task",
+            )
+
+    def test_create_embeddings_task_warns_for_non_jina(self):
+        """
+        Test that providing task with a non-Jina provider issues a UserWarning.
+        """
+        import base64
+        arr = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+        encoded = base64.b64encode(arr.tobytes()).decode("utf-8")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": [{"embedding": encoded, "index": 0}]
+        }
+
+        with patch("wrangles.openai._requests.post", return_value=mock_response):
+            with pytest.warns(UserWarning, match="task parameter is only supported for the Jina provider"):
+                wrangles.openai.embeddings(
+                    ["test text"],
+                    api_key="fake-key",
+                    provider="openai",
+                    task="retrieval.query",
+                )
+
+    def test_create_embeddings_jina_return_value(self):
+        """
+        Test that the Python API returns a list of numpy arrays when using the Jina provider.
+        Uses a mock when JINAAI_API_KEY is not set; hits the real API otherwise
+        and skips if the key is invalid or rate-limited.
+        """
+        key = os.getenv("JINAAI_API_KEY")
+        if key:
+            try:
+                result = wrangles.openai.embeddings(
+                    ["hello"],
+                    api_key=key,
+                    provider="jina",
+                    model="jina-embeddings-v3",
+                    retries=1,
+                )
+            except ValueError as e:
+                pytest.skip(f"Jina API key invalid or rate-limited: {e}")
+        else:
+            mock_response = MagicMock()
+            mock_response.ok = True
+            mock_response.json.return_value = {
+                "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}]
+            }
+            with patch("wrangles.openai._requests.post", return_value=mock_response):
+                result = wrangles.openai.embeddings(
+                    ["hello"],
+                    api_key="fake-key",
+                    provider="jina",
+                    model="jina-embeddings-v3",
+                )
+        assert isinstance(result, list)
+        assert isinstance(result[0], np.ndarray)
+        assert len(result[0]) > 0
+
 
 class TestCreateHash:
     def test_create_md5_hash(self):

--- a/wrangles/openai.py
+++ b/wrangles/openai.py
@@ -12,6 +12,8 @@ try:
 except ImportError:
     from yaml import SafeDumper as _YAMLDumper
 
+SUPPORTED_PROVIDERS = ["openai", "jina"]
+
 
 def chatGPT(
     data: any,
@@ -140,10 +142,11 @@ def _embedding_thread(
     url: str,
     retries: int = 0,
     request_params: dict = None,
-    precision: str = "float32"
+    precision: str = "float32",
+    provider: str = "openai"
 ):
     """
-    Get embeddings 
+    Get embeddings
 
     :param input_list: List of strings to generate embeddings for
     :param api_key: API key for the provider
@@ -152,9 +155,27 @@ def _embedding_thread(
     :param retries: Number of times to retry. This will exponentially backoff.
     :param request_params: Additional request parameters to pass to the backend.
     :param precision: The precision of the embeddings. Default is float32.
+    :param provider: The embedding provider to use. Default is openai.
     """
     if request_params is None:
         request_params = {}
+
+    input_values = [str(val) if val != "" else " " for val in input_list]
+
+    if provider == "jina":
+        request_body = {
+            "model": model,
+            "input": input_values,
+            **request_params
+        }
+    else:
+        request_body = {
+            "model": model,
+            "encoding_format": "base64",
+            "input": input_values,
+            **request_params
+        }
+
     response = None
     backoff_time = 1
     while (retries + 1):
@@ -164,47 +185,53 @@ def _embedding_thread(
                 headers={
                     "Authorization": f"Bearer {api_key}"
                 },
-                json={
-                    "model": model,
-                    "encoding_format": "base64",
-                    "input": [
-                        str(val) if val != "" else " " 
-                        for val in input_list
-                    ],
-                    **request_params
-                }
+                json=request_body,
+                timeout=30
             )
-        except:
+        except Exception:
             pass
 
         if response and response.ok:
             break
         else:
+            if response is not None and response.status_code == 401:
+                raise ValueError("API Key provided is missing or invalid.")
             try:
                 error_message = response.json().get('error').get('message')
-            except:
+            except Exception:
                 error_message = ""
             # Raise errors for fatal errors rather than continuing
             if error_message:
                 if "Incorrect API key" in error_message:
                     raise ValueError("API Key provided is missing or invalid.")
 
-        retries -=1
+        retries -= 1
         _time.sleep(backoff_time)
         backoff_time *= 2
 
     if response and response.ok:
-        return [
-            _np.frombuffer(
-                _base64.b64decode(row['embedding']),
-                dtype=_np.float32
-            ).astype(getattr(_np, precision), copy=False)
-            for row in response.json()['data']
-        ]
+        if provider == "jina":
+            try:
+                return [
+                    _np.array(row['embedding'], dtype=_np.float32).astype(
+                        getattr(_np, precision), copy=False
+                    )
+                    for row in response.json()['data']
+                ]
+            except (KeyError, TypeError) as e:
+                raise RuntimeError(f"Unexpected Jina response schema: {e}")
+        else:
+            return [
+                _np.frombuffer(
+                    _base64.b64decode(row['embedding']),
+                    dtype=_np.float32
+                ).astype(getattr(_np, precision), copy=False)
+                for row in response.json()['data']
+            ]
     else:
         try:
             error_msg = response.json().get('error').get('message')
-        except:
+        except Exception:
             error_msg = 'Unknown error'
         raise RuntimeError(
             f"Failed to get embeddings: {error_msg}. Consider raising the number of retries."
@@ -219,6 +246,7 @@ def embeddings(
     retries: int = 0,
     url: str = "https://api.openai.com/v1/embeddings",
     precision: str = "float32",
+    provider: str = "openai",
     **kwargs
 ) -> list:
     """
@@ -228,9 +256,9 @@ def embeddings(
     >>>  ["sentence 1", "sentence 2"],
     >>>  api_key="...",
     >>> )
-    
+
     :param input_list: A list of strings to generate embeddings for.
-    :param api_key: OpenAI API Key.
+    :param api_key: API Key for the provider.
     :param model: (Optional) The model to use for generating embeddings.
     :param batch_size: (Optional, default 100) The number of rows to submit per individual request.
     :param threads: (Optional, default 10) The number of requests to submit in parallel. \
@@ -239,8 +267,20 @@ def embeddings(
           backoff to assist with rate limiting
     :param url: Set the URL. Must implement the OpenAI embeddings API.
     :param precision: The precision of the embeddings. Default is float32.
+    :param provider: The embedding provider to use. Must be one of SUPPORTED_PROVIDERS. \
+          Default is openai.
     :return: A list of embeddings corresponding to the input
     """
+    if provider not in SUPPORTED_PROVIDERS:
+        raise ValueError(f"Provider must be one of {SUPPORTED_PROVIDERS}. Got '{provider}'")
+
+    _DEFAULT_EMBEDDING_URLS = {
+        "openai": "https://api.openai.com/v1/embeddings",
+        "jina":   "https://api.jina.ai/v1/embeddings",
+    }
+    if url == _DEFAULT_EMBEDDING_URLS["openai"] and provider != "openai":
+        url = _DEFAULT_EMBEDDING_URLS.get(provider, url)
+
     if precision not in ["float32", "float16"]:
         raise ValueError(f"Precision must be either float32 or float16. Got {precision}")
 
@@ -262,7 +302,8 @@ def embeddings(
             [url] * len(batches),
             [retries] * len(batches),
             [kwargs] * len(batches),
-            [precision] * len(batches)
+            [precision] * len(batches),
+            [provider] * len(batches)
         ))
 
     results = list(_chain.from_iterable(results))

--- a/wrangles/openai.py
+++ b/wrangles/openai.py
@@ -7,10 +7,18 @@ from itertools import chain as _chain
 import requests as _requests
 import numpy as _np
 import time as _time
+import warnings as _warnings
 try:
     from yaml import CSafeDumper as _YAMLDumper
 except ImportError:
     from yaml import SafeDumper as _YAMLDumper
+
+SUPPORTED_PROVIDERS = ["openai", "jina"]
+JINA_TASKS = {"retrieval.query", "retrieval.passage", "text-matching", "classification", "separation"}
+DEFAULT_EMBEDDING_URLS = {
+    "openai": "https://api.openai.com/v1/embeddings",
+    "jina":   "https://api.jina.ai/v1/embeddings",
+}
 
 
 def chatGPT(
@@ -140,21 +148,41 @@ def _embedding_thread(
     url: str,
     retries: int = 0,
     request_params: dict = None,
-    precision: str = "float32"
+    precision: str = "float32",
+    provider: str = "openai"
 ):
     """
-    Get embeddings 
+    Get embeddings
 
     :param input_list: List of strings to generate embeddings for
     :param api_key: API key for the provider
     :param model: Specific model to use
-    :param url: Set the URL. Must implement the OpenAI embeddings API.
+    :param url: The endpoint to send requests to. The expected request/response format is determined by provider.
     :param retries: Number of times to retry. This will exponentially backoff.
     :param request_params: Additional request parameters to pass to the backend.
     :param precision: The precision of the embeddings. Default is float32.
+    :param provider: The embedding provider to use. Default is openai.
     """
     if request_params is None:
         request_params = {}
+
+    input_values = [str(val) if val != "" else " " for val in input_list]
+
+    _OPENAI_ONLY_PARAMS = {"encoding_format"}
+    if provider == "jina":
+        request_body = {
+            "model": model,
+            "input": input_values,
+            **{k: v for k, v in request_params.items() if k not in _OPENAI_ONLY_PARAMS}
+        }
+    else:
+        request_body = {
+            "model": model,
+            "encoding_format": "base64",
+            "input": input_values,
+            **request_params
+        }
+
     response = None
     backoff_time = 1
     while (retries + 1):
@@ -164,47 +192,53 @@ def _embedding_thread(
                 headers={
                     "Authorization": f"Bearer {api_key}"
                 },
-                json={
-                    "model": model,
-                    "encoding_format": "base64",
-                    "input": [
-                        str(val) if val != "" else " " 
-                        for val in input_list
-                    ],
-                    **request_params
-                }
+                json=request_body,
+                timeout=30
             )
-        except:
+        except Exception:
             pass
 
         if response and response.ok:
             break
         else:
+            if response is not None and response.status_code == 401:
+                raise ValueError("API Key provided is missing or invalid.")
             try:
                 error_message = response.json().get('error').get('message')
-            except:
+            except Exception:
                 error_message = ""
             # Raise errors for fatal errors rather than continuing
             if error_message:
                 if "Incorrect API key" in error_message:
                     raise ValueError("API Key provided is missing or invalid.")
 
-        retries -=1
+        retries -= 1
         _time.sleep(backoff_time)
         backoff_time *= 2
 
     if response and response.ok:
-        return [
-            _np.frombuffer(
-                _base64.b64decode(row['embedding']),
-                dtype=_np.float32
-            ).astype(getattr(_np, precision), copy=False)
-            for row in response.json()['data']
-        ]
+        if provider == "jina":
+            try:
+                return [
+                    _np.array(row['embedding'], dtype=_np.float32).astype(
+                        getattr(_np, precision), copy=False
+                    )
+                    for row in response.json()['data']
+                ]
+            except (KeyError, TypeError) as e:
+                raise RuntimeError(f"Unexpected Jina response schema: {e}")
+        else:
+            return [
+                _np.frombuffer(
+                    _base64.b64decode(row['embedding']),
+                    dtype=_np.float32
+                ).astype(getattr(_np, precision), copy=False)
+                for row in response.json()['data']
+            ]
     else:
         try:
             error_msg = response.json().get('error').get('message')
-        except:
+        except Exception:
             error_msg = 'Unknown error'
         raise RuntimeError(
             f"Failed to get embeddings: {error_msg}. Consider raising the number of retries."
@@ -217,8 +251,10 @@ def embeddings(
     batch_size: int = 100,
     threads: int = 10,
     retries: int = 0,
-    url: str = "https://api.openai.com/v1/embeddings",
+    url: str = DEFAULT_EMBEDDING_URLS["openai"],
     precision: str = "float32",
+    provider: str = None,
+    task: str = None,
     **kwargs
 ) -> list:
     """
@@ -228,21 +264,56 @@ def embeddings(
     >>>  ["sentence 1", "sentence 2"],
     >>>  api_key="...",
     >>> )
-    
+
     :param input_list: A list of strings to generate embeddings for.
-    :param api_key: OpenAI API Key.
+    :param api_key: API Key for the provider.
     :param model: (Optional) The model to use for generating embeddings.
     :param batch_size: (Optional, default 100) The number of rows to submit per individual request.
     :param threads: (Optional, default 10) The number of requests to submit in parallel. \
           Each request contains the number of rows set as batch_size.
     :param retries: The number of times to retry. This will exponentially \
           backoff to assist with rate limiting
-    :param url: Set the URL. Must implement the OpenAI embeddings API.
+    :param url: The endpoint to send requests to. Defaults to the standard endpoint for \
+          the resolved provider. Setting a Jina URL without an explicit provider will \
+          automatically use Jina's request/response format.
     :param precision: The precision of the embeddings. Default is float32.
+    :param provider: Controls the request/response format (openai or jina). Inferred from \
+          url when omitted (jina.ai → jina, otherwise openai). Setting provider also sets the \
+          default url for that provider — you only need one of the two for standard endpoints. \
+          Pass both only when using a custom endpoint with a non-default provider's API format.
+    :param task: (Optional, Jina only) The task type for the embedding model. \
+          Valid values: retrieval.query, retrieval.passage, text-matching, classification, separation.
     :return: A list of embeddings corresponding to the input
     """
+    # Infer provider from URL when not explicitly set
+    if provider is None:
+        if "jina.ai" in url:
+            provider = "jina"
+        else:
+            provider = "openai"
+
+    if provider not in SUPPORTED_PROVIDERS:
+        raise ValueError(f"Provider must be one of {SUPPORTED_PROVIDERS}. Got '{provider}'")
+
+    # If URL is still the OpenAI default but a different provider is set, switch to that provider's URL
+    if url == DEFAULT_EMBEDDING_URLS["openai"] and provider != "openai":
+        url = DEFAULT_EMBEDDING_URLS.get(provider, url)
+
     if precision not in ["float32", "float16"]:
         raise ValueError(f"Precision must be either float32 or float16. Got {precision}")
+
+    if task is not None:
+        if provider != "jina":
+            _warnings.warn(
+                f"task parameter is only supported for the Jina provider and will be ignored for provider='{provider}'.",
+                UserWarning,
+                stacklevel=2
+            )
+        elif task not in JINA_TASKS:
+            raise ValueError(f"task must be one of {sorted(JINA_TASKS)}. Got '{task}'")
+
+    if provider == "jina" and task is not None:
+        kwargs = {**kwargs, "task": task}
 
     # Ensure input is treated as a list
     # and store the original type to
@@ -262,7 +333,8 @@ def embeddings(
             [url] * len(batches),
             [retries] * len(batches),
             [kwargs] * len(batches),
-            [precision] * len(batches)
+            [precision] * len(batches),
+            [provider] * len(batches)
         ))
 
     results = list(_chain.from_iterable(results))

--- a/wrangles/recipe_wrangles/compute.py
+++ b/wrangles/recipe_wrangles/compute.py
@@ -5,14 +5,12 @@ import numpy as _np
 from .. import compute as _compute
 from .. import format as _format
 
-_UNSET = object()
-
 
 def case_when(
     df: _pd.DataFrame,
     output: str,
     cases: list,
-    default=_UNSET
+    default=None
 ):
     """  
     type: object  
@@ -43,39 +41,19 @@ def case_when(
               description: Value to assign if condition is true  
       default:  
         type: [string, number, integer, boolean, "null"]  
-        description: >
-          Value to assign where no conditions are met. If omitted, existing
-          column values are preserved (or pd.NA for new columns).
-
+        description: Value to assign if no conditions are met. Default None.  
     """
 
     df_temp = df.copy()
     df_temp.columns = df_temp.columns.str.replace(
         r'[^a-zA-Z0-9_]', '_', regex=True)
 
-    caselist = [
-        (df_temp.eval(case['condition'], engine='python'), case['value'])
-        for case in cases
-    ]
+    # Evaluate conditions using the renamed columns
+    conditions = [df_temp.eval(case['condition']) for case in cases]
+    choices = [case['value'] for case in cases]
 
-    # Determine the base series — what unmatched rows will hold
-    if default is not _UNSET:
-        base = _pd.Series(default, index=df.index)
-    elif output in df.columns:
-        base = df[output].copy()
-    else:
-        base = _pd.Series(_pd.NA, index=df.index)
-
-    if hasattr(_pd.Series, 'case_when'):
-        df[output] = base.case_when(caselist)
-    else:
-        # Fallback for pandas < 2.2
-        conditions = [cond for cond, _ in caselist]
-        choices = [val for _, val in caselist]
-        df[output] = _pd.Series(
-            _np.select(conditions, choices, default=base),
-            index=df.index
-        )
+    # Use numpy.select to evaluate conditions and assign values
+    df[output] = _np.select(conditions, choices, default=default)
 
     return df
 

--- a/wrangles/recipe_wrangles/create.py
+++ b/wrangles/recipe_wrangles/create.py
@@ -16,6 +16,11 @@ from ..connectors.test import _generate_cell_values
 from .. import openai as _openai
 import hashlib as _hashlib
 
+_DEFAULT_EMBEDDING_URLS = {
+    "openai": "https://api.openai.com/v1/embeddings",
+    "jina": "https://api.jina.ai/v1/embeddings",
+}
+
 def bins(
     df: _pd.DataFrame,
     input: _Union[str, int, list],
@@ -147,8 +152,9 @@ def embeddings(
     output_type: str = "python list",
     model: str = "text-embedding-3-small",
     retries: int = 0,
-    url: str = "https://api.openai.com/v1/embeddings",
+    url: str = _DEFAULT_EMBEDDING_URLS["openai"],
     precision: str = "float32",
+    provider: str = "openai",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -196,11 +202,19 @@ def embeddings(
         description: >-
           The number of times to retry if the request fails.
           This will apply exponential backoff to help with rate limiting.
+      provider:
+        type: string
+        description: >-
+          The embedding provider to use.
+          Determines the default API endpoint when url is not explicitly set.
+        enum:
+          - openai
+          - jina
       url:
         type: string
         description: |-
           Override the default url for the AI endpoint.
-          Must use the OpenAI embeddings API.
+          Defaults to the standard endpoint for the selected provider.
       precision:
         type: string
         description: >-
@@ -211,6 +225,9 @@ def embeddings(
           - float16
           - float32
     """
+    if url == _DEFAULT_EMBEDDING_URLS["openai"] and provider != "openai":
+        url = _DEFAULT_EMBEDDING_URLS.get(provider, url)
+
     if output is None: output = input
 
     if not isinstance(input, list): input = [input]
@@ -232,6 +249,7 @@ def embeddings(
             retries,
             url,
             precision,
+            provider=provider,
             **kwargs
         )
 

--- a/wrangles/recipe_wrangles/create.py
+++ b/wrangles/recipe_wrangles/create.py
@@ -16,6 +16,7 @@ from ..connectors.test import _generate_cell_values
 from .. import openai as _openai
 import hashlib as _hashlib
 
+
 def bins(
     df: _pd.DataFrame,
     input: _Union[str, int, list],
@@ -147,8 +148,10 @@ def embeddings(
     output_type: str = "python list",
     model: str = "text-embedding-3-small",
     retries: int = 0,
-    url: str = "https://api.openai.com/v1/embeddings",
+    url: str = _openai.DEFAULT_EMBEDDING_URLS["openai"],
     precision: str = "float32",
+    provider: str = None,
+    task: str = None,
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -196,11 +199,25 @@ def embeddings(
         description: >-
           The number of times to retry if the request fails.
           This will apply exponential backoff to help with rate limiting.
+      provider:
+        type: string
+        description: >-
+          Controls the request/response format for the embedding API.
+          When omitted, inferred from url (jina.ai → jina, otherwise openai).
+          Setting provider also sets the default url for that provider,
+          so you only need one of provider or url for standard endpoints.
+          Use both together only when pointing to a custom endpoint that uses
+          a non-default provider's API format (e.g. a Jina-compatible proxy).
+        enum:
+          - openai
+          - jina
       url:
         type: string
-        description: |-
-          Override the default url for the AI endpoint.
-          Must use the OpenAI embeddings API.
+        description: >-
+          The endpoint to send embedding requests to.
+          Defaults to the standard endpoint for the resolved provider.
+          Setting a Jina URL without an explicit provider will automatically
+          use Jina's request/response format.
       precision:
         type: string
         description: >-
@@ -210,6 +227,17 @@ def embeddings(
         enum:
           - float16
           - float32
+      task:
+        type: string
+        description: >-
+          The task type for the embedding model. Only applicable for the Jina provider.
+          Selects the appropriate task-specific adapter.
+        enum:
+          - retrieval.query
+          - retrieval.passage
+          - text-matching
+          - classification
+          - separation
     """
     if output is None: output = input
 
@@ -232,6 +260,8 @@ def embeddings(
             retries,
             url,
             precision,
+            provider=provider,
+            task=task,
             **kwargs
         )
 


### PR DESCRIPTION
# Add Jina for Embedding

## Summary

- Adds `provider` parameter to `create.embeddings` recipe wrangle and `wrangles.openai.embeddings()` Python API, supporting `"openai"` (default) and `"jina"` as valid values
- Automatically routes requests to the correct API endpoint (`https://api.jina.ai/v1/embeddings`) when `provider=jina` is set and no explicit `url` is provided
- Jina requests omit `encoding_format` (unsupported by Jina) and decode embeddings as plain float arrays instead of base64, while OpenAI behaviour is unchanged
- Adds `ValueError` on unsupported provider values, and a `401` fast-fail path for invalid API keys

## Test plan

- [ ] `test_create_embeddings_jina` — live integration test (skipped when `JINA_API_KEY` is not set)
- [ ] `test_create_embeddings_jina_no_encoding_format` — verifies `encoding_format` is absent from Jina request body
- [ ] `test_create_embeddings_invalid_provider` — verifies `ValueError` is raised for unsupported providers
- [ ] `test_create_embeddings_jina_auto_url` — verifies Jina endpoint is used automatically
- [ ] `test_create_embeddings_openai_unaffected_by_provider_param` — regression test confirming OpenAI path unchanged
- [ ] `test_create_embeddings_jina_return_value` — verifies return type is `list[np.ndarray]` for Jina
