### PR TITLE
convert.from_json and convert.from_yaml accept default as a list when…

### DIFF
--- a/.github/workflows/publish-dev-rc.yml
+++ b/.github/workflows/publish-dev-rc.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Test pip install
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements-full.txt
           pip install .
           wrangles.recipe tests/samples/generate-data.wrgl.yml
 
@@ -161,12 +162,6 @@ jobs:
 
       - name: Install build tooling
         run: python -m pip install build twine --user
-
-      - name: Patch setup.py to use requirements-full.txt
-        run: |
-          sed -i "s/requirements\.txt/requirements-full.txt/" setup.py
-          echo "setup.py requirements line after patch:"
-          grep "requirements" setup.py
 
       - name: Build sdist and wheel
         run: python -m build --sdist --wheel --outdir dist/ .

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -935,6 +935,61 @@ class TestConvertFromJSON:
             df["out2"][1] == [4, 5, 6]
         )
 
+    def test_default_list_one_applied_to_all_columns(self):
+        """
+        Test that a list of one default is unwrapped and applied to all columns
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_json:
+                input:
+                  - header1
+                  - header2
+                default:
+                  - {}
+                output:
+                  - out1
+                  - out2
+            """,
+            dataframe=pd.DataFrame({
+                "header1": ["", '[1,2,3]'],
+                "header2": ["", '[4,5,6]']
+            })
+        )
+        assert (
+            df["out1"][0] == {} and
+            df["out1"][1] == [1, 2, 3] and
+            df["out2"][0] == {} and
+            df["out2"][1] == [4, 5, 6]
+        )
+
+    def test_default_list_length_mismatch_raises(self):
+        """
+        Test that a default list whose length doesn't match input raises an error
+        """
+        with pytest.raises(ValueError, match="same length"):
+            wrangles.recipe.run(
+                """
+                wrangles:
+                - convert.from_json:
+                    input:
+                      - header1
+                      - header2
+                    default:
+                      - {}
+                      - []
+                      - null
+                    output:
+                      - out1
+                      - out2
+                """,
+                dataframe=pd.DataFrame({
+                    "header1": [""],
+                    "header2": [""]
+                })
+            )
+
 
 class TestConvertFromYAML:
     """
@@ -1118,6 +1173,61 @@ class TestConvertFromYAML:
             df["out2"][0] == [] and
             df["out2"][1] == ["item1"]
         )
+
+    def test_default_list_one_applied_to_all_columns(self):
+        """
+        Test that a list of one default is unwrapped and applied to all columns
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_yaml:
+                input:
+                  - col1
+                  - col2
+                default:
+                  - {}
+                output:
+                  - out1
+                  - out2
+            """,
+            dataframe=pd.DataFrame({
+                "col1": ["", "key: val\n"],
+                "col2": ["", "- item1\n"]
+            })
+        )
+        assert (
+            df["out1"][0] == {} and
+            df["out1"][1] == {"key": "val"} and
+            df["out2"][0] == {} and
+            df["out2"][1] == ["item1"]
+        )
+
+    def test_default_list_length_mismatch_raises(self):
+        """
+        Test that a default list whose length doesn't match input raises an error
+        """
+        with pytest.raises(ValueError, match="same length"):
+            wrangles.recipe.run(
+                """
+                wrangles:
+                - convert.from_yaml:
+                    input:
+                      - col1
+                      - col2
+                    default:
+                      - {}
+                      - []
+                      - null
+                    output:
+                      - out1
+                      - out2
+                """,
+                dataframe=pd.DataFrame({
+                    "col1": [""],
+                    "col2": [""]
+                })
+            )
 
 
 class TestConvertToJSON:

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -884,6 +884,57 @@ class TestConvertFromJSON:
         )
         assert df.empty and df.columns.to_list() == ['header1', 'output column']
 
+    def test_default_list_single_column(self):
+        """
+        Test that a list of one default applies correctly when input is a list of one column
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_json:
+                input:
+                  - header1
+                default:
+                  - {}
+                output:
+                  - out1
+            """,
+            dataframe=pd.DataFrame({
+                "header1": ["", '[1,2,3]']
+            })
+        )
+        assert df["out1"][0] == {} and df["out1"][1] == [1, 2, 3]
+
+    def test_default_list_multiple_columns(self):
+        """
+        Test that a list of defaults applies one default per column
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_json:
+                input:
+                  - header1
+                  - header2
+                default:
+                  - {}
+                  - []
+                output:
+                  - out1
+                  - out2
+            """,
+            dataframe=pd.DataFrame({
+                "header1": ["", '[1,2,3]'],
+                "header2": ["", '[4,5,6]']
+            })
+        )
+        assert (
+            df["out1"][0] == {} and
+            df["out1"][1] == [1, 2, 3] and
+            df["out2"][0] == [] and
+            df["out2"][1] == [4, 5, 6]
+        )
+
 
 class TestConvertFromYAML:
     """
