### PR TITLE
Add Parquet as a file format in th file connector

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ jinja2
 polars==1.33.0
 xlsxwriter
 pydantic>=2.12.0
+pyarrow

--- a/tests/connectors/test_file.py
+++ b/tests/connectors/test_file.py
@@ -223,6 +223,29 @@ class TestRead:
             and len(df) == 3
         ) 
 
+    def test_read_parquet(self):
+        """
+        Test reading a parquet file
+        """
+        filename = str(_uuid.uuid4())
+        _pd.DataFrame(
+            {"header1": ["value1", "value2", "value3"]}
+        ).to_parquet(f"tests/temp/{filename}.parquet", index=False)
+
+        df = wrangles.recipe.run(
+            """
+            read:
+              - file:
+                  name: tests/temp/${filename}.parquet
+            """,
+            variables={"filename": filename}
+        )
+
+        assert (
+            df["header1"][0] == "value1"
+            and len(df) == 3
+        )
+
     def test_read_unsupported_filetype(self):
         """
         Check an appropriate error is given if the user 
@@ -482,6 +505,30 @@ class TestWrite:
             variables={"filename": filename}
         )
         df = _pd.read_pickle(f"tests/temp/{filename}.pkl.gz")
+        assert (
+            df["header1"][0] == "value1"
+            and len(df) == 5
+        )
+
+    def test_write_parquet(self):
+        """
+        Test writing a parquet file
+        """
+        filename = str(_uuid.uuid4())
+        wrangles.recipe.run(
+            """
+            read:
+              - test:
+                  rows: 5
+                  values:
+                    header1: value1
+            write:
+              - file:
+                  name: tests/temp/${filename}.parquet
+            """,
+            variables={"filename": filename}
+        )
+        df = _pd.read_parquet(f"tests/temp/{filename}.parquet")
         assert (
             df["header1"][0] == "value1"
             and len(df) == 5

--- a/tests/connectors/test_file.py
+++ b/tests/connectors/test_file.py
@@ -534,6 +534,155 @@ class TestWrite:
             and len(df) == 5
         )
 
+    def test_write_parquet_chunk_size(self):
+        """
+        Test writing a parquet file with a custom chunk_size smaller than the data.
+        Data should be written correctly across multiple chunks.
+        """
+        filename = str(_uuid.uuid4())
+        rows = 25
+        wrangles.recipe.run(
+            """
+            read:
+              - test:
+                  rows: ${rows}
+                  values:
+                    header1: value1
+                    header2: value2
+            write:
+              - file:
+                  name: tests/temp/${filename}.parquet
+                  chunk_size: 7
+            """,
+            variables={"filename": filename, "rows": rows}
+        )
+        df = _pd.read_parquet(f"tests/temp/{filename}.parquet")
+        assert len(df) == rows and df["header1"][0] == "value1"
+
+    def test_write_parquet_chunk_size_larger_than_data(self):
+        """
+        Test writing a parquet file with a chunk_size larger than the number of rows.
+        Should behave identically to writing without a chunk_size.
+        """
+        filename = str(_uuid.uuid4())
+        wrangles.recipe.run(
+            """
+            read:
+              - test:
+                  rows: 5
+                  values:
+                    header1: value1
+            write:
+              - file:
+                  name: tests/temp/${filename}.parquet
+                  chunk_size: 10000
+            """,
+            variables={"filename": filename}
+        )
+        df = _pd.read_parquet(f"tests/temp/{filename}.parquet")
+        assert len(df) == 5 and df["header1"][0] == "value1"
+
+    def test_write_parquet_chunk_size_equals_one(self):
+        """
+        Test writing a parquet file with chunk_size=1 (extreme case, one row per chunk).
+        All rows should still be present in the output.
+        """
+        filename = str(_uuid.uuid4())
+        rows = 10
+        wrangles.recipe.run(
+            """
+            read:
+              - test:
+                  rows: ${rows}
+                  values:
+                    col: abc
+            write:
+              - file:
+                  name: tests/temp/${filename}.parquet
+                  chunk_size: 1
+            """,
+            variables={"filename": filename, "rows": rows}
+        )
+        df = _pd.read_parquet(f"tests/temp/{filename}.parquet")
+        assert len(df) == rows and df["col"][0] == "abc"
+
+    def test_write_parquet_chunk_size_data_integrity(self):
+        """
+        Test that chunked parquet write preserves row order and all values exactly.
+        Writes unique values per row to detect any row duplication or reordering.
+        """
+        import os
+        filename = str(_uuid.uuid4())
+        source = _pd.DataFrame({"id": list(range(50)), "val": [f"v{i}" for i in range(50)]})
+        path = f"tests/temp/{filename}.parquet"
+
+        wrangles.connectors.file.write(source, path, chunk_size=12)
+
+        result = _pd.read_parquet(path)
+        os.remove(path)
+
+        assert len(result) == 50
+        assert result["id"].tolist() == list(range(50))
+        assert result["val"].tolist() == [f"v{i}" for i in range(50)]
+
+    def test_write_parquet_auto_chunk_size(self):
+        """
+        Test that writing parquet without specifying chunk_size still produces
+        correct output — the auto-calculated chunk size should be used.
+        """
+        import os
+        rows = 200
+        source = _pd.DataFrame({"id": list(range(rows)), "val": [f"row_{i}" for i in range(rows)]})
+        path = f"tests/temp/{_uuid.uuid4()}.parquet"
+
+        wrangles.connectors.file.write(source, path)
+        result = _pd.read_parquet(path)
+        os.remove(path)
+
+        assert len(result) == rows and result["id"].tolist() == list(range(rows))
+
+    def test_parquet_chunk_size_helper_scales_with_row_width(self):
+        """
+        A wide DataFrame (many heavy columns) should produce a smaller auto chunk
+        size than a narrow DataFrame with the same number of rows.
+        """
+        narrow = _pd.DataFrame({"a": list(range(1000))})
+        wide = _pd.DataFrame({f"col_{i}": [f"long_string_value_{j}" for j in range(1000)] for i in range(50)})
+
+        narrow_chunk = wrangles.connectors.file._parquet_chunk_size(narrow)
+        wide_chunk = wrangles.connectors.file._parquet_chunk_size(wide)
+
+        assert wide_chunk < narrow_chunk
+
+    def test_parquet_chunk_size_helper_empty_df(self):
+        """
+        An empty DataFrame should return 1 (loop never executes, value is irrelevant).
+        """
+        empty = _pd.DataFrame({"a": []})
+        assert wrangles.connectors.file._parquet_chunk_size(empty) == 1
+
+    def test_write_parquet_chunk_vs_no_chunk_identical_output(self):
+        """
+        Test that writing a parquet file with chunk_size produces identical data
+        to writing without specifying chunk_size (default).
+        """
+        import os
+        source = _pd.DataFrame({"a": list(range(100)), "b": [str(i) for i in range(100)]})
+
+        chunked_path = f"tests/temp/{_uuid.uuid4()}.parquet"
+        default_path = f"tests/temp/{_uuid.uuid4()}.parquet"
+
+        wrangles.connectors.file.write(source, chunked_path, chunk_size=30)
+        wrangles.connectors.file.write(source, default_path)
+
+        chunked = _pd.read_parquet(chunked_path)
+        default = _pd.read_parquet(default_path)
+
+        os.remove(chunked_path)
+        os.remove(default_path)
+
+        assert chunked.equals(default)
+
     def test_write_file_format_conditional(self):
         """
         Test the format function with conditional_formats

