### PR TITLE
Fix: evaluate if condition before column validatio

### DIFF
--- a/tests/recipes/test_wrangles.py
+++ b/tests/recipes/test_wrangles.py
@@ -565,6 +565,59 @@ class TestIf:
         assert df['should_be_logged'][0] == 'VALUE'  
         assert 'should_not_be_logged' not in df.columns
 
+    def test_if_false_with_missing_input_column(self):
+        """
+        Test that a wrangle with a false if condition does not
+        raise a KeyError when its input column doesn't exist.
+        Column validation must not run before the if check.
+        """
+        df = wrangles.recipe.run(
+            """
+            read:
+            - test:
+                rows: 1
+                values:
+                    header: value
+            wrangles:
+            - merge.coalesce:
+                if: '"New_Column" in columns'
+                input:
+                  - New_Column
+                  - header
+                output: My Output
+            """
+        )
+        assert "My Output" not in df.columns
+
+    def test_if_columns_check_then_conditional_wrangle(self):
+        """
+        Test the full pattern from issue #765: first wrangle creates a
+        column conditionally, second wrangle uses that column only if it
+        was created — both guarded by if conditions checking 'columns'.
+        """
+        df = wrangles.recipe.run(
+            """
+            read:
+            - test:
+                rows: 1
+                values:
+                    header: value
+            wrangles:
+            - create.column:
+                if: '"NOT THERE" in columns'
+                output: New_Column
+                value: This column is new
+
+            - merge.coalesce:
+                if: '"New_Column" in columns'
+                input:
+                  - New_Column
+                  - header
+                output: My Output
+            """
+        )
+        assert "My Output" not in df.columns
+
 class TestPositionInput:
     """
     Test using column indexes rather than names for input

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -444,6 +444,27 @@ def _execute_wrangles(
                 # Used to store parameters common to all wrangles - e.g where
                 common_params = {}
 
+                # If the action is conditional, check if it should be run
+                # before column validation or wildcard expansion so that
+                # wrangles can be skipped when their input columns don't exist
+                if (
+                    "if" in params and
+                    not _evaluate_conditional(
+                        params["if"],
+                        {
+                            **variables,
+                            **{
+                                "row_count": len(df),
+                                "column_count": len(df.columns),
+                                "columns": df.columns.tolist(),
+                                "df": df
+                            }
+                        }
+                    )
+                ):
+                    _logging.info(f": Wrangling :: {wrangle} skipped due to not passing the if statement.")
+                    continue
+
                 # Blacklist of Wrangles not to allow wildcards for
                 original_input = params.get('input') # Save for later reference
                 if (
@@ -479,25 +500,6 @@ def _execute_wrangles(
                         where_params= params.get('where_params', None),
                         preserve_index=True
                     )
-
-                # If the action is conditional, check if it should be run
-                if (
-                    "if" in params and
-                    not _evaluate_conditional(
-                        params["if"],
-                        {
-                            **variables,
-                            **{
-                                "row_count": len(df),
-                                "column_count": len(df.columns),
-                                "columns": df.columns.tolist(),
-                                "df": df
-                            }
-                        }
-                    )
-                ):
-                    _logging.info(f": Wrangling :: {wrangle} skipped due to not passing the if statement.")
-                    continue
 
                 # Add to common_params dict and remove from params
                 for key in ['where', 'where_params', 'if']:


### PR DESCRIPTION
# Fix: evaluate `if` condition before column validation (#765)


When a wrangle has an `if` condition that evaluates to `False`, it should be skipped entirely. Before this fix, **column validation and wildcard expansion ran first** — before the `if` check. This caused a `KeyError` (or similar validation error) when the skipped wrangle referenced columns that didn't exist yet.

A common real-world pattern that was broken:

```yaml
wrangles:
  # Step 1: conditionally create a column
  - create.column:
      if: '"source_col" in columns'
      output: New_Column
      value: hello

  # Step 2: use that column only if it was created — but column
  # validation fired here before the if check, raising KeyError
  - merge.coalesce:
      if: '"New_Column" in columns'
      input:
        - New_Column
        - fallback_col
      output: result
```

## Fix

Move the `if` condition evaluation to **before** column validation and wildcard expansion in `_execute_wrangles`. If the condition is `False` the wrangle is skipped immediately via `continue`, so no column look-up is ever attempted.

The change is a pure reorder — no logic was altered, only the position of the existing `if` block within the loop.

## Examples

### Before (broken)

```python
import wrangles

# KeyError: 'New_Column' — column validation runs before the if guard
df = wrangles.recipe.run("""
read:
  - test:
      rows: 1
      values:
          header: value
wrangles:
  - merge.coalesce:
      if: '"New_Column" in columns'
      input:
        - New_Column
        - header
      output: My Output
""")
```

### After (fixed)

```python
import wrangles

# if condition is False → wrangle is silently skipped, no error
df = wrangles.recipe.run("""
read:
  - test:
      rows: 1
      values:
          header: value
wrangles:
  - merge.coalesce:
      if: '"New_Column" in columns'
      input:
        - New_Column
        - header
      output: My Output
""")

assert "My Output" not in df.columns  # ✓ skipped cleanly
```

### Full conditional-chain pattern (also fixed)

```python
df = wrangles.recipe.run("""
read:
  - test:
      rows: 1
      values:
          header: value
wrangles:
  - create.column:
      if: '"NOT THERE" in columns'
      output: New_Column
      value: This column is new

  - merge.coalesce:
      if: '"New_Column" in columns'
      input:
        - New_Column
        - header
      output: My Output
""")

assert "My Output" not in df.columns  # ✓ both wrangles skipped cleanly
```
