### PR TITLE
Accept path objects in read / write / run recipe

### DIFF
--- a/tests/connectors/test_file.py
+++ b/tests/connectors/test_file.py
@@ -1,6 +1,7 @@
 """
 Test the file connector for reading and writing files to the local file system.
 """
+import pathlib
 import uuid as _uuid
 import wrangles
 import pandas as _pd
@@ -993,3 +994,42 @@ def test_read_object_json():
       }
     )
     assert len(df) == 3 and df['Col1'][0] == 'a'
+
+
+class TestPathObjects:
+    """
+    Test that read and write accept pathlib.Path objects (issue #986)
+    """
+    def test_read_csv_path_object(self):
+        """
+        Test that file.read accepts a pathlib.Path for a CSV file
+        """
+        df = wrangles.connectors.file.read(pathlib.Path('tests/samples/data.csv'))
+        assert list(df.columns) == ['Find', 'Replace']
+
+    def test_read_excel_path_object(self):
+        """
+        Test that file.read accepts a pathlib.Path for an Excel file
+        """
+        df = wrangles.connectors.file.read(pathlib.Path('tests/samples/data.xlsx'))
+        assert list(df.columns) == ['Find', 'Replace']
+
+    def test_write_csv_path_object(self, tmp_path):
+        """
+        Test that file.write accepts a pathlib.Path for a CSV file
+        """
+        dest = tmp_path / 'out.csv'
+        df = _pd.DataFrame({'col1': ['a'], 'col2': ['b']})
+        wrangles.connectors.file.write(df, dest)
+        result = wrangles.connectors.file.read(dest)
+        assert result['col1'][0] == 'a'
+
+    def test_write_excel_path_object(self, tmp_path):
+        """
+        Test that file.write accepts a pathlib.Path for an Excel file
+        """
+        dest = tmp_path / 'out.xlsx'
+        df = _pd.DataFrame({'col1': ['a'], 'col2': ['b']})
+        wrangles.connectors.file.write(df, dest)
+        result = wrangles.connectors.file.read(dest)
+        assert result['col1'][0] == 'a'