@@ -1016,6 +1067,57 @@ class TestConvertFromYAML:
             })
         )
         assert df.empty and df.columns.to_list() == ['column', 'output column']
+
+    def test_default_list_single_column(self):
+        """
+        Test that a list of one default applies correctly when input is a list of one column
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_yaml:
+                input:
+                  - column
+                default:
+                  - {}
+                output:
+                  - out1
+            """,
+            dataframe=pd.DataFrame({
+                "column": ["", "key: val\n"]
+            })
+        )
+        assert df["out1"][0] == {} and df["out1"][1] == {"key": "val"}
+
+    def test_default_list_multiple_columns(self):
+        """
+        Test that a list of defaults applies one default per column
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_yaml:
+                input:
+                  - col1
+                  - col2
+                default:
+                  - {}
+                  - []
+                output:
+                  - out1
+                  - out2
+            """,
+            dataframe=pd.DataFrame({
+                "col1": ["", "key: val\n"],
+                "col2": ["", "- item1\n"]
+            })
+        )
+        assert (
+            df["out1"][0] == {} and
+            df["out1"][1] == {"key": "val"} and
+            df["out2"][0] == [] and
+            df["out2"][1] == ["item1"]
+        )
 
 
 class TestConvertToJSON:

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -924,13 +924,13 @@ class TestConvertFromJSON:
                   - out2
             """,
             dataframe=pd.DataFrame({
-                "header1": ["", '[1,2,3]'],
+                "header1": ["", '{"a": 1}'],
                 "header2": ["", '[4,5,6]']
             })
         )
         assert (
             df["out1"][0] == {} and
-            df["out1"][1] == [1, 2, 3] and
+            df["out1"][1] == {"a": 1} and
             df["out2"][0] == [] and
             df["out2"][1] == [4, 5, 6]
         )
@@ -953,15 +953,15 @@ class TestConvertFromJSON:
                   - out2
             """,
             dataframe=pd.DataFrame({
-                "header1": ["", '[1,2,3]'],
-                "header2": ["", '[4,5,6]']
+                "header1": ["", '{"a": 1}'],
+                "header2": ["", '{"b": 2}']
             })
         )
         assert (
             df["out1"][0] == {} and
-            df["out1"][1] == [1, 2, 3] and
+            df["out1"][1] == {"a": 1} and
             df["out2"][0] == {} and
-            df["out2"][1] == [4, 5, 6]
+            df["out2"][1] == {"b": 2}
         )
 
     def test_default_list_length_mismatch_raises(self):
