### PR TITLE
992-refactor-lookup-actions-bug-request-key-colm

### DIFF
--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -1,4 +1,6 @@
 import uuid
+import time
+import importlib
 
 from pytest_mock import mocker
 
@@ -7,6 +9,28 @@ import pandas as pd
 import pytest
 import logging
 import re
+
+
+def _wait_for_lookup(model_id, predicate, timeout=15, interval=0.5):
+    """
+    Poll a live train.lookup model until predicate(df) is true.
+
+    The lookup API is eventually consistent, so a fixed sleep after a write
+    can race with a subsequent read. Polling on the actual expected state
+    avoids that race instead of guessing a delay.
+    """
+    deadline = time.time() + timeout
+    result = None
+    while time.time() < deadline:
+        result = wrangles.recipe.run(f"read:\n  - train.lookup:\n      model_id: {model_id}")
+        if predicate(result):
+            return result
+        time.sleep(interval)
+    raise AssertionError(
+        f"Lookup model {model_id} did not reach expected state within {timeout}s; "
+        f"last seen columns: {list(result.columns) if result is not None else None}"
+    )
+
 
 class LogCapture(logging.Handler):
     def __init__(self, *args, **kwargs):
@@ -641,9 +665,12 @@ class TestTrainLookup:
         recipe = f"""
         write:
           - train.lookup:
-              model_id: 3c8f6707-2de4-4be3 
+              model_id: 3c8f6707-2de4-4be3
               action: INSERT
               variant: key
+              columns:
+                - Key
+                - Value
         """
         data = pd.DataFrame({
             'Key': ['Rachel', 'Dolores', 'TARS'],
@@ -651,23 +678,26 @@ class TestTrainLookup:
         })
         df = wrangles.recipe.run(recipe, dataframe=data)
         assert df.iloc[0]['Key'] == 'Rachel' and df.iloc[0]['Value'] == 'Blade Runner'
-  
-    def test_insert_duplicate_keys(self):  
-        """  
-        Test insert fails when DataFrame contains duplicate keys  
-        """  
-        df = pd.DataFrame({  
-            'Key': ['Rachel', 'Rachel', 'Dolores'],  # Duplicate Rachel  
-            'Value': ['Blade Runner', 'Not Rachel', 'Westworld']  
-        })  
+
+    def test_insert_duplicate_keys(self):
+        """
+        Test insert fails when DataFrame contains duplicate keys
+        """
+        df = pd.DataFrame({
+            'Key': ['Rachel', 'Rachel', 'Dolores'],  # Duplicate Rachel
+            'Value': ['Blade Runner', 'Not Rachel', 'Westworld']
+        })
         recipe = f"""
             write:
             - train.lookup:
-                model_id: 3c8f6707-2de4-4be3 
+                model_id: 3c8f6707-2de4-4be3
                 action: INSERT
                 variant: key
-            """ 
-        with pytest.raises(ValueError, match="Lookup: All Keys must be unique"):  
+                columns:
+                  - Key
+                  - Value
+            """
+        with pytest.raises(ValueError, match="Lookup: All Keys must be unique"):
             wrangles.recipe.run(recipe, dataframe=df)
         
     
@@ -680,17 +710,20 @@ class TestTrainLookup:
             'Value': ['Blade Runner 2049', 'Westworld Updated']  
         })  
           
-        recipe = """  
-        write:  
-          - train.lookup:  
-              model_id: test-model-id  
-              action: UPDATE  
-        """  
-          
-        # This would test with an actual existing model  
-        # For testing purposes, we'll catch the expected error  
-        with pytest.raises(RuntimeError, match="Access denied to model test-model-id"):  
-            wrangles.recipe.run(recipe, dataframe=df)  
+        recipe = """
+        write:
+          - train.lookup:
+              model_id: test-model-id
+              action: UPDATE
+              columns:
+                - Key
+                - Value
+        """
+
+        # This would test with an actual existing model
+        # For testing purposes, we'll catch the expected error
+        with pytest.raises(RuntimeError, match="Access denied to model test-model-id"):
+            wrangles.recipe.run(recipe, dataframe=df)
   
     def test_action_parameter_validation_recipe(self):  
         """  
@@ -720,57 +753,66 @@ class TestTrainLookup:
             'Value': ['Updated Rachel', 'Updated Dolores', 'Updated Phipi']  
         })  
           
-        recipe = """  
-        write:  
-          - train.lookup:  
+        recipe = """
+        write:
+          - train.lookup:
               model_id: 3c8f6707-2de4-4be3
-              action: UPDATE  
-        """  
-        
-        df = wrangles.recipe.run(recipe, dataframe=df)  
+              action: UPDATE
+              columns:
+                - Key
+                - Value
+        """
+
+        df = wrangles.recipe.run(recipe, dataframe=df)
         assert df.iloc[0]['Key'] == 'Rachel' and df.iloc[0]['Value'] == 'Updated Rachel'
-                                                            
-    def test_upsert_new_model_recipe(self):  
-        """  
-        Test upsert creates new model when model_id doesn't exist  
-        """  
-        df = pd.DataFrame({  
-            'Key': ['Rachel', 'NewCharacter'],  
-            'Value': ['Updated Rachel', 'New Movie']  
-        })  
+
+    def test_upsert_new_model_recipe(self):
+        """
+        Test upsert creates new model when model_id doesn't exist
+        """
+        df = pd.DataFrame({
+            'Key': ['Rachel', 'NewCharacter'],
+            'Value': ['Updated Rachel', 'New Movie']
+        })
         model_name = f"model {{ {uuid.uuid4().hex[:8]} }}"
-        
-        recipe = f"""  
-        write:  
-        - train.lookup:  
-            name: {model_name} 
-            action: UPSERT  
-            variant: key  
-        """  
-        
-        result = wrangles.recipe.run(recipe, dataframe=df)  
-        assert len(result) == 2  
-        assert 'NewCharacter' in result['Key'].tolist()  
+
+        recipe = f"""
+        write:
+        - train.lookup:
+            name: {model_name}
+            action: UPSERT
+            variant: key
+            columns:
+              - Key
+              - Value
+        """
+
+        result = wrangles.recipe.run(recipe, dataframe=df)
+        assert len(result) == 2
+        assert 'NewCharacter' in result['Key'].tolist()
         assert result['Value'].tolist() == ['Updated Rachel', 'New Movie']
         models = wrangles.data.user.models('lookup')
         assert any(m['name'] == model_name for m in models)