--- a/tests/recipes/test_run.py
+++ b/tests/recipes/test_run.py
@@ -5,6 +5,7 @@ Tests specific to an individual connector should go
 in a test file for the respective connectors
 e.g. tests/connectors/test_notifications.py
 """
+import pathlib
 import pandas as pd
 import wrangles
 import pytest
@@ -166,3 +167,19 @@ def test_overwrite_run():
     )
 
     assert check_var.get("value") is True
+
+
+def test_run_path_object():
+    """
+    Test that recipe.run accepts a pathlib.Path to a YAML file (issue #986)
+    """
+    df = wrangles.recipe.run(pathlib.Path('tests/samples/recipe-basic.wrgl.yml'))
+    assert list(df.columns) == ['header1', 'header2']
+
+
+def test_run_pure_posix_path():
+    """
+    Test that recipe.run accepts a pathlib.PurePosixPath (issue #986)
+    """
+    df = wrangles.recipe.run(pathlib.PurePosixPath('tests/samples/recipe-basic.wrgl.yml'))
+    assert list(df.columns) == ['header1', 'header2']

--- a/wrangles/connectors/file.py
+++ b/wrangles/connectors/file.py
@@ -46,6 +46,10 @@ def read(
     :param kwargs: (Optional) Named arguments to pass to respective pandas function.
     :return: A Pandas dataframe of the imported data.
     """
+    # Accept path-like objects (e.g. pathlib.Path) by converting to str
+    if isinstance(name, _os.PathLike):
+        name = str(name)
+
     if (
         isinstance(name, dict) and
         all(x in name for x in ['name', 'data', 'mimeType'])
@@ -187,6 +191,10 @@ def write(df: _pd.DataFrame, name: str, columns: _Union[str, list] = None, file_
     :param formatting: (Optional) A dictionary of formatting options to apply to Excel files.
     :param kwargs: (Optional) Named arguments to pass to respective pandas function.
     """
+    # Accept path-like objects (e.g. pathlib.Path) by converting to str
+    if isinstance(name, _os.PathLike):
+        name = str(name)
+
     _logging.info(f": Writing data to file :: {name}")
 
     # Select only specific columns if user requests them

--- a/wrangles/connectors/file.py
+++ b/wrangles/connectors/file.py
@@ -118,7 +118,7 @@ required:
 properties:
   name:
     type: string
-    description: The name of the file to import
+    description: The name or path of the file to import. Accepts a string or a Path object (pathlib.Path / os.PathLike).
   columns:
     type: array
     description: Columns to select
@@ -290,7 +290,7 @@ required:
 properties:
   name:
     type: string
-    description: The name of the file to write.
+    description: The name or path of the file to write. Accepts a string or a Path object (pathlib.Path / os.PathLike).
   columns:
     type: array
     description: A list of the columns to write. If omitted, all columns will be written.

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -64,6 +64,11 @@ def _load_recipe(
     """
     if variables is None:
         variables = {}
+
+    # Accept path-like objects (e.g. pathlib.Path) by converting to str
+    if isinstance(recipe, _os.PathLike):
+        recipe = str(recipe)
+
     if isinstance(recipe, str) and "\n" not in recipe:
         _logging.info(f": Reading Recipe :: {recipe}")
     


### PR DESCRIPTION
## Summary

`wrangles.recipe.run()` and the file connector `read`/`write` functions now accept
[`pathlib.Path`](https://docs.python.org/3/library/pathlib.html) objects (and any
`os.PathLike`) wherever a file-path string was previously required.

This removes the need to wrap every path in `str()` when building recipes with
`pathlib`, which is the recommended way to handle paths in modern Python.

## Problem

Passing a `Path` object raised `ValueError: Recipe passed in as an invalid type`
because `_load_recipe()` in `recipe.py` tested `isinstance(recipe, str)` first.
A `Path` is not a `str`, so the code fell into the pre-parsed-recipe branch and
tried to YAML-serialise the `Path` object — which always failed.

The file connector had the same issue: `file.read()` and `file.write()` used
`name.split('.')` to detect the file extension, which raises `AttributeError` for
`Path` objects.

## Changes

| File | What changed |
|---|---|
| `wrangles/recipe.py` | Added `os.PathLike` → `str` conversion at the top of `_load_recipe()` |
| `wrangles/connectors/file.py` | Same conversion at the top of `read()` and `write()` |
| `tests/recipes/test_run.py` | Added `test_run_path_object`, `test_run_pure_posix_path` |
| `tests/connectors/test_file.py` | Added `TestPathObjects` with 4 read/write tests |

The fix is a minimal, non-breaking guard — one `isinstance` check per entry point.
Using `os.PathLike` (rather than `pathlib.Path` directly) means it also covers
`PurePosixPath`, `PureWindowsPath`, and any third-party path-like type.

## Examples

### `recipe.run()` with a Path

```python
import pathlib
import wrangles

recipe_path = pathlib.Path('recipes') / 'clean_data.wrgl.yml'

# Before: had to call str() explicitly
df = wrangles.recipe.run(str(recipe_path))

# After: Path object accepted directly
df = wrangles.recipe.run(recipe_path)
```

### `file.read()` with a Path

```python
import pathlib
import wrangles

data_file = pathlib.Path('data') / 'raw' / 'input.csv'

df = wrangles.connectors.file.read(data_file)
```

### `file.write()` with a Path

```python
import pathlib
import wrangles

output_dir = pathlib.Path('data') / 'processed'
output_dir.mkdir(parents=True, exist_ok=True)

wrangles.connectors.file.write(df, output_dir / 'output.xlsx')
```

### Typical real-world pattern — recipe next to the script

```python
from pathlib import Path
import wrangles

# __file__ gives the location of the current script,
# so the recipe path is always relative to it — no matter where you run from.
HERE = Path(__file__).parent
recipe = HERE / 'recipes' / 'clean_parts.wrgl.yml'

df = wrangles.recipe.run(recipe)
```

### Inside a recipe via the file connector

```yaml
read:
  - file:
      name: data/input.csv   # string paths still work as before

wrangles:
  - convert.case:
      input: Find
      output: Find
      case: upper

write:
  - file:
      name: data/output.csv
```

