### PR TITLE
Fix DataFrame accessor mutating original on assignment

### DIFF
--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1,0 +1,49 @@
+import pandas as pd
+import pytest
+from wrangles.dataframe import DataFrame
+
+
+class TestWranglesAccessor:
+    """Tests for the .wrangles DataFrame accessor (issue #873)."""
+
+    def test_select_sample_does_not_mutate_original(self):
+        df = DataFrame({'col': range(20)})
+        df_sample = df.wrangles.select.sample(rows=5)
+        assert len(df) == 20
+        assert len(df_sample) == 5
+
+    def test_select_sample_returns_independent_object(self):
+        df = DataFrame({'col': range(20)})
+        df_sample = df.wrangles.select.sample(rows=5)
+        assert df is not df_sample
+
+    def test_convert_case_does_not_mutate_original(self):
+        df = DataFrame({'name': ['alice', 'bob', 'carol']})
+        df_upper = df.wrangles.convert.case(input='name', case='upper')
+        assert df['name'].tolist() == ['alice', 'bob', 'carol']
+        assert df_upper['name'].tolist() == ['ALICE', 'BOB', 'CAROL']
+
+    def test_convert_case_returns_independent_object(self):
+        df = DataFrame({'name': ['alice', 'bob']})
+        df_upper = df.wrangles.convert.case(input='name', case='upper')
+        assert df is not df_upper
+
+    def test_split_dictionary_does_not_mutate_original(self):
+        df = DataFrame({'data': [{'a': 1, 'b': 2}]})
+        df_split = df.wrangles.split.dictionary(input='data')
+        assert 'a' not in df.columns
+        assert 'a' in df_split.columns
+
+    def test_reassignment_updates_variable(self):
+        """Reassigning df = df.wrangles... should still work correctly."""
+        df = DataFrame({'col': ['hello', 'world']})
+        df = df.wrangles.convert.case(input='col', case='upper')
+        assert df['col'].tolist() == ['HELLO', 'WORLD']
+
+    def test_chained_calls_do_not_mutate_original(self):
+        """Multiple accessor calls on the same df should each leave it unchanged."""
+        df = DataFrame({'col': ['hello', 'world', 'foo', 'bar', 'baz']})
+        _ = df.wrangles.convert.case(input='col', case='upper')
+        _ = df.wrangles.select.sample(rows=2)
+        assert df['col'].tolist() == ['hello', 'world', 'foo', 'bar', 'baz']
+        assert len(df) == 5

--- a/wrangles/dataframe.py
+++ b/wrangles/dataframe.py
@@ -19,8 +19,7 @@ class _wrangles_accessor:
                 def make_method(func_name):
                     target_func = getattr(wrangle_module, func_name)
                     def method(self, *args, **kwargs):
-                        self._df.__init__(target_func(self._df, *args, **kwargs))
-                        return self._df
+                        return target_func(self._df.copy(), *args, **kwargs)
                     method.__doc__ = target_func.__doc__
                     return method
 
@@ -58,8 +57,7 @@ class _wrangles:
                 def make_method(func_name):
                     target_func = getattr(_recipe_wrangles.main, func_name)
                     def method(self, *args, **kwargs):
-                        self._df.__init__(target_func(self._df, *args, **kwargs))
-                        return self._df
+                        return target_func(self._df.copy(), *args, **kwargs)
                     method.__doc__ = target_func.__doc__
                     return method
 
@@ -139,8 +137,7 @@ class _read:
                 def make_method(func_name):
                     target_func = getattr(getattr(_connectors, func_name), 'read')
                     def method(self, *args, **kwargs):
-                        self._df.__init__(target_func(*args, **kwargs))
-                        return self._df
+                        return target_func(*args, **kwargs)
                     method.__doc__ = target_func.__doc__
                     return method
 
