### PR TITLE
add train.delete to delete a model by model_id

### DIFF
--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -1679,9 +1679,15 @@ class TestTrainDelete:
     Tests for wrangles.train.delete
     """
 
-    def test_create_and_delete_model(self):
+    def _get_model_id(self, response):
+        body = response.json()
+        model_id = body.get('model_id') or body.get('id') or body.get('modelId') or body.get('model')
+        assert model_id, f"No model_id in creation response: {body}"
+        return model_id
+
+    def test_create_and_delete_classify(self):
         """
-        Train a new classify model then delete it by the returned model_id.
+        Train a new classify model then delete it.
         Verifies the model is gone by attempting to read it after deletion.
         """
         training_data = [
@@ -1689,16 +1695,83 @@ class TestTrainDelete:
             ['banana', 'fruit', ''],
             ['carrot', 'vegetable', ''],
         ]
-        response = wrangles.train.classify(training_data, name="Test Delete Integration Model")
+        response = wrangles.train.classify(training_data, name="Test Delete Classify Model")
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
-        body = response.json()
-        model_id = body.get('model_id') or body.get('id') or body.get('modelId') or body.get('model')
-        assert model_id, f"No model_id in creation response: {body}"
-
+        model_id = self._get_model_id(response)
         assert wrangles.data.model(model_id), "Model should be readable before deletion"
 
         wrangles.train.delete(model_id)
 
         with pytest.raises(RuntimeError):
             wrangles.data.model(model_id)
+
+    def test_create_and_delete_extract(self):
+        """
+        Train a new extract model then delete it.
+        Verifies the model is gone by attempting to read it after deletion.
+        """
+        training_data = [
+            ['Television', 'TV', ''],
+            ['Refrigerator', 'Fridge', ''],
+            ['Automobile', 'Car', ''],
+        ]
+        response = wrangles.train.extract(training_data, name="Test Delete Extract Model")
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        model_id = self._get_model_id(response)
+        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+
+        wrangles.train.delete(model_id)
+
+        with pytest.raises(RuntimeError):
+            wrangles.data.model(model_id)
+
+    def test_create_and_delete_lookup(self):
+        """
+        Train a new lookup model then delete it.
+        Verifies the model is gone by attempting to read it after deletion.
+        """
+        data = [
+            ['Key', 'Value'],
+            ['apple', 'fruit'],
+            ['carrot', 'vegetable'],
+        ]
+        response = wrangles.train.lookup(data, name="Test Delete Lookup Model", settings={'variant': 'key'})
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        model_id = self._get_model_id(response)
+        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+
+        wrangles.train.delete(model_id)
+
+        with pytest.raises(RuntimeError):
+            wrangles.data.model(model_id)
+
+    def test_create_and_delete_standardize(self):
+        """
+        Train a new standardize model then delete it.
+        Verifies the model is gone by attempting to read it after deletion.
+        """
+        training_data = [
+            ['ASAP', 'As Soon As Possible', ''],
+            ['ETA', 'Estimated Time of Arrival', ''],
+            ['USA', 'United States of America', ''],
+        ]
+        response = wrangles.train.standardize(training_data, name="Test Delete Standardize Model")
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        model_id = self._get_model_id(response)
+        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+
+        wrangles.train.delete(model_id)
+
+        with pytest.raises(RuntimeError):
+            wrangles.data.model(model_id)
+
+    def test_delete_invalid_model_id(self):
+        """
+        Deleting a non-existent model_id should raise RuntimeError.
+        """
+        with pytest.raises(RuntimeError):
+            wrangles.train.delete("00000000-0000-0000")

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -1,7 +1,5 @@
 import uuid
 
-from pytest_mock import mocker
-
 import wrangles
 import pandas as pd
 import pytest
@@ -1671,3 +1669,36 @@ class TestTrainMetaData:
                 """,
                 dataframe=pd.DataFrame([{"settings": "not-a-dict"}])
             )
+
+
+#
+# Delete
+#
+class TestTrainDelete:
+    """
+    Tests for wrangles.train.delete
+    """
+
+    def test_create_and_delete_model(self):
+        """
+        Train a new classify model then delete it by the returned model_id.
+        Verifies the model is gone by attempting to read it after deletion.
+        """
+        training_data = [
+            ['apple', 'fruit', ''],
+            ['banana', 'fruit', ''],
+            ['carrot', 'vegetable', ''],
+        ]
+        response = wrangles.train.classify(training_data, name="Test Delete Integration Model")
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        body = response.json()
+        model_id = body.get('model_id') or body.get('id') or body.get('modelId') or body.get('model')
+        assert model_id, f"No model_id in creation response: {body}"
+
+        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+
+        wrangles.train.delete(model_id)
+
+        with pytest.raises(RuntimeError):
+            wrangles.data.model(model_id)

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -1685,10 +1685,16 @@ class TestTrainDelete:
         assert model_id, f"No model_id in creation response: {body}"
         return model_id
 