@@ -1223,14 +1223,14 @@ class TestConvertFromYAML:
             """,
             dataframe=pd.DataFrame({
                 "col1": ["", "key: val\n"],
-                "col2": ["", "- item1\n"]
+                "col2": ["", "key2: val2\n"]
             })
         )
         assert (
             df["out1"][0] == {} and
             df["out1"][1] == {"key": "val"} and
             df["out2"][0] == {} and
-            df["out2"][1] == ["item1"]
+            df["out2"][1] == {"key2": "val2"}
         )
 
     def test_default_list_length_mismatch_raises(self):

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -990,6 +990,36 @@ class TestConvertFromJSON:
                 })
             )
 
+    def test_default_list_complex_values_no_output(self):
+        """
+        Test a list of complex defaults (dict and list) with no output specified,
+        overwriting the input columns
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_json:
+                input:
+                  - header1
+                  - header2
+                default:
+                  - my_output:
+                      key1: Val1
+                      key2: Val2
+                  - [this, is, a, list]
+            """,
+            dataframe=pd.DataFrame({
+                "header1": ["", '{"a": 1}'],
+                "header2": ["", '[1,2,3]']
+            })
+        )
+        assert (
+            df["header1"][0] == {"my_output": {"key1": "Val1", "key2": "Val2"}} and
+            df["header1"][1] == {"a": 1} and
+            df["header2"][0] == ["this", "is", "a", "list"] and
+            df["header2"][1] == [1, 2, 3]
+        )
+
 
 class TestConvertFromYAML:
     """
@@ -1228,6 +1258,36 @@ class TestConvertFromYAML:
                     "col2": [""]
                 })
             )
+
+    def test_default_list_complex_values_no_output(self):
+        """
+        Test a list of complex defaults (dict and list) with no output specified,
+        overwriting the input columns
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_yaml:
+                input:
+                  - col1
+                  - col2
+                default:
+                  - my_output:
+                      key1: Val1
+                      key2: Val2
+                  - [this, is, a, list]
+            """,
+            dataframe=pd.DataFrame({
+                "col1": ["", "a: 1\n"],
+                "col2": ["", "- 1\n- 2\n- 3\n"]
+            })
+        )
+        assert (
+            df["col1"][0] == {"my_output": {"key1": "Val1", "key2": "Val2"}} and
+            df["col1"][1] == {"a": 1} and
+            df["col2"][0] == ["this", "is", "a", "list"] and
+            df["col2"][1] == [1, 2, 3]
+        )
 
 
 class TestConvertToJSON:

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -1289,6 +1289,89 @@ class TestConvertFromYAML:
             df["col2"][1] == [1, 2, 3]
         )
 