--- a/wrangles/connectors/file.py
+++ b/wrangles/connectors/file.py
@@ -1,7 +1,7 @@
 """
 Connector to read & write from the local filesystem
 
-Supports Excel, CSV, JSON and JSONL files.
+Supports Excel, CSV, JSON, JSONL and Parquet files.
 """
 from openpyxl.styles import Alignment as _Alignment
 import pandas as _pd
@@ -32,6 +32,7 @@ def read(
       - CSV (.csv, .txt)
       - JSON (.json), JSONL (.jsonl)
       - Pickle (.pkl, .pickle) files.
+      - Parquet (.parquet) files.
 
     JSON, JSONL, CSV and Pickle files may also be gzipped (e.g. .csv.gz, .json.gz) and will be decompressed.
 
@@ -86,6 +87,8 @@ def read(
         (len(name.split('.')) >= 3 and name.split('.')[-2] in ['pkl', "pickle"])
     ):
         df = _pd.read_pickle(file_object, **kwargs).fillna('')
+    elif name.split('.')[-1] in ['parquet']:
+        df = _pd.read_parquet(file_object, **kwargs).fillna('')
     else:
       # If file type is not recognised
       raise ValueError(f"File type '{name.split('.')[-1]}' is not supported by the file connector.")
@@ -160,7 +163,8 @@ def write(df: _pd.DataFrame, name: str, columns: _Union[str, list] = None, file_
     - CSV (.csv, .txt)
     - JSON (.json), JSONL (.jsonl)
     - Pickle (.pkl, .pickle)
-    
+    - Parquet (.parquet)
+
     JSON, JSONL, CSV and pickle may also be gzipped (e.g. .csv.gz, .json.gz) and will be compressed.
 
     :param df: Dataframe to be written to a file
@@ -239,6 +243,9 @@ def write(df: _pd.DataFrame, name: str, columns: _Union[str, list] = None, file_
         (len(name.split('.')) >= 3 and name.split('.')[-2] in ['pkl', "pickle"])
     ):
         df.to_pickle(file_object, **kwargs)
+    elif name.split('.')[-1] in ['parquet']:
+        if 'index' not in kwargs.keys(): kwargs['index'] = False
+        df.to_parquet(file_object, **kwargs)
     else:
       # If file type is not recognised
       raise ValueError(f"File type '{name.split('.')[-1]}' is not supported by the file connector.")

--- a/wrangles/connectors/file.py
+++ b/wrangles/connectors/file.py
@@ -5,6 +5,8 @@ Supports Excel, CSV, JSON, JSONL and Parquet files.
 """
 from openpyxl.styles import Alignment as _Alignment
 import pandas as _pd
+import pyarrow as _pa
+import pyarrow.parquet as _pq
 import logging as _logging
 from typing import Union as _Union
 from io import BytesIO as _BytesIO
@@ -154,6 +156,17 @@ properties:
 """
 
 
+def _parquet_chunk_size(df: _pd.DataFrame, target_mb: int = 128) -> int:
+    """
+    Return a row count that keeps each parquet chunk under target_mb of
+    in-memory data.  Falls back to 100 000 if the dataframe is empty.
+    """
+    if len(df) == 0:
+        return 1  # no rows to write; value is irrelevant
+    bytes_per_row = df.memory_usage(deep=True).sum() / len(df)
+    return max(1, int(target_mb * 1024 * 1024 / bytes_per_row))
+
+
 def write(df: _pd.DataFrame, name: str, columns: _Union[str, list] = None, file_object: _BytesIO  = None, formatting: dict = None, **kwargs) -> None:
     """
     Output a file to the local file system as defined by the parameters.
@@ -244,8 +257,19 @@ def write(df: _pd.DataFrame, name: str, columns: _Union[str, list] = None, file_
     ):
         df.to_pickle(file_object, **kwargs)
     elif name.split('.')[-1] in ['parquet']:
-        if 'index' not in kwargs.keys(): kwargs['index'] = False
-        df.to_parquet(file_object, **kwargs)
+        chunk_size = kwargs.pop('chunk_size', _parquet_chunk_size(df))
+        index = kwargs.pop('index', False)
+        writer = None
+        try:
+            for start in range(0, len(df), chunk_size):
+                chunk = df.iloc[start:start + chunk_size]
+                table = _pa.Table.from_pandas(chunk, preserve_index=index)
+                if writer is None:
+                    writer = _pq.ParquetWriter(file_object, table.schema, **kwargs)
+                writer.write_table(table)
+        finally:
+            if writer:
+                writer.close()
     else:
       # If file type is not recognised
       raise ValueError(f"File type '{name.split('.')[-1]}' is not supported by the file connector.")
@@ -294,4 +318,7 @@ properties:
       - boolean
       - array
     description: Used for CSV files. Whether to write the column headers. Default true. Alternatively, provide a list to overwrite the headings.
+  chunk_size:
+    type: integer
+    description: Used for Parquet files. Number of rows to write per chunk to limit peak memory usage. Defaults to an automatically calculated value that keeps each chunk under 128 MB of in-memory data.
 """


### PR DESCRIPTION
This pull request adds support for reading and writing Parquet files to the local filesystem connector. It updates both the implementation and the tests to handle `.parquet` files, ensuring that users can now seamlessly work with this file format in addition to the previously supported formats.

**Parquet File Support**

* Updated the documentation in `wrangles/connectors/file.py` to include Parquet files as a supported format for both reading and writing. 
* Added logic to the `read` method in `wrangles/connectors/file.py` to handle `.parquet` files using `pandas.read_parquet`.
* Added logic to the `write` method in `wrangles/connectors/file.py` to handle `.parquet` files using `pandas.to_parquet`, ensuring the index is not written by default.

**Testing**

* Added `test_read_parquet` and `test_write_parquet` in `tests/connectors/test_file.py` to verify correct reading from and writing to Parquet files.

##  Speed comparison: CSV vs Parquet
```
import time

runs = 5

t0 = time.perf_counter()
for _ in range(runs):
    wrangles.connectors.file.read('temp/benchmark.csv')
csv_read_ms = (time.perf_counter() - t0) / runs * 1000

t0 = time.perf_counter()
for _ in range(runs):
    wrangles.connectors.file.read('temp/benchmark.parquet')
parquet_read_ms = (time.perf_counter() - t0) / runs * 1000



CSV read avg:     102.8 ms
Parquet read avg: 59.9 ms
Speedup:          1.7x faster
```