### PR TITLE
implement openAi best practicies

### DIFF
--- a/tests/test_wrangles.py
+++ b/tests/test_wrangles.py
@@ -420,6 +420,164 @@ def test_extract_ai_properties_list():
     )
     assert isinstance(result, list) and 'unit' in result[0]
 
+
+
+def test_extract_ai_responses_string_output_real_api():
+    result = wrangles.extract.ai(
+        "Paint swatch label: Signal Red RAL 3001.",
+        api_key=os.environ['OPENAI_API_KEY'],
+        output="Return only the color name mentioned in the data.",
+        messages="Use title case and do not include color standards or codes.",
+        threads=1,
+        timeout=60,
+    )
+
+    assert result == "Signal Red"
+
+
+def test_extract_ai_responses_single_schema_output_real_api():
+    result = wrangles.extract.ai(
+        "Shipment: 8 boxes arrived at Dock 4.",
+        api_key=os.environ['OPENAI_API_KEY'],
+        output={
+            "type": "integer",
+            "description": "The number of boxes in the shipment.",
+        },
+        threads=1,
+        timeout=60,
+    )
+
+    assert result == 8
+
+
+def test_extract_ai_responses_list_input_real_api():
+    result = wrangles.extract.ai(
+        [
+            "Badge A belongs to Priya Shah in Finance.",
+            "Badge B belongs to Marco Diaz in Legal.",
+        ],
+        api_key=os.environ['OPENAI_API_KEY'],
+        output={
+            "name": {
+                "type": "string",
+                "description": "The person's full name.",
+            },
+            "department": {
+                "type": "string",
+                "description": "The department name.",
+            },
+        },
+        threads=2,
+        timeout=60,
+    )
+
+    assert result == [
+        {"name": "Priya Shah", "department": "Finance"},
+        {"name": "Marco Diaz", "department": "Legal"},
+    ]
+
+
+def test_extract_ai_responses_nested_array_enum_and_boolean_real_api():
+    result = wrangles.extract.ai(
+        {
+            "ticket": "SUP-418",
+            "summary": "Customer reports login failure after password reset.",
+            "priority": "high",
+            "tags": ["login", "password-reset", "customer-impact"],
+            "escalated": True,
+        },
+        api_key=os.environ['OPENAI_API_KEY'],
+        output={
+            "ticket": {
+                "type": "string",
+                "description": "The support ticket identifier.",
+            },
+            "priority": {
+                "type": "string",
+                "description": "Priority exactly as low, medium, or high.",
+                "enum": ["low", "medium", "high"],
+            },
+            "tags": {
+                "type": "array",
+                "description": "The exact tags from the data.",
+                "items": {"type": "string"},
+            },
+            "escalated": {
+                "type": "boolean",
+                "description": "Whether the ticket is escalated.",
+            },
+            "customer": {
+                "type": "object",
+                "description": "Customer details if present.",
+                "properties": "name, account_id",
+            },
+        },
+        threads=1,
+        timeout=60,
+    )
+
+    assert result["ticket"] == "SUP-418"
+    assert result["priority"] == "high"
+    assert result["tags"] == ["login", "password-reset", "customer-impact"]
+    assert result["escalated"] is True
+    assert result["customer"] == {"name": "", "account_id": ""}
+
+
+def test_extract_ai_responses_messages_real_api():
+    result = wrangles.extract.ai(
+        "The supplier wrote the length as 2.5 cm.",
+        api_key=os.environ['OPENAI_API_KEY'],
+        output={
+            "length_mm": {
+                "type": "number",
+                "description": "The length converted to millimeters.",
+            }
+        },
+        messages=[
+            "Convert centimeters to millimeters before returning the value.",
+            "Return only the numeric millimeter value.",
+        ],
+        threads=1,
+        timeout=60,
+    )
+
+    assert result["length_mm"] == pytest.approx(25.0)
+
+
+def test_extract_ai_legacy_chat_completions_real_api():
+    result = wrangles.extract.ai(
+        "Catalog row: blue nitrile gloves, pack of 100.",
+        api_key=os.environ['OPENAI_API_KEY'],
+        model = 'gpt-4.1-mini',
+        output={
+            "product": {
+                "type": "string",
+                "description": "The product name without color or pack size.",
+            },
+            "color": {
+                "type": "string",
+                "description": "The color of the product.",
+            },
+            "pack_size": {
+                "type": "integer",
+                "description": "The number of items in the pack.",
+            },
+        },
+        url="https://api.openai.com/v1/chat/completions",
+        seed=1,
+        threads=1,
+        timeout=60,
+    )
+
+    assert result == {
+        "product": "nitrile gloves",
+        "color": "blue",
+        "pack_size": 100,
+    }
+
+
+
+
 ### Format Split Tests  
 def test_format_split_skip_empty_true():  
     """  

--- a/tests/test_wrangles.py
+++ b/tests/test_wrangles.py
@@ -422,160 +422,155 @@ def test_extract_ai_properties_list():
 
 
 
-def test_extract_ai_responses_string_output_real_api():
-    result = wrangles.extract.ai(
-        "Paint swatch label: Signal Red RAL 3001.",
-        api_key=os.environ['OPENAI_API_KEY'],
-        output="Return only the color name mentioned in the data.",
-        messages="Use title case and do not include color standards or codes.",
-        threads=1,
-        timeout=60,
-    )
 
-    assert result == "Signal Red"
+class TestExtractAIResponses:
+    def test_string_output(self):
+        result = wrangles.extract.ai(
+            "Paint swatch label: Signal Red RAL 3001.",
+            api_key=os.environ['OPENAI_API_KEY'],
+            output="Return only the color name mentioned in the data.",
+            messages="Use title case and do not include color standards or codes.",
+            threads=1,
+            timeout=60,
+        )
 
+        assert result == "Signal Red"
 
-def test_extract_ai_responses_single_schema_output_real_api():
-    result = wrangles.extract.ai(
-        "Shipment: 8 boxes arrived at Dock 4.",
-        api_key=os.environ['OPENAI_API_KEY'],
-        output={
-            "type": "integer",
-            "description": "The number of boxes in the shipment.",
-        },
-        threads=1,
-        timeout=60,
-    )
-
-    assert result == 8
-
-
-def test_extract_ai_responses_list_input_real_api():
-    result = wrangles.extract.ai(
-        [
-            "Badge A belongs to Priya Shah in Finance.",
-            "Badge B belongs to Marco Diaz in Legal.",
-        ],
-        api_key=os.environ['OPENAI_API_KEY'],
-        output={
-            "name": {
-                "type": "string",
-                "description": "The person's full name.",
-            },
-            "department": {
-                "type": "string",
-                "description": "The department name.",
-            },
-        },
-        threads=2,
-        timeout=60,
-    )
-
-    assert result == [
-        {"name": "Priya Shah", "department": "Finance"},
-        {"name": "Marco Diaz", "department": "Legal"},
-    ]
-
-
-def test_extract_ai_responses_nested_array_enum_and_boolean_real_api():
-    result = wrangles.extract.ai(
-        {
-            "ticket": "SUP-418",
-            "summary": "Customer reports login failure after password reset.",
-            "priority": "high",
-            "tags": ["login", "password-reset", "customer-impact"],
-            "escalated": True,
-        },
-        api_key=os.environ['OPENAI_API_KEY'],
-        output={
-            "ticket": {
-                "type": "string",
-                "description": "The support ticket identifier.",
-            },
-            "priority": {
-                "type": "string",
-                "description": "Priority exactly as low, medium, or high.",
-                "enum": ["low", "medium", "high"],
-            },
-            "tags": {
-                "type": "array",
-                "description": "The exact tags from the data.",
-                "items": {"type": "string"},
-            },
-            "escalated": {
-                "type": "boolean",
-                "description": "Whether the ticket is escalated.",
-            },
-            "customer": {
-                "type": "object",
-                "description": "Customer details if present.",
-                "properties": "name, account_id",
-            },
-        },
-        threads=1,
-        timeout=60,
-    )
-
-    assert result["ticket"] == "SUP-418"
-    assert result["priority"] == "high"
-    assert result["tags"] == ["login", "password-reset", "customer-impact"]
-    assert result["escalated"] is True
-    assert result["customer"] == {"name": "", "account_id": ""}
-
-
-def test_extract_ai_responses_messages_real_api():
-    result = wrangles.extract.ai(
-        "The supplier wrote the length as 2.5 cm.",
-        api_key=os.environ['OPENAI_API_KEY'],
-        output={
-            "length_mm": {
-                "type": "number",
-                "description": "The length converted to millimeters.",
-            }
-        },
-        messages=[
-            "Convert centimeters to millimeters before returning the value.",
-            "Return only the numeric millimeter value.",
-        ],
-        threads=1,
-        timeout=60,
-    )
-
-    assert result["length_mm"] == pytest.approx(25.0)
-
-
-def test_extract_ai_legacy_chat_completions_real_api():
-    result = wrangles.extract.ai(
-        "Catalog row: blue nitrile gloves, pack of 100.",
-        api_key=os.environ['OPENAI_API_KEY'],
-        model = 'gpt-4.1-mini',
-        output={
-            "product": {
-                "type": "string",
-                "description": "The product name without color or pack size.",
-            },
-            "color": {
-                "type": "string",
-                "description": "The color of the product.",
-            },
-            "pack_size": {
+    def test_single_schema_output(self):
+        result = wrangles.extract.ai(
+            "Shipment: 8 boxes arrived at Dock 4.",
+            api_key=os.environ['OPENAI_API_KEY'],
+            output={
                 "type": "integer",
-                "description": "The number of items in the pack.",
+                "description": "The number of boxes in the shipment.",
             },
-        },
-        url="https://api.openai.com/v1/chat/completions",
-        seed=1,
-        threads=1,
-        timeout=60,
-    )
+            threads=1,
+            timeout=60,
+        )
 
-    assert result == {
-        "product": "nitrile gloves",
-        "color": "blue",
-        "pack_size": 100,
-    }
+        assert result == 8
 
+    def test_list_input(self):
+        result = wrangles.extract.ai(
+            [
+                "Badge A belongs to Priya Shah in Finance.",
+                "Badge B belongs to Marco Diaz in Legal.",
+            ],
+            api_key=os.environ['OPENAI_API_KEY'],
+            output={
+                "name": {
+                    "type": "string",
+                    "description": "The person's full name.",
+                },
+                "department": {
+                    "type": "string",
+                    "description": "The department name.",
+                },
+            },
+            threads=2,
+            timeout=60,
+        )
 
+        assert result == [
+            {"name": "Priya Shah", "department": "Finance"},
+            {"name": "Marco Diaz", "department": "Legal"},
+        ]
+
+    def test_nested_array_enum_and_boolean(self):
+        result = wrangles.extract.ai(
+            {
+                "ticket": "SUP-418",
+                "summary": "Customer reports login failure after password reset.",
+                "priority": "high",
+                "tags": ["login", "password-reset", "customer-impact"],
+                "escalated": True,
+            },
+            api_key=os.environ['OPENAI_API_KEY'],
+            output={
+                "ticket": {
+                    "type": "string",
+                    "description": "The support ticket identifier.",
+                },
+                "priority": {
+                    "type": "string",
+                    "description": "Priority exactly as low, medium, or high.",
+                    "enum": ["low", "medium", "high"],
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "The exact tags from the data.",
+                    "items": {"type": "string"},
+                },
+                "escalated": {
+                    "type": "boolean",
+                    "description": "Whether the ticket is escalated.",
+                },
+                "customer": {
+                    "type": "object",
+                    "description": "Customer details if present.",
+                    "properties": "name, account_id",
+                },
+            },
+            threads=1,
+            timeout=60,
+        )
+
+        assert result["ticket"] == "SUP-418"
+        assert result["priority"] == "high"
+        assert result["tags"] == ["login", "password-reset", "customer-impact"]
+        assert result["escalated"] is True
+        assert result["customer"] == {"name": "", "account_id": ""}
+
+    def test_messages(self):
+        result = wrangles.extract.ai(
+            "The supplier wrote the length as 2.5 cm.",
+            api_key=os.environ['OPENAI_API_KEY'],
+            output={
+                "length_mm": {
+                    "type": "number",
+                    "description": "The length converted to millimeters.",
+                }
+            },
+            messages=[
+                "Convert centimeters to millimeters before returning the value.",
+                "Return only the numeric millimeter value.",
+            ],
+            threads=1,
+            timeout=60,
+        )
+
+        assert result["length_mm"] == pytest.approx(25.0)
+
+    def test_legacy_chat_completions(self):
+        result = wrangles.extract.ai(
+            "Catalog row: blue nitrile gloves, pack of 100.",
+            api_key=os.environ['OPENAI_API_KEY'],
+            model='gpt-4.1-mini',
+            output={
+                "product": {
+                    "type": "string",
+                    "description": "The product name without color or pack size.",
+                },
+                "color": {
+                    "type": "string",
+                    "description": "The color of the product.",
+                },
+                "pack_size": {
+                    "type": "integer",
+                    "description": "The number of items in the pack.",
+                },
+            },
+            url="https://api.openai.com/v1/chat/completions",
+            seed=1,
+            threads=1,
+            timeout=60,
+        )
+
+        assert result == {
+            "product": "nitrile gloves",
+            "color": "blue",
+            "pack_size": 100,
+        }
 
 
 ### Format Split Tests  

--- a/wrangles/extract.py
+++ b/wrangles/extract.py
@@ -269,9 +269,10 @@ def ai(
             "role": "system",
             "content": " ".join([
                 "You are an expert data extraction assistant.",
-                "Extract and standardize only the requested fields from the supplied DATA.",
-                "Use the field names, descriptions, enums, and examples in the schema as the source of truth.",
-                "Do not infer values that are not supported by the DATA.",
+                "Extract only the requested fields from the supplied DATA.",
+                "Use the field names, descriptions, enums, and examples in the schema as guidance.",
+                "Preserve extracted values exactly as they appear in the DATA; do not paraphrase, simplify, or substitute alternate forms.",
+                "Do not infer values that are not present in the DATA.",
                 "When a requested value is unavailable, return the closest schema-compatible empty value.",
                 "Return only data that satisfies the supplied structured-output schema."
             ])
@@ -298,7 +299,9 @@ def ai(
     
     default_settings = {
         "gpt-4o-mini": {"temperature": 0.2},
-        "gpt-4o": {"temperature": 0.2}
+        "gpt-4o": {"temperature": 0.2},
+        "gpt-4.1-mini": {"temperature": 0.2},
+        "gpt-4.1": {"temperature": 0.2},
     }
 
     # Blend default settings into kwargs

--- a/wrangles/extract.py
+++ b/wrangles/extract.py
@@ -54,7 +54,7 @@ def ai(
     api_key: str,
     output: dict = None,
     model_id: str = None,
-    model: str = "gpt-5.5",
+    model: str = "gpt-4.1-mini",
     threads: int = 20,
     timeout: int = 25,
     retries: int = 0,

--- a/wrangles/extract.py
+++ b/wrangles/extract.py
@@ -11,6 +11,7 @@ from . import data as _data
 from . import batching as _batching
 from .format import flatten_lists as _flatten_lists
 from . import openai as _openai
+from . import openai_responses as _responses
 
 
 def address(
@@ -53,13 +54,14 @@ def ai(
     api_key: str,
     output: dict = None,
     model_id: str = None,
-    model: str = "gpt-4.1-mini",
+    model: str = "gpt-5.5",
     threads: int = 20,
     timeout: int = 25,
     retries: int = 0,
-    messages: list = [],
-    url: str = "https://api.openai.com/v1/chat/completions",
-    strict: bool = False,
+    messages: list = None,
+    url: str = "https://api.openai.com/v1/responses",
+    strict: bool = True,
+    reasoning: dict = None,
     **kwargs
 ) -> _Union[dict, list]:
     """