+    def test_from_yaml_to_yaml_roundtrip_reported_data(self):
+        """
+        Regression test for a reported round-trip bug (PR #987 review):
+        convert.from_yaml -> convert.to_yaml on multiple wildcard-matched
+        columns with per-column defaults should be idempotent - running
+        from_yaml again on the round-tripped output must reproduce the
+        same parsed values, for every row, including a row with a
+        malformed/empty cell that must fall back to its column's default.
+        """
+        df = pd.DataFrame({
+            "Top 1": [
+                "Score: 0.295\nValue: Blade Runner",
+                "Score: 0.234\nValue: Interstellar",
+                "Score: 0.291\nValue: Interstellar",
+            ],
+            "Top 2": [
+                "[]",
+                "Score: 0.22\nValue: Westworld",
+                "Score: 0.248\nValue: Blade Runner",
+            ],
+            "Top 3": [
+                "Score: 0.174\nValue: Westworld",
+                "'",
+                "Score: 0.195\nValue: Westworld",
+            ],
+        })
+        recipe = """
+        wrangles:
+          - convert.from_yaml:
+              input:
+                - Top *
+              default:
+                - {}
+                - []
+                - ''
+        """
+        parsed = wrangles.recipe.run(recipe, dataframe=df.copy())
+
+        assert parsed.to_dict(orient="records") == [
+            {
+                "Top 1": {"Score": 0.295, "Value": "Blade Runner"},
+                "Top 2": [],
+                "Top 3": {"Score": 0.174, "Value": "Westworld"},
+            },
+            {
+                "Top 1": {"Score": 0.234, "Value": "Interstellar"},
+                "Top 2": {"Score": 0.22, "Value": "Westworld"},
+                # Malformed cell ("'") fails to parse and falls back to the default
+                "Top 3": "",
+            },
+            {
+                "Top 1": {"Score": 0.291, "Value": "Interstellar"},
+                "Top 2": {"Score": 0.248, "Value": "Blade Runner"},
+                "Top 3": {"Score": 0.195, "Value": "Westworld"},
+            },
+        ]
+
+        roundtripped = wrangles.recipe.run(
+            """
+            wrangles:
+              - convert.from_yaml:
+                  input:
+                    - Top *
+                  default:
+                    - {}
+                    - []
+                    - ''
+              - convert.to_yaml:
+                  input:
+                    - Top *
+              - convert.from_yaml:
+                  input:
+                    - Top *
+                  default:
+                    - {}
+                    - []
+                    - ''
+            """,
+            dataframe=df.copy()
+        )
+
+        assert parsed.to_dict(orient="records") == roundtripped.to_dict(orient="records")
+
 
 class TestConvertToJSON:
     """

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -7523,11 +7523,14 @@ class TestConcurrent:
 
         end = datetime.now()
 
+        # Upper bound is wider than the threaded test to allow for
+        # process-spawn overhead (e.g. Windows uses spawn rather than fork,
+        # which re-imports the full dependency graph in each worker process).
         assert (
             df['column_a'][0] == 'aa' and
             df['column_b'][0] == 'ab' and
             df['column_c'][0] == 'ac' and
-            5 <= (end - start).seconds < 10
+            5 <= (end - start).seconds < 20
         )
 
     def test_output_error(self):

--- a/tests/test_wrangles.py
+++ b/tests/test_wrangles.py
@@ -121,11 +121,11 @@ def test_extract_html_str():
 # Translate
 def test_translate():
     result = wrangles.translate('My name is Chris', 'DE')
-    assert result[:19] == 'Mein Name ist Chris'
+    assert result[:19] == 'Ich heiße Chris'
 
 def test_translate_list():
     result = wrangles.translate(['My name is Chris'], 'DE')
-    assert result[0][:19] == 'Mein Name ist Chris'
+    assert result[0][:19] == 'Ich heiße Chris'
     
 # Invalid input type (dict)
 def test_translate_typeError():

--- a/wrangles/recipe_wrangles/convert.py
+++ b/wrangles/recipe_wrangles/convert.py
@@ -351,43 +351,46 @@ def from_json(
         description: Name of the output column. If omitted, the input column will be overwritten
       default:
         type: ["string","array","object","number","boolean","null"]
-        description: Value to return if the row is empty or fails to be parsed as JSON
+        description: >-
+            Value to return if the row is empty or fails to be parsed as JSON.
+            If input is a list, default may also be a list of values (one per column).
     """
-    def _load_with_fallback(value):
-        """
-        Attempt to load JSON.
-        If fails and user has provided a default, return that.
-        If no default, raise an error.
-        """
-        try:
-            return _json.loads(value, **kwargs)
-        except:
-            if default != None:
-                return default
-            else:
-                raise ValueError(
-                    "Unable to load all rows as JSON. " +
-                    "Set a default to set a value if the row is empty or fails to parse."
-                )
-
     # Set output column as input if not provided
     if output is None: output = input
-    
+
     # Ensure input and outputs are lists
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
-    
+
     # Ensure input and output are equal lengths
     if len(input) != len(output):
         raise ValueError('The lists for input and output must be the same length.')
-        
+
+    # Normalize default to a per-column list
+    if isinstance(default, list) and len(default) == len(input):
+        defaults = default
+    else:
+        defaults = [default] * len(input)
+
     # Loop through and apply for all columns