-  
-    def test_action_parameter_upsert(self):  
-        """  
-        Test write method with action='UPSERT'  
-        """  
-        df = pd.DataFrame({  
-            'Key': ['Rachel'],  
-            'Value': ['Updated Rachel']  
-        })  
-        recipe = f"""  
-        write:  
-        - train.lookup:  
+
+    def test_action_parameter_upsert(self):
+        """
+        Test write method with action='UPSERT'
+        """
+        df = pd.DataFrame({
+            'Key': ['Rachel'],
+            'Value': ['Updated Rachel']
+        })
+        recipe = f"""
+        write:
+        - train.lookup:
             model_id: b2cd1a8a-4d99-4be1
-            action: UPSERT  
-            variant: key  
-        """  
-        result = wrangles.recipe.run(recipe, dataframe=df)  
+            action: UPSERT
+            variant: key
+            columns:
+              - Key
+              - Value
+        """
+        result = wrangles.recipe.run(recipe, dataframe=df)
         assert len(result) == 1
         assert result.iloc[0]['Key'] == 'Rachel' and result.iloc[0]['Value'] == 'Updated Rachel'
 
@@ -857,24 +899,61 @@ class TestTrainLookup:
         assert 'Interstellar' in result.values
         assert 'Value' in result.columns and 'Description' in result.columns
 
-    def test_upsert_mismatched_columns_existing_model(self):
+    def test_upsert_adds_new_column(self):
         """
-        UPSERT should fail when new data includes columns not present
-        in the existing model schema.
+        UPSERT with a column that doesn't exist in the model yet must add
+        that column; existing rows receive '' for the new column.
+
         """
-        df = pd.DataFrame({
-            'Key': ['Rachel'],
-            'Other': ['Blade Runner']
-        })
-        recipe = """
-        write:
-          - train.lookup:
-              model_id: b2cd1a8a-4d99-4be1
-              action: UPSERT
-              variant: key
-        """
-        with pytest.raises(ValueError, match="The following columns are not present in the existing model: Other"):
-            wrangles.recipe.run(recipe, dataframe=df)
+        MODEL = 'c060a706-db4a-4564'
+
+        wrangles.recipe.run(
+            f"""
+            write:
+              - train.lookup:
+                  model_id: {MODEL}
+                  action: overwrite
+                  variant: key
+            """,
+            dataframe=pd.DataFrame({
+                'Key':   ['apple', 'banana'],
+                'Value': ['red',   'yellow'],
+            }),
+        )
+        _wait_for_lookup(
+            MODEL,
+            lambda df: set(df.columns) == {'Key', 'Value'} and set(df['Key']) == {'apple', 'banana'},
+        )
+
+        wrangles.recipe.run(
+            f"""
+            write:
+              - train.lookup:
+                  model_id: {MODEL}
+                  action: upsert
+                  variant: key
+                  columns:
+                    - Key
+                    - Value
+                    - Weight
+            """,
+            dataframe=pd.DataFrame({
+                'Key':    ['apple'],
+                'Value':  ['green'],
+                'Weight': ['1.0'],
+            }),
+        )
+
+        result = _wait_for_lookup(
+            MODEL,
+            lambda df: 'Weight' in df.columns
+            and (df.loc[df['Key'] == 'apple', 'Value'] == 'green').all(),
+        )
+        assert 'Weight' in result.columns, "New column must be present after upsert"
+        apple  = result[result['Key'] == 'apple'].iloc[0]
+        banana = result[result['Key'] == 'banana'].iloc[0]
+        assert apple['Weight']  == '1.0', "Updated row must carry the new column value"
+        assert banana['Weight'] == '',    "Unaffected rows get '' for the new column"
 
     def test_upsert_missing_key_for_key_variant(self):
         """
@@ -890,6 +969,8 @@ class TestTrainLookup:
               model_id: b2cd1a8a-4d99-4be1
               action: UPSERT
               variant: key
+              columns:
+                - Value
         """
         with pytest.raises(ValueError, match="'Key' column must be provided for 'key' variant"):
             wrangles.recipe.run(recipe, dataframe=df)
@@ -905,12 +986,15 @@ class TestTrainLookup:
             model_id: 89637e77-7214-49a0
             action: UPDATE
             variant: semantic
