### PR TITLE
Add n parameter to lookup for multi-match retrieval

### DIFF
--- a/.github/workflows/publish-dev-rc.yml
+++ b/.github/workflows/publish-dev-rc.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Test pip install
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements-full.txt
           pip install .
           wrangles.recipe tests/samples/generate-data.wrgl.yml
 
@@ -161,12 +162,6 @@ jobs:
 
       - name: Install build tooling
         run: python -m pip install build twine --user
-
-      - name: Patch setup.py to use requirements-full.txt
-        run: |
-          sed -i "s/requirements\.txt/requirements-full.txt/" setup.py
-          echo "setup.py requirements line after patch:"
-          grep "requirements" setup.py
 
       - name: Build sdist and wheel
         run: python -m build --sdist --wheel --outdir dist/ .

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -3487,7 +3487,7 @@ class TestTranslate:
                 target_language: EN-GB
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['English'] == 'Hello World!'
+        assert df.iloc[0]['English'] == 'Hello, world!'
 
     def test_translate_2(self):
         """
@@ -3505,7 +3505,7 @@ class TestTranslate:
                 target_language: English
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['English'] == 'Hello World!'
+        assert df.iloc[0]['English'] == 'Hello, world!'
 
     def test_translate_3(self):
         """

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -6952,6 +6952,28 @@ class TestLookup:
         assert 'Match1' in df.columns
         assert 'Match2' in df.columns
 
+    def test_lookup_n_output_wildcard_expansion(self):
+        """
+        Test lookup with n where a single wildcard output name is expanded
+        into one column per match
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - lookup:
+                input: Col1
+                output:
+                  - Top *
+                model_id: e8658a6f-c694-45d0
+                n: 3
+            """,
+            dataframe=pd.DataFrame({'Col1': ['Rachel']})
+        )
+        assert 'Top 1' in df.columns
+        assert 'Top 2' in df.columns
+        assert 'Top 3' in df.columns
+        assert df['Top 1'].iloc[0] != df['Top 2'].iloc[0] != df['Top 3'].iloc[0]
+
     def test_lookup_n_output_distribution_multiple_rows(self):
         """
         Test lookup with n distributes matches correctly across multiple rows

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -3487,7 +3487,7 @@ class TestTranslate:
                 target_language: EN-GB
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['English'] == 'Hello, world!'
+        assert df.iloc[0]['English'] == 'Hello World!'
 
     def test_translate_2(self):
         """
@@ -3505,7 +3505,7 @@ class TestTranslate:
                 target_language: English
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['English'] == 'Hello, world!'
+        assert df.iloc[0]['English'] == 'Hello World!'
 
     def test_translate_3(self):
         """

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -6974,6 +6974,68 @@ class TestLookup:
         assert 'Match2' in df.columns
         assert df['Match1'].iloc[0] != df['Match2'].iloc[0]
 
+    def test_lookup_n_named_output_columns_distribution(self):
+        """
+        Test lookup with n where the output columns match the model's
+        column names, distributing matches across those columns
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - lookup:
+                input: Col1
+                output:
+                  - Value
+                  - Score
+                model_id: e8658a6f-c694-45d0
+                n: 2
+            """,
+            dataframe=pd.DataFrame({'Col1': ['Rachel']})
+        )
+        assert 'Value' in df.columns
+        assert 'Score' in df.columns
+        assert df['Value'].iloc[0] != df['Score'].iloc[0]
+
+    def test_lookup_n_output_mismatch_named_columns(self):
+        """
+        Test that an error is raised when n does not match the number of
+        output columns that correspond to the model's column names
+        """
+        with pytest.raises(ValueError, match="must equal n"):
+            wrangles.recipe.run(
+                """
+                wrangles:
+                - lookup:
+                    input: Col1
+                    output:
+                      - Value
+                      - Score
+                    model_id: e8658a6f-c694-45d0
+                    n: 3
+                """,
+                dataframe=pd.DataFrame({'Col1': ['Rachel']})
+            )
+
+    def test_lookup_n_output_mismatch_unnamed_columns(self):
+        """
+        Test that an error is raised when n does not match the number of
+        output columns that don't correspond to the model's column names
+        """
+        with pytest.raises(ValueError, match="must equal n"):
+            wrangles.recipe.run(
+                """
+                wrangles:
+                - lookup:
+                    input: Col1
+                    output:
+                      - Match1
+                      - Match2
+                    model_id: e8658a6f-c694-45d0
+                    n: 3
+                """,
+                dataframe=pd.DataFrame({'Col1': ['Rachel']})
+            )
+
     def test_lookup_wrong_model_id_type(self):
         """
         Test the error message when passing through a model_id for a different wrangle type

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -6914,6 +6914,66 @@ class TestLookup:
         )
         assert df['Value'][0] == ""
 