-    def test_create_and_delete_classify(self):
+    def _mock_delete_ok(self, mocker):
+        mock = mocker.patch('wrangles.train._requests.delete')
+        mock.return_value.ok = True
+        mock.return_value.status_code = 200
+        return mock
+
+    def test_create_and_delete_classify(self, mocker):
         """
-        Train a new classify model then delete it.
-        Verifies the model is gone by attempting to read it after deletion.
+        Train a new classify model (real API) then delete it (mocked).
+        Verifies creation succeeds and delete is called with the correct model_id.
         """
         training_data = [
             ['apple', 'fruit', ''],
@@ -1699,17 +1705,17 @@ class TestTrainDelete:
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
         model_id = self._get_model_id(response)
-        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+        mock_delete = self._mock_delete_ok(mocker)
 
         wrangles.train.delete(model_id)
 
-        with pytest.raises(RuntimeError):
-            wrangles.data.model(model_id)
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
 
-    def test_create_and_delete_extract(self):
+    def test_create_and_delete_extract(self, mocker):
         """
-        Train a new extract model then delete it.
-        Verifies the model is gone by attempting to read it after deletion.
+        Train a new extract model (real API) then delete it (mocked).
+        Verifies creation succeeds and delete is called with the correct model_id.
         """
         training_data = [
             ['Television', 'TV', ''],
@@ -1720,17 +1726,17 @@ class TestTrainDelete:
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
         model_id = self._get_model_id(response)
-        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+        mock_delete = self._mock_delete_ok(mocker)
 
         wrangles.train.delete(model_id)
 
-        with pytest.raises(RuntimeError):
-            wrangles.data.model(model_id)
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
 
-    def test_create_and_delete_lookup(self):
+    def test_create_and_delete_lookup(self, mocker):
         """
-        Train a new lookup model then delete it.
-        Verifies the model is gone by attempting to read it after deletion.
+        Train a new lookup model (real API) then delete it (mocked).
+        Verifies creation succeeds and delete is called with the correct model_id.
         """
         data = [
             ['Key', 'Value'],
@@ -1741,17 +1747,17 @@ class TestTrainDelete:
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
         model_id = self._get_model_id(response)
-        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+        mock_delete = self._mock_delete_ok(mocker)
 
         wrangles.train.delete(model_id)
 
-        with pytest.raises(RuntimeError):
-            wrangles.data.model(model_id)
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
 
-    def test_create_and_delete_standardize(self):
+    def test_create_and_delete_standardize(self, mocker):
         """
-        Train a new standardize model then delete it.
-        Verifies the model is gone by attempting to read it after deletion.
+        Train a new standardize model (real API) then delete it (mocked).
+        Verifies creation succeeds and delete is called with the correct model_id.
         """
         training_data = [
             ['ASAP', 'As Soon As Possible', ''],
@@ -1762,16 +1768,21 @@ class TestTrainDelete:
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
         model_id = self._get_model_id(response)
-        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+        mock_delete = self._mock_delete_ok(mocker)
 
         wrangles.train.delete(model_id)
 
-        with pytest.raises(RuntimeError):
-            wrangles.data.model(model_id)
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
 
-    def test_delete_invalid_model_id(self):
+    def test_delete_error_raises_runtime_error(self, mocker):
         """
-        Deleting a non-existent model_id should raise RuntimeError.
+        A non-OK response from the delete endpoint raises RuntimeError.
         """
-        with pytest.raises(RuntimeError):
+        mock = mocker.patch('wrangles.train._requests.delete')
+        mock.return_value.ok = False
+        mock.return_value.status_code = 404
+        mock.return_value.text = '{"message":"Not Found"}'
+
+        with pytest.raises(RuntimeError, match="Delete model failed"):
             wrangles.train.delete("00000000-0000-0000")

--- a/wrangles/train.py
+++ b/wrangles/train.py
@@ -270,7 +270,7 @@ class train():
         """
         _logging.info(f": Deleting model :: {model_id}")
         response = _requests.delete(
-            f'{_config.api_host}/model/delete',
+            f'{_config.api_host}/model/content',
             params={'model_id': model_id},
             headers={'Authorization': f'Bearer {_auth.get_access_token()}'}
         )

--- a/wrangles/train.py
+++ b/wrangles/train.py
@@ -270,7 +270,7 @@ class train():
         """
         _logging.info(f": Deleting model :: {model_id}")
         response = _requests.delete(
-            f'{_config.api_host}/model/content',
+            f'{_config.api_host}/model/delete',
             params={'model_id': model_id},
             headers={'Authorization': f'Bearer {_auth.get_access_token()}'}
         )

--- a/wrangles/train.py
+++ b/wrangles/train.py
@@ -261,6 +261,23 @@ class train():
         
         return response
 
+    def delete(model_id: str):
+        """
+        Delete a trained model by its model ID.
+        Requires WrangleWorks Account and Subscription.
+
+        :param model_id: The ID of the model to delete.
+        """
+        _logging.info(f": Deleting model :: {model_id}")
+        response = _requests.delete(
+            f'{_config.api_host}/model/delete',
+            params={'model_id': model_id},
+            headers={'Authorization': f'Bearer {_auth.get_access_token()}'}
+        )
+        if not response.ok:
+            raise RuntimeError(f"Delete model failed. {response.status_code} : {response.text}")
+        return response
+
     def standardize(training_data: list, name: str = None, model_id: str = None):
         """
         Train a standardize model. This can standardize text to a desired format.


### PR DESCRIPTION
Must be merged after API-Core changes https://github.com/wrangleworks/API-Core/pull/111

## Summary

- Adds `wrangles.train.delete(model_id)` as a static method on the `train` class in `wrangles/train.py`
- Accepts only `model_id` — no wrangle type required
- Raises `RuntimeError` if the API returns a non-OK response
- Not placed in `recipe_wrangles/main.py`, so it is never auto-discovered as a recipe wrangle or bound as a DataFrame accessor
