### PR TITLE
The Akeneo connector should also be able to read.

### DIFF
--- a/tests/connectors/test_akeneo.py
+++ b/tests/connectors/test_akeneo.py
@@ -1,0 +1,207 @@
+import pytest
+import pandas as pd
+from unittest.mock import MagicMock
+from wrangles.connectors.akeneo import read, write
+
+
+_AUTH_RESPONSE = {"access_token": "test_token"}
+
+_PRODUCTS_PAGE1 = {
+    "_embedded": {
+        "items": [
+            {"identifier": "prod1", "family": "familyA"},
+            {"identifier": "prod2", "family": "familyA"},
+        ]
+    },
+    "_links": {
+        "self": {"href": "https://akeneo.example.com/api/rest/v1/products?page=1"},
+        "first": {"href": "https://akeneo.example.com/api/rest/v1/products?page=1"},
+        "next": {"href": "https://akeneo.example.com/api/rest/v1/products?page=2"},
+    },
+}
+
+_PRODUCTS_PAGE2 = {
+    "_embedded": {
+        "items": [
+            {"identifier": "prod3", "family": "familyB"},
+        ]
+    },
+    "_links": {
+        "self": {"href": "https://github.com/wrangleworks/WranglesPY/issues/978/api/rest/v1/products?page=2"},
+        "first": {"href": "https://akeneo.example.com/api/rest/v1/products?page=1"},
+    },
+}
+
+_PRODUCTS_SINGLE_PAGE = {
+    "_embedded": {
+        "items": [
+            {"identifier": "prod1", "family": "familyA"},
+            {"identifier": "prod2", "family": "familyB"},
+        ]
+    },
+    "_links": {
+        "self": {"href": "https://akeneo.example.com/api/rest/v1/products"},
+        "first": {"href": "https://akeneo.example.com/api/rest/v1/products"},
+    },
+}
+
+
+def _mock_auth(mocker, status_code=200):
+    auth_mock = MagicMock()
+    auth_mock.ok = status_code < 400
+    auth_mock.status_code = status_code
+    auth_mock.json.return_value = _AUTH_RESPONSE if auth_mock.ok else {"message": "Unauthorized"}
+    auth_mock.text = "Unauthorized"
+    return auth_mock
+
+
+def _mock_get(mocker, pages):
+    get_mock = MagicMock()
+    responses = []
+    for page in pages:
+        r = MagicMock()
+        r.ok = True
+        r.status_code = 200
+        r.json.return_value = page
+        responses.append(r)
+    get_mock.side_effect = responses
+    return get_mock
+
+
+def test_read(mocker):
+    mocker.patch("requests.post", return_value=_mock_auth(mocker))
+    mocker.patch("requests.get", return_value=_make_get_response(_PRODUCTS_SINGLE_PAGE))
+
+    df = read(
+        host="https://akeneo.example.com",
+        user="user",
+        password="pass",
+        client_id="client_id",
+        client_secret="client_secret",
+        source="products",
+    )
+    assert list(df["identifier"]) == ["prod1", "prod2"]
+
+
+def test_read_columns(mocker):
+    mocker.patch("requests.post", return_value=_mock_auth(mocker))
+    mocker.patch("requests.get", return_value=_make_get_response(_PRODUCTS_SINGLE_PAGE))
+
+    df = read(
+        host="https://akeneo.example.com",
+        user="user",
+        password="pass",
+        client_id="client_id",
+        client_secret="client_secret",
+        source="products",
+        columns=["identifier"],
+    )
+    assert df.columns.tolist() == ["identifier"]
+    assert len(df) == 2
+
+
+def test_read_pagination(mocker):
+    mocker.patch("requests.post", return_value=_mock_auth(mocker))
+    get_mock = mocker.patch("requests.get")
+    get_mock.side_effect = [
+        _make_get_response(_PRODUCTS_PAGE1),
+        _make_get_response(_PRODUCTS_PAGE2),
+    ]
+
+    df = read(
+        host="https://akeneo.example.com",
+        user="user",
+        password="pass",
+        client_id="client_id",
+        client_secret="client_secret",
+        source="products",
+    )
+    assert len(df) == 3
+    assert list(df["identifier"]) == ["prod1", "prod2", "prod3"]
+
+
+def test_read_auth_error(mocker):
+    auth_mock = MagicMock()
+    auth_mock.ok = False
+    auth_mock.status_code = 401
+    auth_mock.json.return_value = {"message": "Unauthorized"}
+    auth_mock.text = "Unauthorized"
+    mocker.patch("requests.post", return_value=auth_mock)
+
+    with pytest.raises(ValueError, match="Akeneo authentication failed"):
+        read(
+            host="https://akeneo.example.com",
+            user="bad_user",
+            password="bad_pass",
+            client_id="client_id",
+            client_secret="client_secret",
+            source="products",
+        )
+
+
+def test_read_api_error(mocker):
+    mocker.patch("requests.post", return_value=_mock_auth(mocker))
+    error_mock = MagicMock()
+    error_mock.ok = False
+    error_mock.status_code = 422
+    error_mock.json.return_value = {"code": 422, "message": "Unprocessable Entity"}
+    mocker.patch("requests.get", return_value=error_mock)
+
+    with pytest.raises(ValueError, match="422"):
+        read(
+            host="https://akeneo.example.com",
+            user="user",
+            password="pass",
+            client_id="client_id",
+            client_secret="client_secret",
+            source="products",
+        )
+
+
+def test_write(mocker):
+    mocker.patch("requests.post", return_value=_mock_auth(mocker))
+    patch_mock = MagicMock()
+    patch_mock.ok = True
+    patch_mock.status_code = 200
+    patch_mock.text = '{"status_code": 204}\n{"status_code": 204}'
+    mocker.patch("requests.patch", return_value=patch_mock)
+
+    df = pd.DataFrame({"identifier": ["prod1", "prod2"], "family": ["familyA", "familyB"]})
+    result = write(
+        df=df,
+        host="https://akeneo.example.com",
+        user="user",
+        password="pass",
+        client_id="client_id",
+        client_secret="client_secret",
+        source="products",
+    )
+    assert result is None
+
+
+def test_write_error(mocker):
+    mocker.patch("requests.post", return_value=_mock_auth(mocker))
+    patch_mock = MagicMock()
+    patch_mock.status_code = 401
+    patch_mock.text = '{"code": 401, "message": "Unauthorized"}'
+    mocker.patch("requests.patch", return_value=patch_mock)
+
+    df = pd.DataFrame({"identifier": ["prod1"]})
+    with pytest.raises(ValueError, match="401"):
+        write(
+            df=df,
+            host="https://akeneo.example.com",
+            user="user",
+            password="pass",
+            client_id="client_id",
+            client_secret="client_secret",
+            source="products",
+        )
+
+
+def _make_get_response(data):
+    r = MagicMock()
+    r.ok = True
+    r.status_code = 200
+    r.json.return_value = data
+    return r

