### PR TITLE
support production version run

### DIFF
--- a/tests/recipes/test_recipes.py
+++ b/tests/recipes/test_recipes.py
@@ -135,6 +135,16 @@ def test_recipe_by_production_version():
         list(df.columns) == ["header"]
     )
 
+def test_recipe_by_version_latest():
+    """
+    Test running a recipe using a model ID and latest version
+    """
+    df = wrangles.recipe.run("a6bac9e7-2388-4347:latest")
+    assert (
+        len(df) == 10 and
+        list(df.columns) == ["header"]
+    )
+
 def test_recipe_by_latest_version():
     """
     Test running a recipe using a model ID and latest version

--- a/tests/recipes/test_recipes.py
+++ b/tests/recipes/test_recipes.py
@@ -124,6 +124,27 @@ def test_recipe_by_version_tag():
         len(df2) == 20
     )
 
+
+def test_recipe_by_production_version():
+    """
+    Test running a recipe using a model ID and production version
+    """
+    df = wrangles.recipe.run("a6bac9e7-2388-4347")
+    assert (
+        len(df) == 20 and
+        list(df.columns) == ["header"]
+    )
+
+def test_recipe_by_latest_version():
+    """
+    Test running a recipe using a model ID and latest version
+    """
+    df = wrangles.recipe.run("02fc0c63-1294-415b")
+    assert (
+        len(df) == 15 and
+        list(df.columns) == ["header"]
+    )
+
 def test_recipe_wrong_model():
     """
     Test the error message when a model is incorrect type

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -101,6 +101,10 @@ def _load_recipe(
                 f'Using {purpose} model_id {model_id} in a recipe wrangle.'
             )
         
+        if 'production_version_id' in metadata.keys() and version_id is None:
+            version_id = metadata['production_version_id']
+            _logging.info(f": No version specified, defaulting to production version {version_id}")
+            
         model_contents = _data.model_content(model_id, version_id)
         recipe_string = model_contents['recipe']
         model_functions = model_contents.get('functions', {})

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -93,18 +93,22 @@ def _load_recipe(
         # If model_id format is correct but no mode_id exists
         if metadata.get('message', None) == 'error':
             raise ValueError('Incorrect model_id.\nmodel_id may be wrong or does not exists')
-        
+
         # Using model_id in wrong function
         purpose = metadata['purpose']
         if purpose != 'recipe':
             raise ValueError(
                 f'Using {purpose} model_id {model_id} in a recipe wrangle.'
             )
-        
+
         if 'production_version_id' in metadata.keys() and version_id is None:
             version_id = metadata['production_version_id']
             _logging.info(f": No version specified, defaulting to production version {version_id}")
-            
+        
+        if version_id == 'latest':
+            version_id = None
+            _logging.info(f": 'latest' version specified, using the most recent version")
+
         model_contents = _data.model_content(model_id, version_id)
         recipe_string = model_contents['recipe']
         model_functions = model_contents.get('functions', {})


### PR DESCRIPTION
This pull request adds support for running recipes using a model's production or latest version when no specific version is provided, and includes new tests to cover these scenarios. The main changes are grouped into enhancements to recipe version handling and corresponding test coverage.

**Enhancements to recipe version selection:**

* Updated `_load_recipe` in `wrangles/recipe.py` to automatically use the `production_version_id` from model metadata when a version is not specified, logging this behavior for clarity.

**Test coverage improvements:**

* Added `test_recipe_by_production_version` and `test_recipe_by_latest_version` in `tests/recipes/test_recipes.py` to validate running recipes with a model ID and either the production or latest version, ensuring correct output shape and columns.