### PR TITLE
add tests to check yaml description

### DIFF
--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -8080,3 +8080,48 @@ class TestWrangleExecutionLogging:
 
         # Check that the wildcard is not expanded (appears as literal)  
         assert any('col1, col2 >> col*, other' in message for message in caplog.messages)
+
+
+class TestWrangleSchema:
+    """
+    Validate that every recipe wrangle has a parseable YAML schema docstring.
+    Regression test for issues like lookup being silently missing from the schema
+    because its docstring couldn't be parsed.
+    """
+
+    def _collect_leaf_methods(self, obj, path=''):
+        """Return (path, method) pairs for all non-hidden leaf methods."""
+        non_hidden = [m for m in dir(obj) if not m.startswith('_')]
+        if non_hidden:
+            results = []
+            for method in non_hidden:
+                if method not in ('main', 'pandas'):
+                    results.extend(
+                        self._collect_leaf_methods(getattr(obj, method), f'{path}.{method}')
+                    )
+            return results
+        return [(path, obj)]
+
+    def test_all_wrangle_docstrings_parse_as_yaml(self):
+        """
+        Any wrangle docstring that begins with 'type:' or 'anyOf:' (i.e. is intended
+        to be a JSON Schema) must parse as valid YAML without errors.
+        This catches regressions like lookup being silently dropped from the schema
+        because its docstring had a YAML syntax error.
+        """
+        import yaml
+
+        failures = []
+        for path, method in self._collect_leaf_methods(wrangles.recipe._recipe_wrangles):
+            doc = getattr(method, '__doc__', None)
+            if doc is None:
+                continue
+            stripped = doc.strip()
+            if not (stripped.startswith('type:') or stripped.startswith('anyOf:')):
+                continue
+            try:
+                yaml.safe_load(doc)
+            except Exception as e:
+                failures.append(f'{path}: YAML parse error — {e}')
+
+        assert not failures, 'Wrangle schema docstring YAML parse failures:\n' + '\n'.join(failures)

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -928,15 +928,16 @@ def lookup(
         description: Name of the output column(s)
       lookup_mode:
         type: string
-        description: How to perform lookups
-                 'by_row': current behavior, lookup each row individually
-                 'by_dataframe': lookup unique values once, copy results to all rows  
-                 'by_matrix': lookup once per matrix permutation
+        description: >-
+          How to perform lookups.
+          'by_row' (default): lookup each row individually.
+          'by_dataframe': lookup unique values once, copy results to all rows.
+          'by_matrix': lookup once per matrix permutation.
         enum:
           - by_row
           - by_matrix
           - by_dataframe
-    """ 
+    """
     # Ensure input is only 1 value
     if isinstance(input, list):
         if len(input) == 1:


### PR DESCRIPTION
This pull request introduces a new regression test to ensure that all wrangle recipe docstrings intended as YAML schemas are valid and parseable, helping to prevent issues where schema documentation might be accidentally dropped due to syntax errors. Additionally, it improves the clarity of the `lookup_mode` documentation in the wrangle schema.

**Testing and validation improvements:**

* Added a new test class `TestWrangleSchema` in `tests/recipes/wrangles/test_main.py` that recursively checks all wrangle docstrings starting with `type:` or `anyOf:` are valid YAML, catching schema docstring parse errors before they can cause regressions.

**Documentation improvements:**

* Updated the `lookup_mode` field documentation in the `lookup` wrangle schema to use clearer formatting and explanations for each mode.