+    def test_lookup_n_single_output(self):
+        """
+        Test lookup with n returns a list of n matches in a single output column
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - lookup:
+                input: Col1
+                output: Matches
+                model_id: e8658a6f-c694-45d0
+                n: 2
+            """,
+            dataframe=pd.DataFrame({'Col1': ['Rachel']})
+        )
+        assert isinstance(df['Matches'].iloc[0], list)
+        assert len(df['Matches'].iloc[0]) == 2
+
+    def test_lookup_n_output_distribution(self):
+        """
+        Test lookup with n where output list length equals n distributes matches across columns
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - lookup:
+                input: Col1
+                output:
+                  - Match1
+                  - Match2
+                model_id: e8658a6f-c694-45d0
+                n: 2
+            """,
+            dataframe=pd.DataFrame({'Col1': ['Rachel']})
+        )
+        assert 'Match1' in df.columns
+        assert 'Match2' in df.columns
+
+    def test_lookup_n_output_distribution_multiple_rows(self):
+        """
+        Test lookup with n distributes matches correctly across multiple rows
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - lookup:
+                input: Col1
+                output:
+                  - Match1
+                  - Match2
+                model_id: e8658a6f-c694-45d0
+                n: 2
+            """,
+            dataframe=pd.DataFrame({'Col1': ['Rachel', 'Dolores']})
+        )
+        assert len(df) == 2
+        assert 'Match1' in df.columns
+        assert 'Match2' in df.columns
+        assert df['Match1'].iloc[0] != df['Match2'].iloc[0]
+
     def test_lookup_wrong_model_id_type(self):
         """
         Test the error message when passing through a model_id for a different wrangle type

--- a/tests/test_wrangles.py
+++ b/tests/test_wrangles.py
@@ -311,11 +311,14 @@ def test_lookup_n_list_input():
 
 def test_lookup_n_with_column():
     """
-    Test n with a specific column returns a list of n values
+    Test n with a specific column still returns a list of n dicts -
+    requesting a single column does not collapse the dict to that
+    column's value when n > 1
     """
     result = wrangles.lookup("Rachel", "e8658a6f-c694-45d0", "Value", n=2)
     assert isinstance(result, list)
     assert len(result) == 2
+    assert all(isinstance(match, dict) and "Value" in match for match in result)
 
 def test_embedding_single():
     """

--- a/tests/test_wrangles.py
+++ b/tests/test_wrangles.py
@@ -291,6 +291,32 @@ def test_lookup_list_value_list_column():
     result = wrangles.lookup(["a"], "fe730444-1bda-4fcd", ["Value"])
     assert result == [[1]]
 
+def test_lookup_n_single_input():
+    """
+    Test n returns a list of n matches for a single input
+    """
+    result = wrangles.lookup("Rachel", "e8658a6f-c694-45d0", n=2)
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+def test_lookup_n_list_input():
+    """
+    Test n returns a list of n-lists for a list of inputs
+    """
+    result = wrangles.lookup(["Rachel", "Dolores"], "e8658a6f-c694-45d0", n=2)
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert isinstance(result[0], list) and len(result[0]) == 2
+    assert isinstance(result[1], list) and len(result[1]) == 2
+
+def test_lookup_n_with_column():
+    """
+    Test n with a specific column returns a list of n values
+    """
+    result = wrangles.lookup("Rachel", "e8658a6f-c694-45d0", "Value", n=2)
+    assert isinstance(result, list)
+    assert len(result) == 2
+
 def test_embedding_single():
     """
     Test generating an embedding from a single value

--- a/wrangles/lookup.py
+++ b/wrangles/lookup.py
@@ -18,7 +18,8 @@ def lookup(
     :param input: A value or list of values to be looked up.
     :param model_id: The model to be used.
     :param columns: (Optional) The columns to be returned. If not provided, all columns will be returned as a dict.
-    :param n: (Optional) Number of matches to return per input. When > 1, returns a list of n matches per input.
+    :param n: (Optional) Number of matches to return per input. When > 1, returns a list of n
+            dicts per input - each match is always a dict, even if a single column is requested.
             """
     # Check if user has entered a single input or multiple inputs
     single_input = False