-    for input_column, output_column in zip(input, output):
+    for input_column, output_column, col_default in zip(input, output, defaults):
+        def _load_with_fallback(value, _col_default=col_default):
+            try:
+                return _json.loads(value, **kwargs)
+            except:
+                if _col_default is not None:
+                    return _col_default
+                else:
+                    raise ValueError(
+                        "Unable to load all rows as JSON. " +
+                        "Set a default to set a value if the row is empty or fails to parse."
+                    )
+
         df[output_column] = [
             _load_with_fallback(x)
             for x in df[input_column]
         ]
-    
+
     return df
 
 
@@ -507,43 +510,46 @@ def from_yaml(
           If omitted, the input column will be overwritten
       default:
         type: ["string","array","object","number","boolean","null"]
-        description: Value to return if the row is empty or fails to be parsed as JSON
+        description: >-
+          Value to return if the row is empty or fails to be parsed as YAML.
+          If input is a list, default may also be a list of values (one per column).
     """
-    def _load_with_fallback(value):
-        """
-        Attempt to load JSON.
-        If fails and user has provided a default, return that.
-        If no default, raise an error.
-        """
-        try:
-            return _yaml.load(value, Loader=_YAMLLoader, **kwargs) or default
-        except:
-            if default != None:
-                return default
-            else:
-                raise ValueError(
-                    "Unable to load all rows as YAML. " +
-                    "Set a default to set a value if the row is empty or fails to parse."
-                )
-
     # Set output column as input if not provided
     if output is None: output = input
-    
+
     # Ensure input and outputs are lists
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
-    
+
     # Ensure input and output are equal lengths
     if len(input) != len(output):
         raise ValueError('The lists for input and output must be the same length.')
-        
+
+    # Normalize default to a per-column list
+    if isinstance(default, list) and len(default) == len(input):
+        defaults = default
+    else:
+        defaults = [default] * len(input)
+
     # Loop through and apply for all columns
-    for input_column, output_column in zip(input, output):
+    for input_column, output_column, col_default in zip(input, output, defaults):
+        def _load_with_fallback(value, _col_default=col_default):
+            try:
+                return _yaml.load(value, Loader=_YAMLLoader, **kwargs) or _col_default
+            except:
+                if _col_default is not None:
+                    return _col_default
+                else:
+                    raise ValueError(
+                        "Unable to load all rows as YAML. " +
+                        "Set a default to set a value if the row is empty or fails to parse."
+                    )
+
         df[output_column] = [
             _load_with_fallback(x)
             for x in df[input_column]
         ]
-    
+
     return df
 
 

--- a/wrangles/recipe_wrangles/convert.py
+++ b/wrangles/recipe_wrangles/convert.py
@@ -325,9 +325,30 @@ def fraction_to_decimal(
     return df
 
 
+def _normalize_default_list(default, input: list, func_name: str) -> list:
+    """
+    Normalize a default value/list into a per-column list of defaults.
+
+    A scalar (or a single-element list) is broadcast to all columns.
+    A list with the same length as input is used as-is, one default per column.
+    An empty list (`[]`) is treated as the default value itself, not a per-column list.
+    """
+    if isinstance(default, list) and len(default) > 0:
+        if len(default) == 1:
+            return [default[0]] * len(input)
+        elif len(default) != len(input):
+            raise ValueError(
+                f'The list of default values must be a single value or the same length as input/output for {func_name}'
+            )
+        else:
+            return default
+    else:
+        return [default] * len(input)
+
+
 def from_json(
-    df: _pd.DataFrame, 
-    input: _Union[str, int, list], 
+    df: _pd.DataFrame,
+    input: _Union[str, int, list],
     output: _Union[str, list] = None,
     default = None,
     **kwargs
@@ -353,7 +374,8 @@ def from_json(
         type: ["string","array","object","number","boolean","null"]
         description: >-
             Value to return if the row is empty or fails to be parsed as JSON.
-            If input is a list, default may also be a list of values (one per column).
+            If input is a list, default may also be a list - either a single
+            value to apply to all columns, or one value per input column.
     """
     # Set output column as input if not provided
     if output is None: output = input
@@ -366,18 +388,7 @@ def from_json(
     if len(input) != len(output):
         raise ValueError('The lists for input and output must be the same length.')
 
-    # Normalize default to a per-column list.
-    # Only treat default as a per-column list when it is a non-empty list
-    # (an empty list like `default: []` is always the default value itself).
-    if isinstance(default, list) and len(default) > 0:
-        if len(default) == 1:
-            defaults = [default[0]] * len(input)
-        elif len(default) != len(input):
-            raise ValueError('The list of default values must be the same length as input/output for convert.from_json')
-        else:
-            defaults = default
-    else:
-        defaults = [default] * len(input)
+    defaults = _normalize_default_list(default, input, 'convert.from_json')
 
     # Loop through and apply for all columns
     for input_column, output_column, col_default in zip(input, output, defaults):
@@ -519,7 +530,8 @@ def from_yaml(
         type: ["string","array","object","number","boolean","null"]
         description: >-
           Value to return if the row is empty or fails to be parsed as YAML.
-          If input is a list, default may also be a list of values (one per column).
+          If input is a list, default may also be a list - either a single
+          value to apply to all columns, or one value per input column.
     """
     # Set output column as input if not provided
     if output is None: output = input
@@ -532,18 +544,7 @@ def from_yaml(
     if len(input) != len(output):
         raise ValueError('The lists for input and output must be the same length.')
 
-    # Normalize default to a per-column list.
-    # Only treat default as a per-column list when it is a non-empty list
-    # (an empty list like `default: []` is always the default value itself).
-    if isinstance(default, list) and len(default) > 0:
-        if len(default) == 1:
-            defaults = [default[0]] * len(input)
-        elif len(default) != len(input):
-            raise ValueError('The list of default values must be the same length as input/output for convert.from_yaml')
-        else:
-            defaults = default
-    else:
-        defaults = [default] * len(input)
+    defaults = _normalize_default_list(default, input, 'convert.from_yaml')
 
     # Loop through and apply for all columns
     for input_column, output_column, col_default in zip(input, output, defaults):

--- a/wrangles/recipe_wrangles/convert.py
+++ b/wrangles/recipe_wrangles/convert.py
@@ -366,9 +366,16 @@ def from_json(
     if len(input) != len(output):
         raise ValueError('The lists for input and output must be the same length.')
 
-    # Normalize default to a per-column list
-    if isinstance(default, list) and len(default) == len(input):
-        defaults = default
+    # Normalize default to a per-column list.
+    # Only treat default as a per-column list when it is a non-empty list
+    # (an empty list like `default: []` is always the default value itself).
+    if isinstance(default, list) and len(default) > 0:
+        if len(default) == 1:
+            defaults = [default[0]] * len(input)
+        elif len(default) != len(input):
+            raise ValueError('The list of default values must be the same length as input/output for convert.from_json')
+        else:
+            defaults = default
     else:
         defaults = [default] * len(input)
 
@@ -525,9 +532,16 @@ def from_yaml(
     if len(input) != len(output):
         raise ValueError('The lists for input and output must be the same length.')
 
-    # Normalize default to a per-column list
-    if isinstance(default, list) and len(default) == len(input):
-        defaults = default
+    # Normalize default to a per-column list.
+    # Only treat default as a per-column list when it is a non-empty list
+    # (an empty list like `default: []` is always the default value itself).
+    if isinstance(default, list) and len(default) > 0:
+        if len(default) == 1:
+            defaults = [default[0]] * len(input)
+        elif len(default) != len(input):
+            raise ValueError('The list of default values must be the same length as input/output for convert.from_yaml')
+        else:
+            defaults = default
     else:
         defaults = [default] * len(input)
 

--- a/wrangles/recipe_wrangles/convert.py
+++ b/wrangles/recipe_wrangles/convert.py
@@ -550,7 +550,11 @@ def from_yaml(
     for input_column, output_column, col_default in zip(input, output, defaults):
         def _load_with_fallback(value, _col_default=col_default):
             try:
-                return _yaml.load(value, Loader=_YAMLLoader, **kwargs) or _col_default
+                result = _yaml.load(value, Loader=_YAMLLoader, **kwargs)
+                # Only fall back to the default if the row was empty (parses to None).
+                # A falsy-but-valid result (e.g. [], {}, '', False, 0) must be preserved
+                # as-is rather than being overwritten by the default.
+                return _col_default if result is None else result
             except:
                 if _col_default is not None:
                     return _col_default


### PR DESCRIPTION
## Summary

`convert.from_json` and `convert.from_yaml` now accept a **list of defaults** when `input` is also a list of columns. Previously, passing `default` as a YAML list (e.g. `default: - {}`) caused an error because only scalar defaults were supported.

## Behaviour

| `default` value | `input` columns | What happens |
|---|---|---|
| Any scalar (`{}`, `null`, `0`, …) | any | Broadcast to all columns (unchanged) |
| `[]` — empty list | any | `[]` used as the default for every column |
| `[value]` — 1-element list | any | Unwrap `value` and broadcast to all columns |
| `[v1, v2, …]` — n-element list | n columns | Each column gets the corresponding default |
| `[v1, v2, v3]` — n-element list | m ≠ n columns | `ValueError` (length mismatch) |

## Examples

### 1 — Original issue: single column with a list-style default

```yaml
wrangles:
  - convert.from_json:
      input:
        - Dict
      default:
        - {}        # {} applied to the one input column
      output:
        - dict
```

| Dict (input) | dict (output) |
|---|---|
| `'{"a": 1}'` | `{"a": 1}` |
| `''` | `{}` |
| `'bad json'` | `{}` |

---

### 2 — One default broadcast across multiple columns

```yaml
wrangles:
  - convert.from_json:
      input:
        - col1
        - col2
      default:
        - {}        # {} applied to both columns
      output:
        - out1
        - out2
```

| col1 | col2 | out1 | out2 |
|---|---|---|---|
| `'{"a":1}'` | `'{"b":2}'` | `{"a": 1}` | `{"b": 2}` |
| `''` | `''` | `{}` | `{}` |

---

### 3 — Different default per column

```yaml
wrangles:
  - convert.from_json:
      input:
        - col1
        - col2
      default:
        - {}        # {} for col1
        - []        # [] for col2
      output:
        - out1
        - out2
```

| col1 | col2 | out1 | out2 |
|---|---|---|---|
| `'{"a":1}'` | `'[1,2,3]'` | `{"a": 1}` | `[1, 2, 3]` |
| `''` | `''` | `{}` | `[]` |

---

### 4 — Same patterns work for `convert.from_yaml`

```yaml
wrangles:
  - convert.from_yaml:
      input:
        - col1
        - col2
      default:
        - {}
        - []
      output:
        - out1
        - out2
```

---

### 5 — Empty list as a default value (pre-existing behaviour preserved)

```yaml
wrangles:
  - convert.from_json:
      input: header1
      default: []   # scalar empty-list default — unchanged behaviour
```

| header1 | header1 (output) |
|---|---|
| `'[1,2,3]'` | `[1, 2, 3]` |
| `''` | `[]` |

---

### 6 — Length mismatch raises an error

```yaml
wrangles:
  - convert.from_json:
      input:
        - col1
        - col2
      default:
        - {}
        - []
        - null      # 3 defaults for 2 columns → ValueError
      output:
        - out1
        - out2
```

```
ValueError: The list of default values must be the same length as input/output for convert.from_json
```

## Implementation notes

- The guard condition is `isinstance(default, list) and len(default) > 0`. An empty list (`[]`) is unambiguously a default *value*, not a zero-length per-column list, so it falls through to the scalar broadcast path.
- A single-element list (`[value]`) is always unwrapped and broadcast regardless of how many input columns there are.
