### PR TITLE
 Fix RuntimeError when reading "input" without a dataframe (#943)

### DIFF
--- a/tests/connectors/test_input.py
+++ b/tests/connectors/test_input.py
@@ -79,3 +79,42 @@ def test_read_union():
         df["header1"].values.tolist() == ["a", "b", "c", "d"] and
         len(df) == 4
     )
+
+def test_read_no_dataframe():
+    """
+    Test that reading input without a dataframe being
+    passed in returns an empty dataframe instead of erroring
+    https://github.com/wrangleworks/WranglesPY/issues/943
+    """
+    df = wrangles.recipe.run(
+        """
+        read:
+          - input
+        """
+    )
+    assert df.empty
+
+def test_read_union_no_dataframe():
+    """
+    Test that a union with input as a source falls back to
+    the other source(s) when no dataframe is passed in
+    https://github.com/wrangleworks/WranglesPY/issues/943
+    """
+    df = wrangles.recipe.run(
+        """
+        read:
+          - union:
+              sources:
+                - test:
+                    rows: 1
+                    values:
+                      idx: 0
+                      header1: a
+                - input
+        """
+    )
+    assert (
+        df.columns.tolist() == ["idx", "header1"] and
+        df["header1"].values.tolist() == ["a"] and
+        len(df) == 1
+    )

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -3469,7 +3469,7 @@ class TestTranslate:
                 target_language: EN-GB
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['English'] == 'Hello World!'
+        assert df.iloc[0]['English'] == 'Hello, world!'
 
     def test_translate_2(self):
         """
@@ -3487,7 +3487,7 @@ class TestTranslate:
                 target_language: English
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['English'] == 'Hello World!'
+        assert df.iloc[0]['English'] == 'Hello, world!'
 
     def test_translate_3(self):
         """

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -3469,7 +3469,7 @@ class TestTranslate:
                 target_language: EN-GB
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['English'] == 'Hello, world!'
+        assert df.iloc[0]['English'] == 'Hello World!'
 
     def test_translate_2(self):
         """
@@ -3487,7 +3487,7 @@ class TestTranslate:
                 target_language: English
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['English'] == 'Hello, world!'
+        assert df.iloc[0]['English'] == 'Hello World!'
 
     def test_translate_3(self):
         """

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -334,6 +334,11 @@ def _read_data(
 
                 # Reference the recipe execution input dataframe
                 if read_type == "input":
+                    if input_dataframe is None:
+                        # No dataframe was passed in to the recipe.
+                        # Treat as if this source returned nothing,
+                        # consistent with a false if condition above.
+                        return None
                     df = input_dataframe
                 # Allow blended imports
                 elif read_type in ['join', 'concatenate', 'union']:


### PR DESCRIPTION

## Problem

When a recipe's `read:` section references the `input` connector (the dataframe
passed into `recipe.run(dataframe=...)`), but **no dataframe is actually passed
in**, `_read_data` raised a confusing error instead of treating it as "no data
from this source":

```python
import wrangles

recipe = """
read:
  - union:
      sources:
        - input: {}
        - file:
            name: test_file.xlsx
"""

# No dataframe= passed
wrangles.recipe.run(recipe)
```

```
RuntimeError: ERROR IN READ: union - ERROR IN READ: input - Function input did not return a dataframe
```

This is the exact error seen from the Excel add-in lambda (issue #943) — when
the user's recipe contains `read: - union: - input: {} - file: ...` and the
add-in doesn't (or can't) pass selection data through as the input dataframe,
the whole recipe crashes instead of just using the other source(s).

## Fix

In `wrangles/recipe.py::_read_data`, when `read_type == "input"` and
`input_dataframe is None`, return `None` — the same signal already used when
an `if` condition on a read source evaluates to `False`. Callers already
handle `None` correctly:

- In a `union`/`join`/`concatenate`, a `None` sub-result is skipped, so the
  other sources are used.
- As a top-level `read:`, a `None` result becomes an empty dataframe.

## Behavior after the fix

```python
# Union falls back to just the file source
result = wrangles.recipe.run("""
read:
  - union:
      sources:
        - input: {}
        - file:
            name: test_file.xlsx
""")
# -> returns test_file.xlsx's contents, no error

# Plain input read with no dataframe -> empty dataframe, no error
result = wrangles.recipe.run("""
read:
  - input
""")
# -> empty DataFrame
```

## Tests

Added to `tests/connectors/test_input.py`:

- `test_read_no_dataframe` — `read: - input` with no `dataframe=` returns an
  empty dataframe.
- `test_read_union_no_dataframe` — `union` of `input` + another source with no
  `dataframe=` falls back to the other source's data.