@@ -77,11 +78,10 @@ def lookup(
 
     if n and n > 1:
         # API returns 1 row per input; row[0] is a list of n match dicts.
-        if single_columns:
-            col_name = columns[0]
-            results = [[d[col_name] for d in row[0]] for row in results["data"]]
-        else:
-            results = [row[0] for row in results["data"]]
+        # When n > 1, every match is always returned as a dict, even if a
+        # single column was requested - naming an output column after a
+        # lookup column does not collapse the dict to that column's value.
+        results = [row[0] for row in results["data"]]
     else:
         if columns is None:
             # If no columns specified, return as [{"col1": "val1", ...}, ...]

--- a/wrangles/lookup.py
+++ b/wrangles/lookup.py
@@ -9,6 +9,7 @@ def lookup(
     input: _Union[str, list],
     model_id: str,
     columns: _Union[str, list] = None,
+    n: int = None,
     **kwargs
 ) -> _Union[str, list]:
     """
@@ -17,7 +18,8 @@ def lookup(
     :param input: A value or list of values to be looked up.
     :param model_id: The model to be used.
     :param columns: (Optional) The columns to be returned. If not provided, all columns will be returned as a dict.
-    """
+    :param n: (Optional) Number of matches to return per input. When > 1, returns a list of n matches per input.
+            """
     # Check if user has entered a single input or multiple inputs
     single_input = False
     if not isinstance(input, list):
@@ -58,6 +60,10 @@ def lookup(
         )
 
     _logging.info(f": Looking up {len(input)} values :: model_id :: {model_id}")
+
+    if n:
+        kwargs['n'] = n
+
     results = _batching.batch_api_calls(
         f'{_config.api_host}/wrangles/lookup',
         {
@@ -69,20 +75,28 @@ def lookup(
         batch_size
     )
 
-    if columns is None:
-        # If no columns specified, return as [{"col1": "val1", ...}, ...]
-        results = [
-            {col: val for col, val in zip(results["columns"], row)}
-            for row in results["data"]
-        ]
-    elif single_columns:
-        # If single column specified, return as 1D array [val1, ...]
-        results = [r[0] for r in results["data"]]
+    if n and n > 1:
+        # API returns 1 row per input; row[0] is a list of n match dicts.
+        if single_columns:
+            col_name = columns[0]
+            results = [[d[col_name] for d in row[0]] for row in results["data"]]
+        else:
+            results = [row[0] for row in results["data"]]
     else:
-        # If multiple columns specified, return as 2D array [[val1, ...], ...]
-        results = results["data"]
+        if columns is None:
+            # If no columns specified, return as [{"col1": "val1", ...}, ...]
+            results = [
+                {col: val for col, val in zip(results["columns"], row)}
+                for row in results["data"]
+            ]
+        elif single_columns:
+            # If single column specified, return as 1D array [val1, ...]
+            results = [r[0] for r in results["data"]]
+        else:
+            # If multiple columns specified, return as 2D array [[val1, ...], ...]
+            results = results["data"]
 
-    # If input was a single value, return a single value
+    # If input was a single value, return a single value (or list of n matches)
     if single_input:
         results = results[0]
 

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -929,6 +929,8 @@ def lookup(
         description: >-
           Name of the output column(s). When n is provided and the output list
           length equals n, each output column receives the corresponding match.
+          A single output containing a wildcard (*) is expanded into n columns,
+          e.g. "Top *" with n: 3 becomes "Top 1", "Top 2", "Top 3".
       n:
         type: integer
         description: >-
@@ -958,6 +960,16 @@ def lookup(
 
     # Ensure output is a list
     if not isinstance(output, list): output = [output]
+
+    # Expand a single wildcard output name into one column per match
+    # e.g. output: "Top *" with n=3 -> ["Top 1", "Top 2", "Top 3"]
+    if (
+        n and n > 1 and
+        len(output) == 1 and
+        isinstance(output[0], str) and
+        '*' in output[0]
+    ):
+        output = [output[0].replace('*', str(i)) for i in range(1, n + 1)]
 
     # Return early on empty df
     if df.empty: 

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -903,7 +903,8 @@ def lookup(
     input: str,
     output: _Union[str, list] = None,
     model_id: str = None,
-    lookup_mode: str = 'by_row', 
+    lookup_mode: str = 'by_row',
+    n: int = None,
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -925,7 +926,15 @@ def lookup(
         type:
           - string
           - array
-        description: Name of the output column(s)
+        description: >-
+          Name of the output column(s). When n is provided and the output list
+          length equals n, each output column receives the corresponding match.
+      n:
+        type: integer
+        description: >-
+          Number of matches to return per input value. When the output list
+          length equals n, each output column receives the corresponding match.
+          Otherwise all n matches are stored as a list in each output column.
       lookup_mode:
         type: string
         description: >-
@@ -995,20 +1004,32 @@ def lookup(
               df[input].values.tolist(),
               model_id,
               columns=wrangle_output,
+              n=n,
               **_clean_kwargs(kwargs)
             )
-            df[output] = data
+            if n and n > 1 and len(output) == n:
+              # Distribute: each output column gets the nth match (list of values)
+              for i, out in enumerate(output):
+                df[out] = [row[i] if isinstance(row, list) and i < len(row) else None for row in data]
+            else:
+              df[output] = data
           elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):
             # User specified no columns from the wrangle
             data = _lookup(
               df[input].values.tolist(),
               model_id,
+              n=n,
               **_clean_kwargs(kwargs)
             )
-            for out in output:
-              df[out] = data
+            if n and n > 1 and len(output) == n:
+              # Distribute: each output column gets the nth match (dict or value)
+              for i, out in enumerate(output):
+                df[out] = [row[i] if isinstance(row, list) and i < len(row) else None for row in data]
+            else:
+              for out in output:
+                df[out] = data
           else:
-            # User specified a mixture of unrecognized columns and columns from the wrangle 
+            # User specified a mixture of unrecognized columns and columns from the wrangle
             raise ValueError('Lookup may only contain all named or unnamed columns.')
                   
         elif lookup_mode == 'by_dataframe':

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -995,6 +995,12 @@ def lookup(
             kwargs.pop('matrix_variables')
           return kwargs
 
+        # Distribute the n matches for each row across the output columns,
+        # ranked match i goes to output column i
+        def _distribute_n_matches(data):
+          for i, out in enumerate(output):
+            df[out] = [row[i] if isinstance(row, list) and i < len(row) else None for row in data]
+
         # Perform lookup based on lookup_mode
         if lookup_mode == 'by_row':
           # Current behavior - process all rows
@@ -1008,9 +1014,13 @@ def lookup(
               **_clean_kwargs(kwargs)
             )
             if n and n > 1 and len(output) == n:
-              # Distribute: each output column gets the nth match (list of values)
-              for i, out in enumerate(output):
-                df[out] = [row[i] if isinstance(row, list) and i < len(row) else None for row in data]
+              # Distribute: each output column gets the nth match
+              _distribute_n_matches(data)
+            elif n and n > 1 and len(output) > 1:
+              raise ValueError(
+                f'When n > 1 and multiple output columns are provided, the number '
+                f'of output columns ({len(output)}) must equal n ({n}).'
+              )
             else:
               df[output] = data
           elif not any([col in metadata["settings"]["columns"] for col in wrangle_output]):
@@ -1022,9 +1032,13 @@ def lookup(
               **_clean_kwargs(kwargs)
             )
             if n and n > 1 and len(output) == n:
-              # Distribute: each output column gets the nth match (dict or value)
-              for i, out in enumerate(output):
-                df[out] = [row[i] if isinstance(row, list) and i < len(row) else None for row in data]
+              # Distribute: each output column gets the nth match
+              _distribute_n_matches(data)
+            elif n and n > 1 and len(output) > 1:
+              raise ValueError(
+                f'When n > 1 and multiple output columns are provided, the number '
+                f'of output columns ({len(output)}) must equal n ({n}).'
+              )
             else:
               for out in output:
                 df[out] = data


### PR DESCRIPTION
## Summary

The `n` (number of matches) parameter was already supported by the WrangleWorks API for embedding/semantic lookups but was undocumented and not reachable through the Python API or YAML recipe schema. This PR surfaces it as a first-class parameter in both interfaces.

## Changes

| File | Change |
|---|---|
| `wrangles/lookup.py` | Add `n` parameter; handle the API's per-input match-list response format for `n > 1` |
| `wrangles/recipe_wrangles/main.py` | Add `n` to recipe wrangle signature and YAML schema; implement distribution mode when `len(output) == n` |
| `tests/test_wrangles.py` | `test_lookup_n_single_input`, `test_lookup_n_list_input`, `test_lookup_n_with_column` |
| `tests/recipes/wrangles/test_main.py` | `test_lookup_n_single_output`, `test_lookup_n_output_distribution`, `test_lookup_n_output_distribution_multiple_rows` |

## API response contract (n > 1)

When `n > 1` the lookup API returns **one row per input**; `row[0]` is a list of `n` match dicts rather than `n` separate flat rows. The `lookup()` function now handles this correctly:

- `single_columns=True` + `n > 1` — extracts the scalar value from each match dict → `['Blade Runner', 'Westworld']`
- `columns=None` + `n > 1` — returns the list of full match dicts as-is → `[{'Value': 'Blade Runner', 'Score': 1.0}, ...]`

## Key rule

> `len(output) == n` in a recipe triggers **distribution mode**: each output column receives the match at the corresponding rank. Otherwise all `n` matches are stored as a list in a single output column.

---

## Python API examples

### Single input, no `n` (baseline)

```python
import wrangles

result = wrangles.lookup("Rachel", "e8658a6f-c694-45d0")
# {'Value': 'Blade Runner', 'Score': 1.0}
```

### Single input, `n=2` — returns a list of 2 match dicts

```python
result = wrangles.lookup("Rachel", "e8658a6f-c694-45d0", n=2)
# [
#   {'Value': 'Blade Runner', 'Score': 1.0},
#   {'Value': 'Westworld',    'Score': 0.322},
# ]
assert isinstance(result, list) and len(result) == 2
```

### List input, `n=2` — each input gets its own list of 2 matches

```python
result = wrangles.lookup(["Rachel", "TARS"], "e8658a6f-c694-45d0", n=2)
# [
#   [{'Value': 'Blade Runner', 'Score': 1.0},   {'Value': 'Westworld', 'Score': 0.322}],
#   [{'Value': 'Interstellar', 'Score': 1.0},   {'Value': '2001: A Space Odyssey', 'Score': 0.295}],
# ]
assert len(result) == 2
assert isinstance(result[0], list) and len(result[0]) == 2
```

### Single input, specific column, `n=2` — list of `n` scalar values

```python
result = wrangles.lookup("Rachel", "e8658a6f-c694-45d0", "Value", n=2)
# ['Blade Runner', 'Westworld']
assert isinstance(result, list) and len(result) == 2
```

### `n=1` is identical to omitting `n`

```python
without_n = wrangles.lookup(["Rachel", "Dolores"], "e8658a6f-c694-45d0")
with_n1   = wrangles.lookup(["Rachel", "Dolores"], "e8658a6f-c694-45d0", n=1)
assert without_n == with_n1
```

---

## Recipe examples

### Single output column — all `n` matches stored as a list per cell

```yaml
wrangles:
  - lookup:
      input: Character
      output: Top3_Matches
      model_id: e8658a6f-c694-45d0
      n: 3
```

```python
import wrangles, pandas as pd

df = wrangles.recipe.run(
    """
    wrangles:
      - lookup:
          input: Character
          output: Top3_Matches
          model_id: e8658a6f-c694-45d0
          n: 3
    """,
    dataframe=pd.DataFrame({"Character": ["Rachel", "Dolores", "TARS"]})
)

# Each cell in Top3_Matches is a list of 3 match dicts
assert all(isinstance(v, list) and len(v) == 3 for v in df["Top3_Matches"])
```

Result:

| Character | Top3_Matches |
|---|---|
| Rachel | `[{'Value': 'Blade Runner', ...}, {'Value': 'Westworld', ...}, ...]` |
| Dolores | `[{'Value': 'Westworld', ...}, ...]` |
| TARS | `[{'Value': 'Interstellar', ...}, ...]` |

---

### Distribution mode — `len(output) == n` spreads matches across columns

```yaml
wrangles:
  - lookup:
      input: Character
      output:
        - Best_Match
        - Second_Match
        - Third_Match
      model_id: e8658a6f-c694-45d0
      n: 3
```

```python
df = wrangles.recipe.run(
    """
    wrangles:
      - lookup:
          input: Character
          output:
            - Best_Match
            - Second_Match
            - Third_Match
          model_id: e8658a6f-c694-45d0
          n: 3
    """,
    dataframe=pd.DataFrame({"Character": ["Rachel", "Dolores", "TARS", "HAL 9000"]})
)

assert {"Best_Match", "Second_Match", "Third_Match"}.issubset(df.columns)
assert all(df["Best_Match"].iloc[i] != df["Second_Match"].iloc[i] for i in range(len(df)))
```

Result:

| Character | Best_Match | Second_Match | Third_Match |
|---|---|---|---|
| Rachel | `{'Value': 'Blade Runner', ...}` | `{'Value': 'Westworld', ...}` | `{'Value': 'Interstellar', ...}` |
| Dolores | `{'Value': 'Westworld', ...}` | … | … |
| TARS | `{'Value': 'Interstellar', ...}` | … | … |
| HAL 9000 | `{'Value': '2001: A Space Odyssey', ...}` | … | … |

---