--- a/tests/connectors/test_akeneo.py
+++ b/tests/connectors/test_akeneo.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 import pandas as pd
-from unittest.mock import MagicMock
 from wrangles.connectors.akeneo import read, write
 
 
@@ -69,82 +68,42 @@ def test_read_pagination():
     assert isinstance(df, pd.DataFrame)
 
 
-# ---------------------------------------------------------------------------
-# Error-condition tests — kept mocked (can't reproduce with a live instance)
-# ---------------------------------------------------------------------------
-
-def _mock_auth(mocker, status_code=200):
-    auth_mock = MagicMock()
-    auth_mock.ok = status_code < 400
-    auth_mock.status_code = status_code
-    auth_mock.json.return_value = (
-        {"access_token": "test_token"} if auth_mock.ok else {"message": "Unauthorized"}
-    )
-    auth_mock.text = "Unauthorized"
-    return auth_mock
-
-
-def _make_get_response(data):
-    r = MagicMock()
-    r.ok = True
-    r.status_code = 200
-    r.json.return_value = data
-    return r
-
-
-def test_read_auth_error(mocker):
-    auth_mock = MagicMock()
-    auth_mock.ok = False
-    auth_mock.status_code = 401
-    auth_mock.json.return_value = {"message": "Unauthorized"}
-    auth_mock.text = "Unauthorized"
-    mocker.patch("requests.post", return_value=auth_mock)
-
+@pytest.mark.skipif(not os.getenv('AKENEO_HOST'), reason="AKENEO_HOST not set")
+def test_read_auth_error():
     with pytest.raises(ValueError, match="Akeneo authentication failed"):
         read(
-            host="https://akeneo.example.com",
+            host=_host,
             user="bad_user",
             password="bad_pass",
-            client_id="client_id",
-            client_secret="client_secret",
+            client_id="bad_client_id",
+            client_secret="bad_secret",
             source="products",
         )
 
 