@@ -163,8 +160,7 @@ class _read:
         :param name: Name of the file to import
         :return: A Pandas dataframe of the imported data.
         """
-        self._df.__init__(_connectors.file.read(name, *args, **kwargs))
-        return self._df
+        return _connectors.file.read(name, *args, **kwargs)
 
 
 class _write:


### PR DESCRIPTION
## Fix: DataFrame accessor no longer mutates the original on assignment

### Problem

When using the `.wrangles` accessor and assigning the result to a new variable, the **original** DataFrame was also mutated. Both variables ended up pointing to the same in-memory object.

```python
df = DataFrame({'col': range(20)})
df_sample = df.wrangles.select.sample(rows=5)

print(len(df))        # 5  ← should still be 20
print(len(df_sample)) # 5
print(df is df_sample) # True ← same object
```

The same problem affected any wrangle that modifies columns:

```python
df = DataFrame({'name': ['alice', 'bob', 'carol']})
df_upper = df.wrangles.convert.case(input='name', case='upper')

print(df['name'].tolist())       # ['ALICE', 'BOB', 'CAROL'] ← should be unchanged
print(df_upper['name'].tolist()) # ['ALICE', 'BOB', 'CAROL']
print(df is df_upper)            # True
```

### Root cause

Every `make_method` closure in `dataframe.py` used this pattern:

```python
def method(self, *args, **kwargs):
    self._df.__init__(target_func(self._df, *args, **kwargs))  # reinitialises df in-place
    return self._df                                             # returns the same object as df
```

Two things go wrong:

1. **`self._df.__init__(result)`** calls `__init__` on the existing object, which reinitialises its data in-place without changing its identity (`id()`). So `df` is mutated.
2. **`return self._df`** hands back the same reference as `df`. Any assignment (`df_sample = ...`) just creates a second name for the same object.

Many wrangle functions also assign columns directly (`df[col] = ...`), so even without the `__init__` trick the original would be modified.

The pattern appeared in four places: `_wrangles_accessor.make_method`, `_wrangles.make_method`, `_read.make_method`, and `_read.file`.

### Fix

Pass a copy of the DataFrame into `target_func` and return its result directly — no `__init__`, no returning `self._df`:

```python
# Before
def method(self, *args, **kwargs):
    self._df.__init__(target_func(self._df, *args, **kwargs))
    return self._df

# After
def method(self, *args, **kwargs):
    return target_func(self._df.copy(), *args, **kwargs)
```

Using `.copy()` means wrangle functions that assign columns in-place operate on a throwaway copy, so the caller's original DataFrame is never touched. The returned value is always an independent object.

### Behaviour after fix

**Assigning to a new variable — original unchanged:**

```python
df = DataFrame({'col': range(20)})
df_sample = df.wrangles.select.sample(rows=5)

print(len(df))         # 20 ✓
print(len(df_sample))  # 5  ✓
print(df is df_sample) # False ✓
```

```python
df = DataFrame({'name': ['alice', 'bob', 'carol']})
df_upper = df.wrangles.convert.case(input='name', case='upper')

print(df['name'].tolist())       # ['alice', 'bob', 'carol'] ✓
print(df_upper['name'].tolist()) # ['ALICE', 'BOB', 'CAROL'] ✓
print(df is df_upper)            # False ✓
```

**Reassignment still works as before:**

```python
df = DataFrame({'col': ['hello', 'world']})
df = df.wrangles.convert.case(input='col', case='upper')

print(df['col'].tolist())  # ['HELLO', 'WORLD'] ✓
```

**Multiple calls on the same DataFrame — each independent:**

```python
df = DataFrame({'col': ['hello', 'world', 'foo', 'bar', 'baz']})
_ = df.wrangles.convert.case(input='col', case='upper')
_ = df.wrangles.select.sample(rows=2)

print(df['col'].tolist())  # ['hello', 'world', 'foo', 'bar', 'baz'] ✓
print(len(df))             # 5 ✓
```