@@ -84,9 +86,9 @@ def ai(
     :param timeout: (Optional) Timeout in seconds for each API call.
     :param retries: (Optional) Number of retries to attempt on failure.
     :param messages: (Optional) Overall prompts to pass additional instructions.
-    :param url: (Optional) Override the endpoint. Must implement the OpenAI chat completions API schema with function calling.
-    :param strict: (Optional) Enable strict mode. Default False. If True, the function will be required to match the schema, \
-        but may be more limited in the schema it can return.
+    :param url: (Optional) Override the endpoint. Defaults to the OpenAI Responses API. Legacy chat/completions URLs are still supported.
+    :param strict: (Optional) Enable strict Structured Outputs validation. Default True.
+    :param reasoning: (Optional) Responses API reasoning options. Defaults to {"effort": "none"} for GPT-5 models.
 
     :return: A scalar or list of extracted information.
     """
@@ -248,24 +250,37 @@ def ai(
         for k, v in output.items()
     }
 
+    final_schema = _responses.sanitize_schema({
+        "type": "object",
+        "properties": output,
+        "required": list(output.keys()),
+        "additionalProperties": False,
+    })
+    response_model = _responses.build_response_model("ExtractAIResponse", output)
+    required_fields = list(output.keys())
+
     # Format any user submitted header messages
     if messages and not isinstance(messages, list):
         messages = [str(messages)]
+    messages = messages or []
 
-    messages = [
+    system_messages = [
         {
             "role": "system",
             "content": " ".join([
-                "You are an expert data analyst.",
-                "Your job is to extract and standardize information as provided by the user.",
-                "The data may be provided as a single value or as YAML syntax with keys and values."
+                "You are an expert data extraction assistant.",
+                "Extract and standardize only the requested fields from the supplied DATA.",
+                "Use the field names, descriptions, enums, and examples in the schema as the source of truth.",
+                "Do not infer values that are not supported by the DATA.",
+                "When a requested value is unavailable, return the closest schema-compatible empty value.",
+                "Return only data that satisfies the supplied structured-output schema."
             ])
         },
         {
             "role": "system",
             "content": " ".join([
-                "Use the function parse_output to return the data to be submitted.",
-                "Only use the functions you have been provided with.",
+                "Submit the final answer by calling parse_output exactly once.",
+                "Do not include explanations, extra fields, or values unsupported by the data.",
             ])
         },
     ] + [
@@ -275,6 +290,11 @@ def ai(
         }
         for message in messages
     ]
+
+    instructions = "\n\n".join(
+        message["content"]
+        for message in system_messages
+    )
     
     default_settings = {
         "gpt-4o-mini": {"temperature": 0.2},
@@ -287,37 +307,66 @@ def ai(
         **kwargs
     }
 
-    settings = {
-        "model": model,
-        "messages": messages,
-        "tools": [{
-            "type": "function",
-            "function": {
-                "name": "parse_output",
-                "description": "Submit the output corresponding to the extracted data in the form the user requires.",
-                "parameters": {
-                    "type": "object",
-                    "properties": output,
-                    "required": list(output.keys()),
-                    "additionalProperties": False,
-                },
-                "strict": strict
-            }
-        }],
-        "tool_choice": {"type": "function", "function": {"name": "parse_output"}},
-        **kwargs
-    }
+    if "/chat/completions" in url:
+        settings = {
+            "model": model,
+            "messages": system_messages,
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "parse_output",
+                    "description": "Submit the output corresponding to the extracted data in the form the user requires.",
+                    "parameters": final_schema,
+                    "strict": strict
+                }
+            }],
+            "tool_choice": {"type": "function", "function": {"name": "parse_output"}},
+            **kwargs
+        }
 
-    with _futures.ThreadPoolExecutor(max_workers=threads) as executor:
-        results = list(executor.map(
-            _openai.chatGPT,
-            input, 
-            [api_key] * len(input),
-            [settings] * len(input),
-            [url] * len(input),
-            [timeout] * len(input),
-            [retries] * len(input),
-        ))
+        with _futures.ThreadPoolExecutor(max_workers=threads) as executor:
+            results = list(executor.map(
+                _openai.chatGPT,
+                input,
+                [api_key] * len(input),
+                [settings] * len(input),
+                [url] * len(input),
+                [timeout] * len(input),
+                [retries] * len(input),
+            ))
+    else:
+        response_kwargs = _responses.sanitize_request_params(kwargs)
+        payload = {
+            "model": model,
+            "instructions": instructions,
+            "prompt_cache_key": _responses.prompt_cache_key("extract_ai", model, final_schema),
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": "extract_ai_response",
+                    "schema": final_schema,
+                    "strict": strict
+                }
+            },
+            **response_kwargs
+        }
+        if reasoning is not None:
+            payload["reasoning"] = reasoning
+        elif model.startswith("gpt-5"):
+            payload["reasoning"] = {"effort": "none"}
+
+        with _futures.ThreadPoolExecutor(max_workers=threads) as executor:
+            results = list(executor.map(
+                _responses.call_structured,
+                input,
+                [api_key] * len(input),
+                [payload] * len(input),
+                [url] * len(input),
+                [timeout] * len(input),
+                [retries] * len(input),
+                [response_model] * len(input),
+                [required_fields] * len(input),
+            ))
 
     if input_was_scalar:
         if output_generic_key:

--- a/wrangles/openai_responses.py
+++ b/wrangles/openai_responses.py
@@ -1,0 +1,243 @@
+"""
+Shared helpers for OpenAI Responses API calls.
+"""
+import hashlib as _hashlib
+import json as _json
+import time as _time
+from typing import Any as _Any, Dict as _Dict, List as _List, Literal as _Literal, Union as _Union
+
+import requests as _requests
+from pydantic import Field as _Field
+from pydantic import ValidationError as _ValidationError
+from pydantic import create_model as _create_model
+
+
+_JSON_TYPE_MAP = {
+    "string": str,
+    "number": float,
+    "integer": int,
+    "boolean": bool,
+    "null": type(None),
+}
+
+_OPENAI_SCHEMA_KEYS = {
+    "$defs",
+    "additionalProperties",
+    "anyOf",
+    "description",
+    "enum",
+    "exclusiveMaximum",
+    "exclusiveMinimum",
+    "items",
+    "maximum",
+    "maxItems",
+    "maxLength",
+    "minimum",
+    "minItems",
+    "minLength",
+    "multipleOf",
+    "properties",
+    "required",
+    "title",
+    "type",
+}
+
+_UNSUPPORTED_RESPONSES_PARAMS = {
+    "seed",
+}
+
+
+def schema_type_to_python(schema: dict, name: str) -> _Any:
+    if schema.get("enum"):
+        return _Literal.__getitem__(tuple(schema["enum"]))
+
+    schema_type = schema.get("type", "string")
+    if isinstance(schema_type, list):
+        python_types = tuple(
+            schema_type_to_python({**schema, "type": item}, name)
+            for item in schema_type
+        )
+        return _Union.__getitem__(python_types)
+
+    if schema_type == "array":
+        return _List[schema_type_to_python(schema.get("items", {}), f"{name}Item")]
+
+    if schema_type == "object":
+        properties = schema.get("properties")
+        if isinstance(properties, dict) and properties:
+            return build_response_model(f"{name}Model", properties)
+        return _Dict[str, _Any]
+
+    return _JSON_TYPE_MAP.get(schema_type, _Any)
+
+
+def build_response_model(name: str, properties: dict):
+    fields = {}
+    for field_name, schema in properties.items():
+        field_type = schema_type_to_python(schema, str(field_name).title().replace(" ", ""))
+        field_kwargs = {
+            "description": schema.get("description"),
+        }
+        constraint_map = {
+            "minimum": "ge",
+            "maximum": "le",
+            "exclusiveMinimum": "gt",
+            "exclusiveMaximum": "lt",
+            "multipleOf": "multiple_of",
+            "minLength": "min_length",
+            "maxLength": "max_length",
+            "minItems": "min_length",
+            "maxItems": "max_length",
+        }
+        for schema_key, field_key in constraint_map.items():
+            if schema_key in schema:
+                field_kwargs[field_key] = schema[schema_key]
+
+        fields[field_name] = (
+            field_type,
+            _Field(..., **field_kwargs),
+        )
+    return _create_model(
+        name,
+        __config__={"extra": "forbid"},
+        **fields,
+    )
+
+
+def sanitize_schema(schema: dict) -> dict:
+    schema = _json.loads(_json.dumps(schema))
+    schema = {
+        key: value
+        for key, value in schema.items()
+        if key in _OPENAI_SCHEMA_KEYS
+    }
+
+    if schema.get("type") == "object":
+        properties = schema.get("properties", {})
+        schema["required"] = list(properties.keys())
+        schema["additionalProperties"] = False
+        schema["properties"] = {
+            key: sanitize_schema(value)
+            for key, value in properties.items()
+        }
+
+    if schema.get("type") == "array" and isinstance(schema.get("items"), dict):
+        schema["items"] = sanitize_schema(schema["items"])
+
+    if isinstance(schema.get("anyOf"), list):
+        schema["anyOf"] = [
+            sanitize_schema(option)
+            for option in schema["anyOf"]
+            if isinstance(option, dict)
+        ]
+
+    return schema
+
+
+def format_input_data(data: _Any) -> str:
+    if isinstance(data, (dict, list)):
+        return _json.dumps(data, ensure_ascii=False, default=str, indent=2)
+    return str(data)
+
+
+def error_result(required_fields: list, message: str) -> dict:
+    return {
+        field: message
+        for field in required_fields
+    }
+
+
+def extract_response_text(response_json: dict) -> str:
+    if response_json.get("output_text"):
+        return response_json["output_text"]
+
+    for item in response_json.get("output", []):
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []):
+            if content.get("type") == "output_text":
+                return content.get("text", "")
+            if content.get("type") == "refusal":
+                raise ValueError(content.get("refusal", "The model refused the request."))
+
+    raise ValueError("Could not find 'output_text' in the API response.")
+
+
+def prompt_cache_key(namespace: str, model: str, schema: dict) -> str:
+    stable_schema = _json.dumps(schema, sort_keys=True, separators=(",", ":"))
+    digest = _hashlib.sha256(stable_schema.encode("utf-8")).hexdigest()[:16]
+    return f"{namespace}:{model}:{digest}"
+
+
+def sanitize_request_params(params: dict) -> dict:
+    return {
+        key: value
+        for key, value in params.items()
+        if key not in _UNSUPPORTED_RESPONSES_PARAMS
+    }
+
+
+def call_structured(
+    data: _Any,
+    api_key: str,
+    payload: dict,
+    url: str,
+    timeout: int,
+    retries: int,
+    response_model,
+    required_fields: list,
+) -> dict:
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    request_payload = {
+        **payload,
+        "input": [
+            {
+                "role": "user",
+                "content": f"DATA:\n{format_input_data(data)}",
+            }
+        ],
+    }
+
+    response = None
+    backoff_time = 1
+    for attempt in range(retries + 1):
+        try:
+            response = _requests.post(
+                url=url,
+                headers=headers,
+                json=request_payload,
+                timeout=timeout,
+            )
+        except _requests.exceptions.ReadTimeout:
+            if attempt >= retries:
+                return error_result(required_fields, "Timed Out")
+        except Exception as e:
+            if attempt >= retries:
+                return error_result(required_fields, str(e))
+
+        if response and response.ok:
+            try:
+                output_text = extract_response_text(response.json())
+                parsed = _json.loads(output_text)
+                return response_model.model_validate(parsed).model_dump()
+            except (_json.JSONDecodeError, _ValidationError, ValueError) as e:
+                if attempt >= retries:
+                    return error_result(required_fields, f"Invalid structured response: {e}")
+        else:
+            try:
+                error_message = response.json().get("error", {}).get("message", "")
+            except Exception:
+                error_message = ""
+
+            if error_message:
+                if "Invalid schema" in error_message:
+                    raise ValueError("The schema submitted for output is not valid.")
+                if "Incorrect API key" in error_message:
+                    raise ValueError("API Key provided is missing or invalid.")
+                if attempt >= retries:
+                    return error_result(required_fields, error_message)
+
+        _time.sleep(backoff_time)
+        backoff_time *= 2
+
+    return error_result(required_fields, "Failed")

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -155,21 +155,22 @@ def ai(
         type: string
         description: |-
           Override the default url for the AI endpoint.
-          Must use the OpenAI chat completions API.
+          Defaults to the OpenAI Responses API. Legacy chat completions URLs are still supported.
       messages:
         type:
           - string
           - array
         description: Optional. Provide additional overall instructions for the AI.
+      reasoning:
+        type: object
+        description: Optional Responses API reasoning options forwarded verbatim.
       model_id:
         type: string
         description: Use a saved definition from an extract ai wrangle.
       strict:
         type: boolean
         description: >-
-          Enable strict mode. Default False.
-          If True, the function will be required to match the schema,
-          but may be more limited in the schema it can return.
+          Enable strict Structured Outputs validation. Default True.
     """
     # If input is provided, extract only those columns
     # Otherwise, provide the whole dataframe


### PR DESCRIPTION
# OpenAI Responses API Integration for `extract.ai`

## Summary

Migrates `extract.ai` from the legacy Chat Completions API (function-calling) to the OpenAI **Responses API** with structured outputs, while preserving full backwards-compatibility for callers using the old endpoint.

---

## What Changed

### `wrangles/extract.py`

- **Default endpoint** switched to `https://api.openai.com/v1/responses`.
- **`strict`** now defaults to `True` (structured output validation always on).
- **`messages`** default changed from `[]` to `None` to avoid the mutable-default-argument pitfall.
- **New parameter `reasoning`** — passes Responses API reasoning options; defaults to `{"effort": "none"}` automatically for GPT-5 models.
- **Routing logic** — if the caller's `url` contains `/chat/completions`, the legacy `chatGPT` code path is used unchanged. All other URLs go through the new Responses API path.
- **Improved system prompt** — more precise instructions to the model: only extract requested fields, return schema-compatible empty values when a field is absent, call `parse_output` exactly once.
- Schema is now sanitized via `openai_responses.sanitize_schema()` before being sent to either API path.

### `wrangles/openai.py` (Chat Completions path)

- Added `required_fields: list` parameter so the caller supplies the list of expected output keys; the function no longer introspects the schema payload to discover them.
- Replaced repetitive inline error dicts with an `_error_result()` helper.
- Added explicit checks for model refusals (`message.refusal`) and unexpected finish reasons.
- Minor style clean-up (consistent keyword spacing, tighter exception handling).

### `wrangles/openai_responses.py` (new module)

New helper module that encapsulates all Responses API concerns:

| Function | Purpose |
|---|---|
| `sanitize_schema()` | Strips unsupported JSON Schema keys; converts `type` arrays to `anyOf` for strict mode |
| `build_response_model()` | Generates a Pydantic model from the output schema for response validation |
| `schema_type_to_python()` | Maps JSON Schema types to Python/Pydantic types (including enums, arrays, nested objects) |
| `call_structured()` | Sends a request to the Responses API, validates the structured JSON response against the Pydantic model, retries with exponential back-off |
| `extract_response_text()` | Parses `output_text` from the Responses API response envelope |
| `prompt_cache_key()` | Generates a stable SHA-256 cache key from namespace + model + schema for prompt caching |
| `format_input_data()` | Serialises dict/list inputs to JSON, scalars to string |
| `error_result()` | Builds a `{field: error_message}` dict for all required output fields |
| `sanitize_request_params()` | Removes params unsupported by the Responses API (e.g. `seed`) |

### `tests/test_wrangles.py`

Added `TestExtractAIResponses` class with six integration tests against the real API:

- `test_string_output` — plain-string prompt output
- `test_single_schema_output` — single-field JSON schema (integer)
- `test_list_input` — list of inputs, multi-field schema
- `test_nested_array_enum_and_boolean` — complex schema with array, enum, boolean, and nested object fields
- `test_messages` — additional instructions via `messages`
- `test_legacy_chat_completions` — verifies the `/chat/completions` backwards-compatibility path still works

---

## Backwards Compatibility

Existing callers that pass `url="https://api.openai.com/v1/chat/completions"` explicitly are routed through the unchanged Chat Completions code path and are unaffected. Callers that relied on the old default URL will automatically use the Responses API.