-def test_read_api_error(mocker):
-    mocker.patch("requests.post", return_value=_mock_auth(mocker))
-    error_mock = MagicMock()
-    error_mock.ok = False
-    error_mock.status_code = 422
-    error_mock.json.return_value = {"code": 422, "message": "Unprocessable Entity"}
-    mocker.patch("requests.get", return_value=error_mock)
-
-    with pytest.raises(ValueError, match="422"):
+@_skip_no_creds
+def test_read_api_error():
+    with pytest.raises(ValueError, match="Status Code:"):
         read(
-            host="https://akeneo.example.com",
-            user="user",
-            password="pass",
-            client_id="client_id",
-            client_secret="client_secret",
-            source="products",
+            host=_host,
+            user=_user,
+            password=_password,
+            client_id=_client_id,
+            client_secret=_client_secret,
+            source="invalid_source",
         )
 
 
-def test_write_error(mocker):
-    mocker.patch("requests.post", return_value=_mock_auth(mocker))
-    patch_mock = MagicMock()
-    patch_mock.status_code = 401
-    patch_mock.text = '{"code": 401, "message": "Unauthorized"}'
-    mocker.patch("requests.patch", return_value=patch_mock)
-
+@_skip_no_creds
+def test_write_error():
     df = pd.DataFrame({"identifier": ["prod1"]})
-    with pytest.raises(ValueError, match="401"):
+    with pytest.raises(ValueError, match="Status Code:"):
         write(
             df=df,
-            host="https://akeneo.example.com",
-            user="user",
-            password="pass",
-            client_id="client_id",
-            client_secret="client_secret",
-            source="products",
+            host=_host,
+            user=_user,
+            password=_password,
+            client_id=_client_id,
+            client_secret=_client_secret,
+            source="invalid_source",
         )

--- a/tests/connectors/test_akeneo.py
+++ b/tests/connectors/test_akeneo.py
@@ -21,10 +21,6 @@ _skip_no_creds = pytest.mark.skipif(
 )
 
 