+            columns:
+              - Not Key
+              - Not Value
         """
         data = pd.DataFrame({
             'Not Key': ['A', 'B'],
             'Not Value': ['X', 'Y']
         })
-        
+
         with pytest.raises(ValueError, match="UPDATE requires 'Key' or 'MatchingColumns' for non-key variants"):
             wrangles.recipe.run(recipe, dataframe=data)
 
@@ -924,6 +1008,9 @@ class TestTrainLookup:
             model_id: 3c8f6707-2de4-4be3
             action: UPDATE
             variant: key
+            columns:
+              - NotKey
+              - Value
         """
         data = pd.DataFrame({
             'NotKey': ['A', 'B'],
@@ -985,6 +1072,11 @@ class TestTrainLookup:
             model_id: 3c8f6707-2de4-4be3
             action: INSERT
             variant: key
+            columns:
+              - City
+              - Country
+              - Key
+              - Value
             settings:
               MatchingColumns:
                 - Not City
@@ -1028,6 +1120,9 @@ class TestTrainLookup:
             - train.lookup:
                     name: 083ed6fe-a073-4b1a
                     action: UPSERT
+                    columns:
+                      - City
+                      - Country
                     settings:
                         MatchingColumns:
                             - NotKey
@@ -1049,6 +1144,9 @@ class TestTrainLookup:
             - train.lookup:
                     model_id: 083ed6fe-a073-4b1a
                     action: UPSERT
+                    columns:
+                      - City
+                      - Country
                     settings:
                         MatchingColumns:
                             - NotKey
@@ -1071,6 +1169,9 @@ class TestTrainLookup:
             - train.lookup:
                     model_id: 083ed6fe-a073-4b1a
                     action: INSERT
+                    columns:
+                      - City
+                      - Country
                     settings:
                         MatchingColumns:
                             - NotKey
@@ -1123,6 +1224,11 @@ class TestTrainLookup:
                         model_id: 4202c974-430a-46b9
                         action: update
                         variant: semantic
+                        columns:
+                          - City
+                          - Country
+                          - Code
+                          - Currency
                         settings:
                             MatchingColumns: City
             ''',
@@ -1154,8 +1260,13 @@ class TestTrainLookup:
                         model_id: 4202c974-430a-46b9
                         action: update
                         variant: semantic
+                        columns:
+                          - City
+                          - Country
+                          - Code
+                          - Currency
                         settings:
-                            MatchingColumns: 
+                            MatchingColumns:
                             - City
                             - Country
             ''',
@@ -1186,6 +1297,11 @@ class TestTrainLookup:
                 - train.lookup:
                         model_id: 4202c974-430a-46b9
                         action: insert
+                        columns:
+                          - City
+                          - Country
+                          - Code
+                          - Currency
                         settings:
                             MatchingColumns: City
             ''',
@@ -1217,8 +1333,13 @@ class TestTrainLookup:
                         model_id: 4202c974-430a-46b9
                         action: insert
                         variant: semantic
+                        columns:
+                          - City
+                          - Country
+                          - Code
+                          - Currency
                         settings:
-                            MatchingColumns: 
+                            MatchingColumns:
                                 - City
             ''',
             dataframe=df
@@ -1247,6 +1368,11 @@ class TestTrainLookup:
                 - train.lookup:
                         model_id: 4202c974-430a-46b9
                         action: upsert
+                        columns:
+                          - City
+                          - Country
+                          - Code
+                          - Currency
                         settings:
                             MatchingColumns: City
             ''',
@@ -1277,8 +1403,13 @@ class TestTrainLookup:
                         model_id: 4202c974-430a-46b9
                         action: upsert
                         variant: semantic
+                        columns:
+                          - City
+                          - Country
+                          - Code
+                          - Currency
                         settings:
-                            MatchingColumns: 
+                            MatchingColumns:
                                 - City
                                 - Country
             ''',
@@ -1288,7 +1419,7 @@ class TestTrainLookup:
         messages = [record.message for record in caplog.records if record.levelname == "INFO"]
         assert any("Lookup UPSERT: 1 rows inserted, 2 rows updated. Total rows:" in msg for msg in messages), "Log should mention rows inserted (variant specified)"
 
-    def test_insert_key_only(self, caplog):
+    def test_insert_key_only(self):
         """
         Test INSERT with only a Key column and no MatchingColumns/settings.
         """
@@ -1298,6 +1429,9 @@ class TestTrainLookup:
                 model_id: 12b7ac66-7418-45b5
                 action: INSERT
                 variant: key
+                columns:
+                  - Key
+                  - City
         """
         data = pd.DataFrame({
             'Key': ['Rachel', 'Dolores'],
@@ -1326,6 +1460,9 @@ class TestTrainLookup:
             - train.lookup:
                 model_id: 12b7ac66-7418-45b5
                 action: UPDATE
+                columns:
+                  - Key
+                  - City
         """
         data = pd.DataFrame({
             'Key': ['Alice'],
@@ -1352,6 +1489,9 @@ class TestTrainLookup:
                 model_id: 12b7ac66-7418-45b5
                 action: UPSERT
                 variant: key
+                columns:
+                  - Key
+                  - City
         """
         data = pd.DataFrame({
             'Key': ['Charlie', 'NewKey'],
@@ -1360,47 +1500,236 @@ class TestTrainLookup:
         df = wrangles.recipe.run(recipe, dataframe=data)
         assert 'Blade Runner Upsert' in df['City'].values
         assert 'New Value' in df['City'].values
-    
-    def test_missing_columns_error_message(self, mocker):
+
+    def test_upsert_preserves_unspecified_columns(self):
         """
-        Verify that INSERT/UPSERT/UPDATE raise the expected error
-        when incoming columns are not present in the existing model.
+        UPSERT with a partial set of columns must not delete columns that are
+        present in the model but absent from the incoming DataFrame.
+        Issue #992: unspecified columns were silently dropped.
         """
+        MODEL = 'be1fcb1c-08ea-43bc'
+
+        wrangles.recipe.run(
+            f"""
+            write:
+              - train.lookup:
+                  model_id: {MODEL}
+                  action: overwrite
+                  variant: key
+            """,
+            dataframe=pd.DataFrame({
+                'Key':     ['apple', 'banana', 'cherry'],
+                'Schema':  ['fruit', 'fruit',  'fruit'],
+                'Mapping': ['red',   'yellow', 'red'],
+            }),
+        )
+        _wait_for_lookup(
+            MODEL,
+            lambda df: set(df.columns) == {'Key', 'Schema', 'Mapping'}
+            and set(df['Key']) == {'apple', 'banana', 'cherry'},
+        )
+
+        wrangles.recipe.run(
+            f"""
+            write:
+              - train.lookup:
+                  model_id: {MODEL}
+                  action: upsert
+                  variant: key
+                  columns:
+                    - Key
+                    - Mapping
+            """,
+            dataframe=pd.DataFrame({'Key': ['apple'], 'Mapping': ['green']}),
+        )
+
+        result = _wait_for_lookup(
+            MODEL,
+            lambda df: 'Schema' in df.columns
+            and (df.loc[df['Key'] == 'apple', 'Mapping'] == 'green').all(),
+        )
+        assert 'Schema' in result.columns, "Schema must be preserved after partial upsert"
+        apple = result[result['Key'] == 'apple'].iloc[0]
+        assert apple['Mapping'] == 'green', "Updated column must reflect new value"
+        assert apple['Schema']  == 'fruit', "Unspecified column must retain original value"
+
+    def test_insert_preserves_unspecified_columns(self):
+        """
+        INSERT must not drop columns that exist in the model but are absent
+        from the incoming DataFrame.  New rows get '' for unspecified columns.
+        """
+        MODEL = '29a87d05-0617-4283'
+
+        wrangles.recipe.run(
+            f"""
+            write:
+              - train.lookup:
+                  model_id: {MODEL}
+                  action: overwrite
+                  variant: key
+            """,
+            dataframe=pd.DataFrame({
+                'Key':     ['apple', 'banana'],
+                'Schema':  ['fruit', 'fruit'],
+                'Mapping': ['red',   'yellow'],
+            }),
+        )
+        _wait_for_lookup(
+            MODEL,
+            lambda df: set(df.columns) == {'Key', 'Schema', 'Mapping'}
+            and set(df['Key']) == {'apple', 'banana'},
+        )
+
+        wrangles.recipe.run(
+            f"""
+            write:
+              - train.lookup:
+                  model_id: {MODEL}
+                  action: insert
+                  variant: key
+                  columns:
+                    - Key
+                    - Mapping
+            """,
+            dataframe=pd.DataFrame({'Key': ['cherry'], 'Mapping': ['red']}),
+        )
+
+        result = _wait_for_lookup(
+            MODEL,
+            lambda df: 'Schema' in df.columns and len(df) == 3,
+        )
+        assert 'Schema' in result.columns, "Schema column must be preserved after insert"
+        assert len(result) == 3, "New row must be added"
+        cherry = result[result['Key'] == 'cherry'].iloc[0]
+        assert cherry['Mapping'] == 'red'
+        assert cherry['Schema']  == '', "Unspecified column for new row must be empty string"
+
+    def test_update_preserves_unspecified_columns(self, mocker):
+        """
+        UPDATE must only modify the columns present in the incoming DataFrame;
+        all other columns — on both the updated and untouched rows — must be
+        preserved exactly.
+
+        Mocked rather than run against the live API: this previously polled
+        a real model for up to 15s and was flaky under eventual consistency.
+        """
+        MODEL = 'dcac58c3-7da0-403f'
+        store = {}
+
+        mocker.patch("wrangles.data.model", return_value={'variant': 'key'})
+        mocker.patch(
+            "wrangles.data.model_content",
+            side_effect=lambda id, version_id=None: store[id]
+        )
+        mocker.patch(
+            "wrangles.train.train.lookup",
+            side_effect=lambda data, name=None, model_id=None, settings=None: store.__setitem__(model_id, data)
+        )
+
+        wrangles.recipe.run(
+            f"""
+            write:
+              - train.lookup:
+                  model_id: {MODEL}
+                  action: overwrite
+                  variant: key
+            """,
+            dataframe=pd.DataFrame({
+                'Key':     ['apple', 'banana', 'cherry'],
+                'Schema':  ['fruit', 'fruit',  'fruit'],
+                'Mapping': ['red',   'yellow', 'red'],
+            }),
+        )
+
+        wrangles.recipe.run(
+            f"""
+            write:
+              - train.lookup:
+                  model_id: {MODEL}
+                  action: update
+                  variant: key
+                  columns:
+                    - Key
+                    - Mapping
+            """,
+            dataframe=pd.DataFrame({'Key': ['apple'], 'Mapping': ['green']}),
+        )
+
+        result = wrangles.recipe.run(f"read:\n  - train.lookup:\n      model_id: {MODEL}")
+        assert 'Schema' in result.columns, "Schema must be preserved after update"
+        apple  = result[result['Key'] == 'apple'].iloc[0]
+        banana = result[result['Key'] == 'banana'].iloc[0]
+        assert apple['Mapping']  == 'green',  "Updated Mapping must reflect new value"
+        assert apple['Schema']   == 'fruit',  "Unspecified Schema on updated row must be preserved"
+        assert banana['Mapping'] == 'yellow', "Untouched row must be unchanged"
+        assert banana['Schema']  == 'fruit',  "Untouched row Schema must be unchanged"
+
+    def test_missing_columns_error_message(self, monkeypatch):
+        """
+        INSERT and UPDATE raise an error when incoming columns are not present
+        in the existing model schema.  UPSERT is intentionally excluded: it
+        allows new columns (adds them to the model schema, filling existing
+        rows with '').
+        """
+        train_connector = importlib.import_module("wrangles.connectors.train")
+        monkeypatch.setattr(
+            train_connector._data,
+            "model",
+            lambda model_id: {"variant": "key"}
+        )
+        monkeypatch.setattr(
+            train_connector._data,
+            "model_content",
+            lambda model_id: {
+                "Columns": ["Key", "Value"],
+                "Data": [["k1", "v1"], ["k2", "v2"]],
+            }
+        )
 
         df = pd.DataFrame({
             "Key": ["k3"],
             "Value": ["v3"],
-            "ExtraCol": ["x"]  # This column does not exist in the model
+            "ExtraCol": ["x"]  # does not exist in the model
         })
 
-        # Mock the existing model so the test does not depend on a real, live model
-        mocker.patch(
-            "wrangles.data.model_content",
-            return_value={
-                "Columns": ["Key", "Value"],
-                "Data": [["k1", "v1"]]
-            }
-        )
-        mocker.patch(
-            "wrangles.data.model",
-            return_value={"variant": "key"}
-        )
-
-        # Test each action that performs the column-alignment check
-        for action in ("insert", "upsert", "update"):
+        for action in ("insert", "update"):
             recipe = f"""
                 write:
                     - train.lookup:
                         model_id: bc3ee6a0-e104-4700
                         action: {action}
                         variant: key
-
+                        columns:
+                          - Key
+                          - Value
+                          - ExtraCol
                 """
             with pytest.raises(ValueError, match="Lookup: The following columns are not present in the existing model: ExtraCol"):
                 wrangles.recipe.run(recipe, dataframe=df)
-    
-            
-def test_lookup_write_logs_new_model_id(caplog):  
+
+    def test_columns_required_for_partial_update_actions(self):
+        """
+        INSERT, UPDATE, and UPSERT must raise ValueError when 'columns' is not specified.
+        OVERWRITE does not require it.
+        """
+        df = pd.DataFrame({'Key': ['apple'], 'Value': ['red']})
+        for action in ('insert', 'update', 'upsert'):
+            with pytest.raises(
+                ValueError,
+                match=f"Lookup: 'columns' is required for action '{action}'"
+            ):
+                wrangles.recipe.run(
+                    f"""
+                    write:
+                      - train.lookup:
+                          model_id: 3c8f6707-2de4-4be3
+                          action: {action}
+                    """,
+                    dataframe=df,
+                )
+
+
+def test_lookup_write_logs_new_model_id(caplog):
     """  
     Integration test for lookup model creation logging  
     """  

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -6111,10 +6111,89 @@ class TestBatch:
   
 
 
+def _seed_lookup_model(model_id, dataframe, timeout=15, interval=0.5):
+    """
+    Overwrite a live train.lookup model and poll until the write is visible.
+
+    The lookup API is eventually consistent, so callers must wait for the
+    write to land before reading it back rather than assuming it's immediate.
+    """
+    wrangles.recipe.run(
+        f"""
+        write:
+          - train.lookup:
+              model_id: {model_id}
+              action: overwrite
+              variant: key
+        """,
+        dataframe=dataframe,
+    )
+    expected_keys = set(dataframe['Key'])
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        result = wrangles.recipe.run(f"read:\n  - train.lookup:\n      model_id: {model_id}")
+        if set(result.columns) == set(dataframe.columns) and set(result['Key']) == expected_keys:
+            return
+        time.sleep(interval)
+    raise AssertionError(f"Lookup model {model_id} did not reach seeded state within {timeout}s")
+
+
 class TestLookup:
     """
     Test lookup wrangle
     """
+    def test_lookup_output_key_only(self):
+        """
+        Specifying output: Key should return the looked-up key string, not a dict.
+        Issue #992: 'Key' was not in metadata["settings"]["columns"] so the unnamed-
+        columns path was hit and the full dict was returned instead.
+        """
+        _seed_lookup_model(
+            '3f23acaf-a2e6-4327',
+            pd.DataFrame({
+                'Key':    ['apple', 'banana', 'cherry'],
+                'Schema': ['fruit', 'fruit',  'fruit'],
+            }),
+        )
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+              - lookup:
+                  input: fruit
+                  output: Key
+                  model_id: 3f23acaf-a2e6-4327
+            """,
+            dataframe=pd.DataFrame({'fruit': ['apple', 'banana', 'cherry']}),
+        )
+        assert df['Key'].tolist() == ['apple', 'banana', 'cherry']
+
+    def test_lookup_output_key_and_value_column(self):
+        """
+        Specifying output: [Key, Schema] must work without error.
+        Issue #992: mixing 'Key' with a real model column raised ValueError.
+        """
+        _seed_lookup_model(
+            '33961b4e-92f5-4705',
+            pd.DataFrame({
+                'Key':    ['apple', 'banana', 'cherry'],
+                'Schema': ['fruit', 'fruit',  'fruit'],
+            }),
+        )
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+              - lookup:
+                  input: fruit
+                  output:
+                    - Key
+                    - Schema
+                  model_id: 33961b4e-92f5-4705
+            """,
+            dataframe=pd.DataFrame({'fruit': ['apple', 'banana', 'cherry']}),
+        )
+        assert df['Key'].tolist() == ['apple', 'banana', 'cherry']
+        assert df['Schema'].tolist() == ['fruit', 'fruit', 'fruit']
+
     def test_lookup_mode_by_row_default(self):  
         """  
         Test lookup with by_row mode (default behavior)  

--- a/wrangles/connectors/train.py
+++ b/wrangles/connectors/train.py
@@ -234,16 +234,17 @@ class lookup():
             description: Specific model to read
         """
 
-    def write(df: _pd.DataFrame, name: str = None, model_id: str = None, settings: dict = None, variant: str = 'key', action: str = 'overwrite') -> None:
+    def write(df: _pd.DataFrame, columns: list = None, name: str = None, model_id: str = None, settings: dict = None, variant: str = 'key', action: str = 'overwrite') -> None:
         """
         Train a new or existing lookup wrangle
 
         :param df: DataFrame to be written to a file
+        :param columns: Columns to include. Required for INSERT, UPDATE and UPSERT — only the listed columns will be added or updated.
         :param name: Name to give to a new Wrangle that will be created
         :param model_id: Model to be updated. Either this or name must be provided
         :param settings: Specific settings to apply to the wrangle
         :param variant: Variant of the Lookup Wrangle that will be created (key or semantic)
-        :param action: Action to take when training the lookup wrangle (insert, update, upsert)
+        :param action: Action to take when training the lookup wrangle (overwrite, insert, update, upsert)
         """
         _logging.info(f": Training Lookup Wrangle")
         if settings is None:
@@ -256,6 +257,18 @@ class lookup():
         # Normalize inputs and avoid mutating default args
         act = (action or 'overwrite').upper()
         settings = dict(settings or {})
+
+        # columns is required for partial-update actions
+        if columns is None and act in ('INSERT', 'UPDATE', 'UPSERT'):
+            raise ValueError(
+                f"Lookup: 'columns' is required for action '{action}'. "
+                "Specify the columns to add or update so that unrelated columns are not modified."
+            )
+
+        # Filter the DataFrame to only the requested columns
+        if columns is not None:
+            columns = _wildcard_expansion(df.columns, columns)
+            df = df[columns]
 
         def _get_columns_from_payload(payload):
             # payload can be a DataFrame or the 'tight' dict produced by _to_tight
@@ -333,18 +346,8 @@ class lookup():
                     columns=existing_content['Columns']
                 )
 
-                # Validate column compatibility with existing model
-                requested_cols = new_data['Columns']
-                missing_in_existing = [c for c in requested_cols if c not in existing_df_all.columns]
-                if missing_in_existing:
-                    raise ValueError(
-                        "Lookup: The following columns are not present in the existing model: "
-                        + ", ".join(missing_in_existing)
-                    )
-
-                existing_df = existing_df_all[requested_cols]  # Ensure same column order
-
                 # For key variant, ensure new data contains Key column
+                requested_cols = new_data['Columns']
                 normalized_variant = settings.get('variant', variant)
                 if normalized_variant == 'key' and 'Key' not in df.columns:
                     raise ValueError("Lookup: 'Key' column must be provided for 'key' variant")
@@ -353,13 +356,17 @@ class lookup():
                 updated = 0
 
                 # Merge data - avoid duplicates based on Key column
-                if variant== 'key' and 'Key' in existing_df.columns and 'Key' in df.columns:
+                if variant == 'key' and 'Key' in existing_df_all.columns and 'Key' in df.columns:
                     if df['Key'].duplicated().any():
                         raise ValueError("Lookup: All Keys must be unique")
-                    existing_keys = set(existing_df['Key'].tolist())
+                    existing_keys = set(existing_df_all['Key'].tolist())
 
-                    # Start with current data
-                    merged_df = existing_df.copy()
+                    # Use ALL existing columns as the base so unspecified columns are preserved.
+                    # New columns introduced by this upsert are added with '' for existing rows.
+                    merged_df = existing_df_all.copy()
+                    new_cols = [c for c in requested_cols if c not in merged_df.columns]
+                    for col in new_cols:
+                        merged_df[col] = ''
 
                     # Apply updates for matching keys
                     for _, row in df.iterrows():
@@ -367,13 +374,14 @@ class lookup():
                         if key in existing_keys:
                             mask = merged_df['Key'] == key
                             for col in df.columns:
-                                if col != 'Key' and col in merged_df.columns:
+                                if col != 'Key':
                                     merged_df.loc[mask, col] = row[col]
                             updated += 1
                         else:
-                            # Insert new rows for non-existing keys
+                            # New key: fill columns absent from the incoming row with empty string
+                            new_row = {col: (row[col] if col in df.columns else '') for col in merged_df.columns}
                             merged_df = _pd.concat(
-                                [merged_df, _pd.DataFrame([row[merged_df.columns].tolist()], columns=merged_df.columns)],
+                                [merged_df, _pd.DataFrame([new_row])],
                                 ignore_index=True
                             )
                             inserted += 1
@@ -422,7 +430,7 @@ class lookup():
                         merged_df = merged_df[existing_df_all.columns]
                     else:
                         # Without MatchingColumns, append all
-                        merged_df = _pd.concat([existing_df, df], ignore_index=True)
+                        merged_df = _pd.concat([existing_df_all, df], ignore_index=True)
                         inserted = len(df)
 
                 merged_data = {
@@ -598,10 +606,11 @@ class lookup():
                     inserted = len(df)
                     merged_df = _pd.concat([existing_df, df], ignore_index=True)  
             
-            merged_data = {  
-                'Columns': merged_df.columns.tolist(),  
-                'Data': merged_df.values.tolist()  
-            }  
+            merged_df = merged_df.fillna('')
+            merged_data = {
+                'Columns': merged_df.columns.tolist(),
+                'Data': merged_df.values.tolist()
+            }
             _validate_matching_columns(merged_data, settings)
             total_rows = len(merged_df)
             _train.lookup(merged_data, None, model_id, settings)
@@ -611,6 +620,8 @@ class lookup():
         type: object
         description: Train a new or existing Lookup Wrangle
         additionalProperties: false
+        required:
+          - action
         properties:
           name:
             type: string
@@ -620,21 +631,28 @@ class lookup():
             description: Model to be updated. Either this or a name must be provided
           columns:
             type: array
-            description: Columns to submit
+            description: >-
+              Columns to include from the DataFrame.
+              Required for INSERT, UPDATE and UPSERT — only the listed columns
+              will be added or updated; all other columns in the model are left
+              unchanged.
+            items:
+              type: string
+          action:
+            type: string
+            description: Action to take when training the lookup wrangle
+            default: overwrite
+            enum:
+              - insert
+              - update
+              - upsert
+              - overwrite
           variant:
             type: string
             description: Variant of the Lookup Wrangle that will be created
             enum:
               - key
               - semantic
-        action:
-            type: string
-            description: Action to take when training the lookup wrangle
-            enum:
-              - insert
-              - update
-              - upsert
-              - overwrite
         """
 
 

--- a/wrangles/lookup.py
+++ b/wrangles/lookup.py
@@ -69,7 +69,7 @@ def lookup(
         f'{_config.api_host}/wrangles/lookup',
         {
             "model_id": model_id,
-            "columns": _json.dumps(columns or metadata["settings"]["columns"]),
+            "columns": _json.dumps(columns if columns is not None else metadata.get("settings", {}).get("columns", [])),
             **kwargs
         },
         input,

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -903,7 +903,7 @@ def lookup(
     input: str,
     output: _Union[str, list] = None,
     model_id: str = None,
-    lookup_mode: str = 'by_row',
+    lookup_mode: str = 'by_row', 
     n: int = None,
     **kwargs
 ) -> _pd.DataFrame:
@@ -999,7 +999,14 @@ def lookup(
             list(val.values())[0] if isinstance(val, dict) else val
             for val in output    
         ]
-  
+
+        # 'Key' is valid as output — it echoes the input key value, not a model value column.
+        # Strip it before routing so the named/unnamed check is not confused by it.
+        _key_indices = {i for i, col in enumerate(wrangle_output) if col == 'Key'}
+        _key_out_cols = [output[i] for i in sorted(_key_indices)]
+        _wrangle_cols = [col for i, col in enumerate(wrangle_output) if i not in _key_indices]
+        _out_cols = [col for i, col in enumerate(output) if i not in _key_indices]
+
         # Remove matrix_variables from kwargs if present before passing to _lookup
         def _clean_kwargs(kwargs):
           if 'matrix_variables' in kwargs:
@@ -1010,100 +1017,87 @@ def lookup(
         # Distribute the n matches for each row across the output columns,
         # ranked match i goes to output column i
         def _distribute_n_matches(data):
-          for i, out in enumerate(output):
+          for i, out in enumerate(_out_cols):
             df[out] = [row[i] if isinstance(row, list) and i < len(row) else None for row in data]
 
         # Perform lookup based on lookup_mode
+        model_columns = metadata.get("settings", {}).get("columns", [])
         if lookup_mode == 'by_row':
-          # Current behavior - process all rows
-          if all([col in metadata["settings"]["columns"] for col in wrangle_output]):
-            # User specified all columns from the wrangle
-            data = _lookup(
-              df[input].values.tolist(),
-              model_id,
-              columns=wrangle_output,
-              n=n,
-              **_clean_kwargs(kwargs)
-            )
-            if n and n > 1 and len(output) == n:
-              # Distribute: each output column gets the nth match
-              _distribute_n_matches(data)
-            elif n and n > 1 and len(output) > 1:
-              raise ValueError(
-                f'When n > 1 and multiple output columns are provided, the number '
-                f'of output columns ({len(output)}) must equal n ({n}).'
+          if _wrangle_cols:
+            if all([col in model_columns for col in _wrangle_cols]):
+              data = _lookup(
+                df[input].values.tolist(),
+                model_id,
+                columns=_wrangle_cols,
+                n=n,
+                **_clean_kwargs(kwargs)
               )
-            else:
-              df[output] = data
-          elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):
-            # User specified no columns from the wrangle
-            data = _lookup(
-              df[input].values.tolist(),
-              model_id,
-              n=n,
-              **_clean_kwargs(kwargs)
-            )
-            if n and n > 1 and len(output) == n:
-              # Distribute: each output column gets the nth match
-              _distribute_n_matches(data)
-            elif n and n > 1 and len(output) > 1:
-              raise ValueError(
-                f'When n > 1 and multiple output columns are provided, the number '
-                f'of output columns ({len(output)}) must equal n ({n}).'
+              if n and n > 1 and len(_out_cols) == n:
+                # Distribute: each output column gets the nth match
+                _distribute_n_matches(data)
+              elif n and n > 1 and len(_out_cols) > 1:
+                raise ValueError(
+                  f'When n > 1 and multiple output columns are provided, the number '
+                  f'of output columns ({len(_out_cols)}) must equal n ({n}).'
+                )
+              else:
+                df[_out_cols] = data
+
+            elif not any([col in model_columns for col in _wrangle_cols]):
+              data = _lookup(
+                df[input].values.tolist(),
+                model_id,
+                n=n,
+                **_clean_kwargs(kwargs)
               )
+              if n and n > 1 and len(_out_cols) == n:
+                # Distribute: each output column gets the nth match
+                _distribute_n_matches(data)
+              elif n and n > 1 and len(_out_cols) > 1:
+                raise ValueError(
+                  f'When n > 1 and multiple output columns are provided, the number '
+                  f'of output columns ({len(_out_cols)}) must equal n ({n}).'
+                )
+              else:
+                for out in _out_cols:
+                  df[out] = data
             else:
-              for out in output:
-                df[out] = data
-          else:
-            # User specified a mixture of unrecognized columns and columns from the wrangle
-            raise ValueError('Lookup may only contain all named or unnamed columns.')
-                  
+              raise ValueError('Lookup may only contain all named or unnamed columns.')
+
         elif lookup_mode == 'by_dataframe':
-          # Optimized - lookup unique values once, then map to all rows  
-          unique_values = df[input].unique()  
-            
-          if all([col in metadata["settings"]["columns"] for col in wrangle_output]):  
-            # User specified all columns from the wrangle  
-            unique_data = _lookup(  
-              unique_values.tolist(),  
-              model_id,  
-              columns=wrangle_output,  
-              **_clean_kwargs(kwargs)  
-            )  
-                
-            # Create mapping from values to results  
-            value_to_result = dict(zip(unique_values, unique_data))  
-                
-            # Map results back to all rows - extract correct values  
-            if len(output) == 1:  
-              df[output[0]] = df[input].map(  
-                lambda x: value_to_result.get(x, [])[0] if x in value_to_result and value_to_result[x] else ""  
-              )  
-            else:  
-              for i, out_col in enumerate(output):  
-                df[out_col] = df[input].map(  
-                  lambda x: value_to_result.get(x, [])[i] if x in value_to_result and len(value_to_result[x]) > i else ""  
-                )  
-                        
-          elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):  
-            # User specified no columns from the wrangle  
-            unique_data = _lookup(  
-            unique_values.tolist(),  
-            model_id, 
-            **_clean_kwargs(kwargs)
-            )  
+          unique_values = df[input].unique()
+          if _wrangle_cols:
+            if all([col in model_columns for col in _wrangle_cols]):
+              unique_data = _lookup(
+                unique_values.tolist(),
+                model_id,
+                columns=_wrangle_cols,
+                **_clean_kwargs(kwargs)
+              )
+              value_to_result = dict(zip(unique_values, unique_data))
+              if len(_out_cols) == 1:
+                df[_out_cols[0]] = df[input].map(
+                  lambda x: value_to_result.get(x, [])[0] if x in value_to_result and value_to_result[x] else ""
+                )
+              else:
+                for i, out_col in enumerate(_out_cols):
+                  df[out_col] = df[input].map(
+                    lambda x: value_to_result.get(x, [])[i] if x in value_to_result and len(value_to_result[x]) > i else ""
+                  )
+            elif not any([col in model_columns for col in _wrangle_cols]):
+              unique_data = _lookup(
+                unique_values.tolist(),
+                model_id,
+                **_clean_kwargs(kwargs)
+              )
+              value_to_result = dict(zip(unique_values, unique_data))
+              for out in _out_cols:
+                df[out] = df[input].map(lambda x: value_to_result.get(x, {}))
+            else:
+              # User specified a mixture of unrecognized columns and columns from the wrangle
+              raise ValueError('Lookup may only contain all named or unnamed columns.')
 
-            # Create mapping from values to results (preserve full dict as in by_row)
-            value_to_result = dict(zip(unique_values, unique_data))
-
-            # Map results back to all rows - output is the full dict as in by_row
-            for out in output:
-              df[out] = df[input].map(lambda x: value_to_result.get(x, {}))
-          else:  
-            # User specified a mixture of unrecognized columns and columns from the wrangle  
-            raise ValueError('Lookup may only contain all named or unnamed columns.')
-            
-        elif lookup_mode == 'by_matrix':   
+        elif lookup_mode == 'by_matrix':
           # Get matrix variables and permutations  
           matrix_vars = kwargs.get('matrix_variables', [])  
           if not matrix_vars:  
@@ -1130,48 +1124,40 @@ def lookup(
               # Get unique values for this permutation  
               perm_values = df.loc[mask, input].unique()  
                     
-              if all([col in metadata["settings"]["columns"] for col in wrangle_output]):  
-                # User specified all columns from the wrangle  
-                perm_data = _lookup(  
-                  perm_values.tolist(),  
-                  model_id,  
-                  columns=wrangle_output,  
-                  **_clean_kwargs(kwargs)  
-                )  
-                        
-                # Create mapping for this permutation  
-                value_to_result = dict(zip(perm_values, perm_data))  
-                        
-                # Apply results to matching rows - extract correct values  
-                if len(output) == 1:  
-                  df.loc[mask, output[0]] = df.loc[mask, input].map(  
-                    lambda x: value_to_result.get(x, [])[0] if x in value_to_result and value_to_result[x] else ""  
-                  )  
-                else:  
-                  for i, out_col in enumerate(output):  
-                    df.loc[mask, out_col] = df.loc[mask, input].map(  
-                      lambda x: value_to_result.get(x, [])[i] if x in value_to_result and len(value_to_result[x]) > i else ""  
-                    )  
-                                
-              elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):  
-                # User specified no columns from the wrangle  
-                perm_data = _lookup(  
-                  perm_values.tolist(),  
-                  model_id,  
-                  **_clean_kwargs(kwargs)  
-                )  
-                        
-                # Create mapping for this permutation  
-                value_to_result = dict(zip(perm_values, perm_data))  
-                        
-                # Apply results to matching rows - extract correct values  
-                for out in output:
-                  df.loc[mask, out] = df.loc[mask, input].map(lambda x: value_to_result.get(x, {}))
-              else:  
-                # User specified a mixture of unrecognized columns and columns from the wrangle  
-                raise ValueError('Lookup may only contain all named or unnamed columns.')
+              if _wrangle_cols:
+                if all([col in model_columns for col in _wrangle_cols]):
+                  perm_data = _lookup(
+                    perm_values.tolist(),
+                    model_id,
+                    columns=_wrangle_cols,
+                    **_clean_kwargs(kwargs)
+                  )
+                  value_to_result = dict(zip(perm_values, perm_data))
+                  if len(_out_cols) == 1:
+                    df.loc[mask, _out_cols[0]] = df.loc[mask, input].map(
+                      lambda x: value_to_result.get(x, [])[0] if x in value_to_result and value_to_result[x] else ""
+                    )
+                  else:
+                    for i, out_col in enumerate(_out_cols):
+                      df.loc[mask, out_col] = df.loc[mask, input].map(
+                        lambda x: value_to_result.get(x, [])[i] if x in value_to_result and len(value_to_result[x]) > i else ""
+                      )
+                elif not any([col in model_columns for col in _wrangle_cols]):
+                  perm_data = _lookup(
+                    perm_values.tolist(),
+                    model_id,
+                    **_clean_kwargs(kwargs)
+                  )
+                  value_to_result = dict(zip(perm_values, perm_data))
+                  for out in _out_cols:
+                    df.loc[mask, out] = df.loc[mask, input].map(lambda x: value_to_result.get(x, {}))
+                else:
+                  raise ValueError('Lookup may only contain all named or unnamed columns.')
         else:
           raise ValueError(f"Invalid lookup_mode: {lookup_mode}. Must be 'by_row', 'by_dataframe', or 'by_matrix'")
+
+        for _key_col in _key_out_cols:
+          df[_key_col] = df[input].values
     else:
         raise ValueError('model_id is required for lookup')
     


### PR DESCRIPTION

## Summary

Two bugs in `train.lookup` write actions and the `lookup` wrangle are resolved.

---

## Bug 1 — `upsert` / `insert` / `update` destroyed columns not in the incoming DataFrame

### Problem

When running any non-overwrite action with a DataFrame that only contains a *subset* of the model's columns, the columns absent from the DataFrame were silently deleted from the model.

```python
# Model has: Key, Schema, Mapping
# User only wants to update Mapping for one row — Schema is intentionally omitted

wrangles.recipe.run("""
write:
  - train.lookup:
      model_id: <model_id>
      action: upsert
      variant: key
""", dataframe=pd.DataFrame({'Key': ['apple'], 'Mapping': ['green']}))

# BEFORE (bug): model now has Key, Mapping only — Schema was dropped
# AFTER (fix):  model still has Key, Schema, Mapping — Schema preserved
```

The same issue existed for `insert` (new rows had `NaN` in unspecified columns, which broke JSON serialisation) and `update`.

### Root cause

**`wrangles/connectors/train.py` — UPSERT branch (~line 345):**

```python
# BEFORE — slices the existing data to only the incoming columns
existing_df = existing_df_all[requested_cols]   # ← BUG
merged_df   = existing_df.copy()                # merge base is now partial
```

```python
# AFTER — uses ALL existing columns as the merge base
merged_df = existing_df_all.copy()
# New columns introduced by the upsert are added with '' for existing rows
new_cols = [c for c in requested_cols if c not in merged_df.columns]
for col in new_cols:
    merged_df[col] = ''
```

The same `existing_df` reference was also used in the non-key no-`MatchingColumns` path (`_pd.concat([existing_df, df])`), which is now `existing_df_all`.

For INSERT, `_pd.concat` can produce `NaN` for columns absent from new rows. Added `merged_df = merged_df.fillna('')` before building the JSON payload.

> `upsert` is the only action that accepts new columns — it treats them as an additive schema extension.  
> `insert` and `update` still raise `ValueError` when a column that doesn't exist in the model is supplied.

---

## Bug 2 — `Key` column could not be requested as output in a `lookup` wrangle

### Problem

```yaml
wrangles:
  - lookup:
      input: fruit
      output: Key           # wanted the key string back
      model_id: <model_id>
```

**Case A — `output: Key` only**  
`Key` is not in `metadata["settings"]["columns"]` (which lists only value columns).  
The routing fell into the "no named columns" branch, treating `Key` as an arbitrary output name and returning a full dict of all columns instead of the key string.

**Case B — `output: [Key, Schema]`**  
`Key` not in settings cols, `Schema` is → routing hit the "mixture" branch → `ValueError: Lookup may only contain all named or unnamed columns.`

### Root cause

**`wrangles/recipe_wrangles/main.py` — `lookup()` (~line 980):**

```python
# routing check used wrangle_output directly, which included 'Key'
if all([col in metadata["settings"]["columns"] for col in wrangle_output]):
    ...
elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):
    ...
else:
    raise ValueError('Lookup may only contain all named or unnamed columns.')
```

### Fix

Before the routing check, `Key` entries are extracted from `wrangle_output`. The routing and API call use only the remaining non-Key columns. After the lookup completes, any requested `Key` output column is populated directly from the input values.

```python
# Strip 'Key' from routing — it echoes the input, not a model value column
_key_indices  = {i for i, col in enumerate(wrangle_output) if col == 'Key'}
_key_out_cols = [output[i] for i in sorted(_key_indices)]
_wrangle_cols = [col for i, col in enumerate(wrangle_output) if i not in _key_indices]
_out_cols     = [col for i, col in enumerate(output)         if i not in _key_indices]

# ... (routing + API call using _wrangle_cols / _out_cols) ...

# Populate Key output column(s) with the input key values
for _key_col in _key_out_cols:
    df[_key_col] = df[input].values
```

Applied consistently across `by_row`, `by_dataframe`, and `by_matrix` modes.

### Examples after fix

```python
import wrangles, pandas as pd

df = pd.DataFrame({'fruit': ['apple', 'banana', 'cherry']})

# Case A — Key only
result = wrangles.recipe.run("""
wrangles:
  - lookup:
      input: fruit
      output: Key
      model_id: <model_id>
""", dataframe=df)
# result['Key'] → ['apple', 'banana', 'cherry']  ✓

# Case B — Key + value column together
result = wrangles.recipe.run("""
wrangles:
  - lookup:
      input: fruit
      output:
        - Key
        - Schema
      model_id: <model_id>
""", dataframe=df)
# result['Key']    → ['apple', 'banana', 'cherry']  ✓
# result['Schema'] → ['fruit', 'fruit',  'fruit']   ✓
```

---