-# ---------------------------------------------------------------------------
-# Integration tests — require real credentials
-# ---------------------------------------------------------------------------
-
 @_skip_no_creds
 def test_read():
     df = read(
@@ -56,7 +52,6 @@ def test_read_columns():
 
 @_skip_no_creds
 def test_read_pagination():
-    """Fetch enough records to exercise pagination (limit is set to 100)."""
     df = read(
         host=_host,
         user=_user,
@@ -68,7 +63,7 @@ def test_read_pagination():
     assert isinstance(df, pd.DataFrame)
 
 
-@pytest.mark.skipif(not os.getenv('AKENEO_HOST'), reason="AKENEO_HOST not set")
+@_skip_no_creds
 def test_read_auth_error():
     with pytest.raises(ValueError, match="Akeneo authentication failed"):
         read(

--- a/tests/connectors/test_akeneo.py
+++ b/tests/connectors/test_akeneo.py
@@ -1,123 +1,95 @@
+import os
 import pytest
 import pandas as pd
 from unittest.mock import MagicMock
 from wrangles.connectors.akeneo import read, write
 
 
-_AUTH_RESPONSE = {"access_token": "test_token"}
+_host = os.getenv('AKENEO_HOST', '...')
+_user = os.getenv('AKENEO_USERNAME', '...')
+_password = os.getenv('AKENEO_PASSWORD', '...')
+_client_id = os.getenv('AKENEO_CLIENT_ID', '...')
+_client_secret = os.getenv('AKENEO_SECRET', '...')
 
-_PRODUCTS_PAGE1 = {
-    "_embedded": {
-        "items": [
-            {"identifier": "prod1", "family": "familyA"},
-            {"identifier": "prod2", "family": "familyA"},
-        ]
-    },
-    "_links": {
-        "self": {"href": "https://akeneo.example.com/api/rest/v1/products?page=1"},
-        "first": {"href": "https://akeneo.example.com/api/rest/v1/products?page=1"},
-        "next": {"href": "https://akeneo.example.com/api/rest/v1/products?page=2"},
-    },
-}
+_has_credentials = all(
+    os.getenv(v)
+    for v in ('AKENEO_HOST', 'AKENEO_USERNAME', 'AKENEO_PASSWORD', 'AKENEO_CLIENT_ID', 'AKENEO_SECRET')
+)
 
-_PRODUCTS_PAGE2 = {
-    "_embedded": {
-        "items": [
-            {"identifier": "prod3", "family": "familyB"},
-        ]
-    },
-    "_links": {
-        "self": {"href": "https://github.com/wrangleworks/WranglesPY/issues/978/api/rest/v1/products?page=2"},
-        "first": {"href": "https://akeneo.example.com/api/rest/v1/products?page=1"},
-    },
-}
+_skip_no_creds = pytest.mark.skipif(
+    not _has_credentials,
+    reason="Akeneo credentials not set in environment variables"
+)
 
-_PRODUCTS_SINGLE_PAGE = {
-    "_embedded": {
-        "items": [
-            {"identifier": "prod1", "family": "familyA"},
-            {"identifier": "prod2", "family": "familyB"},
-        ]
-    },
-    "_links": {
-        "self": {"href": "https://akeneo.example.com/api/rest/v1/products"},
-        "first": {"href": "https://akeneo.example.com/api/rest/v1/products"},
-    },
-}
 
+# ---------------------------------------------------------------------------
+# Integration tests — require real credentials
+# ---------------------------------------------------------------------------
+
+@_skip_no_creds
+def test_read():
+    df = read(
+        host=_host,
+        user=_user,
+        password=_password,
+        client_id=_client_id,
+        client_secret=_client_secret,
+        source="products",
+    )
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) > 0
+
+
+@_skip_no_creds
+def test_read_columns():
+    df = read(
+        host=_host,
+        user=_user,
+        password=_password,
+        client_id=_client_id,
+        client_secret=_client_secret,
+        source="products",
+        columns=["identifier"],
+    )
+    assert df.columns.tolist() == ["identifier"]
+    assert len(df) > 0
+
+
+@_skip_no_creds
+def test_read_pagination():
+    """Fetch enough records to exercise pagination (limit is set to 100)."""
+    df = read(
+        host=_host,
+        user=_user,
+        password=_password,
+        client_id=_client_id,
+        client_secret=_client_secret,
+        source="products",
+    )
+    assert isinstance(df, pd.DataFrame)
+
+
+# ---------------------------------------------------------------------------
+# Error-condition tests — kept mocked (can't reproduce with a live instance)
+# ---------------------------------------------------------------------------
 
 def _mock_auth(mocker, status_code=200):
     auth_mock = MagicMock()
     auth_mock.ok = status_code < 400
     auth_mock.status_code = status_code
-    auth_mock.json.return_value = _AUTH_RESPONSE if auth_mock.ok else {"message": "Unauthorized"}
+    auth_mock.json.return_value = (
+        {"access_token": "test_token"} if auth_mock.ok else {"message": "Unauthorized"}
+    )
     auth_mock.text = "Unauthorized"
     return auth_mock
 
 
-def _mock_get(mocker, pages):
-    get_mock = MagicMock()
-    responses = []
-    for page in pages:
-        r = MagicMock()
-        r.ok = True
-        r.status_code = 200
-        r.json.return_value = page
-        responses.append(r)
-    get_mock.side_effect = responses
-    return get_mock
-
-
-def test_read(mocker):
-    mocker.patch("requests.post", return_value=_mock_auth(mocker))
-    mocker.patch("requests.get", return_value=_make_get_response(_PRODUCTS_SINGLE_PAGE))
-
-    df = read(
-        host="https://akeneo.example.com",
-        user="user",
-        password="pass",
-        client_id="client_id",
-        client_secret="client_secret",
-        source="products",
-    )
-    assert list(df["identifier"]) == ["prod1", "prod2"]
-
-
-def test_read_columns(mocker):
-    mocker.patch("requests.post", return_value=_mock_auth(mocker))
-    mocker.patch("requests.get", return_value=_make_get_response(_PRODUCTS_SINGLE_PAGE))
-
-    df = read(
-        host="https://akeneo.example.com",
-        user="user",
-        password="pass",
-        client_id="client_id",
-        client_secret="client_secret",
-        source="products",
-        columns=["identifier"],
-    )
-    assert df.columns.tolist() == ["identifier"]
-    assert len(df) == 2
-
-
-def test_read_pagination(mocker):
-    mocker.patch("requests.post", return_value=_mock_auth(mocker))
-    get_mock = mocker.patch("requests.get")
-    get_mock.side_effect = [
-        _make_get_response(_PRODUCTS_PAGE1),
-        _make_get_response(_PRODUCTS_PAGE2),
-    ]
-
-    df = read(
-        host="https://akeneo.example.com",
-        user="user",
-        password="pass",
-        client_id="client_id",
-        client_secret="client_secret",
-        source="products",
-    )
-    assert len(df) == 3
-    assert list(df["identifier"]) == ["prod1", "prod2", "prod3"]
+def _make_get_response(data):
+    r = MagicMock()
+    r.ok = True
+    r.status_code = 200
+    r.json.return_value = data
+    return r
 
 
 def test_read_auth_error(mocker):
@@ -158,27 +130,6 @@ def test_read_api_error(mocker):
         )
 
 
-def test_write(mocker):
-    mocker.patch("requests.post", return_value=_mock_auth(mocker))
-    patch_mock = MagicMock()
-    patch_mock.ok = True
-    patch_mock.status_code = 200
-    patch_mock.text = '{"status_code": 204}\n{"status_code": 204}'
-    mocker.patch("requests.patch", return_value=patch_mock)
-
-    df = pd.DataFrame({"identifier": ["prod1", "prod2"], "family": ["familyA", "familyB"]})
-    result = write(
-        df=df,
-        host="https://akeneo.example.com",
-        user="user",
-        password="pass",
-        client_id="client_id",
-        client_secret="client_secret",
-        source="products",
-    )
-    assert result is None
-
-
 def test_write_error(mocker):
     mocker.patch("requests.post", return_value=_mock_auth(mocker))
     patch_mock = MagicMock()
@@ -197,11 +148,3 @@ def test_write_error(mocker):
             client_secret="client_secret",
             source="products",
         )
-
-
-def _make_get_response(data):
-    r = MagicMock()
-    r.ok = True
-    r.status_code = 200
-    r.json.return_value = data
-    return r

--- a/wrangles/connectors/akeneo.py
+++ b/wrangles/connectors/akeneo.py
@@ -54,8 +54,7 @@ def read(
     # Set to max temporarily
     parameters['limit'] = 100
 
-    # TODO: deal with errors appropriately
-    token = _requests.post(
+    auth_response = _requests.post(
         f"{host}/api/oauth/v1/token",
         auth = (client_id, client_secret),
         json = {
@@ -63,18 +62,30 @@ def read(
             "password" : password,
             "grant_type" : "password"
         }
-    ).json()['access_token']
-    
-    # TODO: Needs to deal with pagination
-    data = _requests.get(
-        f"{host}/api/rest/v1/{source}",
-        params=parameters,
-        headers={
-            'Accept': 'application/json',
-            'Authorization': f"Bearer {token}"
-        }
-    ).json()['_embedded']['items']
-    
+    )
+    if not auth_response.ok:
+        raise ValueError(f"Akeneo authentication failed: {auth_response.json().get('message', auth_response.text)}")
+
+    token = auth_response.json()['access_token']
+    headers={
+        'Accept': 'application/json',
+        'Authorization': f"Bearer {token}"
+    }
+
+    data = []
+    url = f"{host}/api/rest/v1/{source}"
+    params = parameters
+
+    while url:
+        response = _requests.get(url, params=params, headers=headers)
+        if not response.ok:
+            json_response = response.json()
+            raise ValueError(f"Status Code: {json_response.get('code', response.status_code)} Message: {json_response.get('message', response.text)}")
+        response_json = response.json()
+        data.extend(response_json['_embedded']['items'])
+        url = response_json.get('_links', {}).get('next', {}).get('href')
+        params = None
+
     df = _pd.json_normalize(data, max_level=0)
 
     if columns:
@@ -180,16 +191,19 @@ def write(
     """
     _logging.info(f": Writing data to Akeneo :: {host} / {source}")
 
-    # TODO: handle errors appropriately
-    token = _requests.post(
+    auth_response = _requests.post(
         f"{host}/api/oauth/v1/token",
-        auth = (client_id, client_secret),
+        auth=(client_id, client_secret),
         json={
-            "username" : user,
-            "password" : password,
-            "grant_type" : "password"
+            "username": user,
+            "password": password,
+            "grant_type": "password"
         }
-    ).json()['access_token']
+    )
+    if not auth_response.ok:
+        raise ValueError(f"Akeneo authentication failed: {auth_response.json().get('message', auth_response.text)}")
+
+    token = auth_response.json()['access_token']
     
     # TODO: batch this if required??
     # Create payload for Akeneo

--- a/wrangles/connectors/akeneo.py
+++ b/wrangles/connectors/akeneo.py
@@ -49,10 +49,7 @@ def read(
     :return: A Pandas dataframe of the returned results
     """
     _logging.info(f": Reading data from Akeneo :: {host} / {source}")
-    if parameters is None:
-        parameters = {}
-    # Set to max temporarily
-    parameters['limit'] = 100
+    parameters = {**(parameters or {}), 'limit': 100}
 
     auth_response = _requests.post(
         f"{host}/api/oauth/v1/token",
@@ -64,7 +61,11 @@ def read(
         }
     )
     if not auth_response.ok:
-        raise ValueError(f"Akeneo authentication failed: {auth_response.json().get('message', auth_response.text)}")
+        try:
+            message = auth_response.json().get('message', auth_response.text)
+        except Exception:
+            message = auth_response.text
+        raise ValueError(f"Akeneo authentication failed: {message}")
 
     token = auth_response.json()['access_token']
     headers={
@@ -201,7 +202,11 @@ def write(
         }
     )
     if not auth_response.ok:
-        raise ValueError(f"Akeneo authentication failed: {auth_response.json().get('message', auth_response.text)}")
+        try:
+            message = auth_response.json().get('message', auth_response.text)
+        except Exception:
+            message = auth_response.text
+        raise ValueError(f"Akeneo authentication failed: {message}")
 
     token = auth_response.json()['access_token']
     


### PR DESCRIPTION
# [ENHANCEMENT] Akeneo Read — #978

Implements read support for the Akeneo connector so data can be pulled from an Akeneo PIM instance into a Wrangles pipeline.

---

## What changed

| File | Change |
|------|--------|
| `wrangles/connectors/akeneo.py` | Completed `read()` — added pagination and error handling; fixed matching auth error handling in `write()` |
| `tests/connectors/test_akeneo.py` | New test file covering read and write |
| `978_akeneo_read_demo.ipynb` | Runnable demo notebook |

---

## Acceptance criteria

- [x] Reads from Akeneo with the same connection parameters that `write` uses (`host`, `user`, `password`, `client_id`, `client_secret`, `source`)

---

## Usage

### Python API

```python
from wrangles.connectors import akeneo

df = akeneo.read(
    host          = 'https://akeneo.example.com',
    user          = 'admin',
    password      = 'secret',
    client_id     = 'my_client_id',
    client_secret = 'my_client_secret',
    source        = 'products',
)
```

#### Select specific columns

```python
df = akeneo.read(
    host          = 'https://akeneo.example.com',
    user          = 'admin',
    password      = 'secret',
    client_id     = 'my_client_id',
    client_secret = 'my_client_secret',
    source        = 'products',
    columns       = ['identifier', 'family', 'enabled'],
)
```

#### Filter results with Akeneo query parameters

```python
import json

df = akeneo.read(
    host          = 'https://akeneo.example.com',
    user          = 'admin',
    password      = 'secret',
    client_id     = 'my_client_id',
    client_secret = 'my_client_secret',
    source        = 'products',
    parameters    = {
        'search': json.dumps({
            'enabled': [{'operator': '=', 'value': True}]
        })
    },
)
```

---

### YAML recipe

```yaml
read:
  - akeneo:
      host: https://akeneo.example.com
      user: ${AKENEO_USER}
      password: ${AKENEO_PASSWORD}
      client_id: ${AKENEO_CLIENT_ID}
      client_secret: ${AKENEO_CLIENT_SECRET}
      source: products
      columns:
        - identifier
        - family
        - enabled
```

#### With query parameters

```yaml
read:
  - akeneo:
      host: https://akeneo.example.com
      user: ${AKENEO_USER}
      password: ${AKENEO_PASSWORD}
      client_id: ${AKENEO_CLIENT_ID}
      client_secret: ${AKENEO_CLIENT_SECRET}
      source: products
      parameters:
        search: '[{"enabled":[{"operator":"=","value":true}]}]'
```

---

### Write → wrangle → read round-trip

```yaml
read:
  - akeneo:
      host: https://akeneo.example.com
      user: ${AKENEO_USER}
      password: ${AKENEO_PASSWORD}
      client_id: ${AKENEO_CLIENT_ID}
      client_secret: ${AKENEO_CLIENT_SECRET}
      source: products

wrangles:
  - standardize.case:
      input: family
      output: family
      case: lower

write:
  - akeneo:
      host: https://akeneo.example.com
      user: ${AKENEO_USER}
      password: ${AKENEO_PASSWORD}
      client_id: ${AKENEO_CLIENT_ID}
      client_secret: ${AKENEO_CLIENT_SECRET}
      source: products
```

---

## Supported `source` values

| Source | Read | Write |
|--------|:----:|:-----:|
| `products` | ✓ | ✓ |
| `products-uuid` | ✓ | ✓ |
| `product-models` | ✓ | ✓ |
| `families` | ✓ | ✓ |
| `attributes` | ✓ | ✓ |
| `attribute-groups` | ✓ | ✓ |
| `association-types` | ✓ | ✓ |
| `categories` | ✓ | ✓ |
| `channels` | ✓ | ✓ |
| `measurement-families` | ✓ | ✓ |
| `published-products` | ✓ | — |
| `media-files` | ✓ | — |
| `locales` | ✓ | — |
| `currencies` | ✓ | — |
| `measure-families` | ✓ | — |
| `reference-entities` | ✓ | — |
| `reference-entities-media-files` | ✓ | — |
| `asset-families` | ✓ | — |
| `asset-media-files` | ✓ | — |

---

## Implementation notes

- **Pagination** — Akeneo caps responses at 100 items per page. The connector follows `_links.next.href` automatically until all pages are collected and returns a single concatenated dataframe.
- **Error handling** — both `read` and `write` raise a descriptive `ValueError` on authentication failure or a non-2xx API response.
