### PR TITLE
1013 update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,31 +1,17 @@
 ---
 name: Bug
 about: An unexpected problem or behavior
-title: '[BUG] '
-labels: bug
+title: ''
+labels: 'P0'
 assignees: ''
+type: Bug
 ---
 
-**Describe the bug**
+**Description**
 What happened?
 
-**To Reproduce**
-1. 
-2. 
-3. 
+**Desired Behavior**
+What should happen instead?
 
-**Expected**
-What should happen?
-
-**Environment**
-- WranglesXL version:
-- Excel version:
-- OS:
-
-**Additional context**
-Screenshots, error messages, data samples
-
-**Acceptance criteria**
-- [ ] 
-- [ ] 
-- [ ] 
+**Example current / desired**
+Code snippet, error message, or screenshot showing current vs. expected behavior

--- a/.github/ISSUE_TEMPLATE/deliverable.md
+++ b/.github/ISSUE_TEMPLATE/deliverable.md
@@ -1,29 +1,17 @@
 ---
 name: Deliverable
 about: Deliverable for Projects & PoCs
-title: '[DELIVERABLE] '
-labels: deliverable
+title: ''
+labels: 'P1'
 assignees: ''
+type: Task
 ---
 
-**Deliverable name**
-
-
-**Project/PoC**
-Which project is this for?
-
 **Description**
-What needs to be delivered?
+What needs to be delivered and for which project?
 
-**Acceptance criteria**
-- [ ] 
-- [ ] 
-- [ ] 
+**Desired Behavior**
+What does a completed deliverable look like?
 
-**Due date**
-
-
-**Dependencies**
-What's needed before this can be completed?
-
-
+**Example current / desired**
+Acceptance criteria, mockups, or examples illustrating the expected output

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,22 +1,17 @@
 ---
 name: Documentation
 about: Updates for Docs
-title: '[DOCS] '
-labels: documentation
+title: ''
+labels: 'P1'
 assignees: ''
+type: Enhancement
 ---
 
-**Location**
-URL or path to documentation
-
-**Issue**
-- [ ] Missing
-- [ ] Incorrect
-- [ ] Unclear
-- [ ] Outdated
-
 **Description**
-What needs to be fixed or added?
+What is missing, incorrect, or unclear in the documentation?
 
-**Suggestion**
-How should it be improved?
+**Desired Behavior**
+What should the documentation say or cover?
+
+**Example current / desired**
+Link to the page + current text vs. proposed text

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,24 +1,17 @@
 ---
 name: Enhancement
 about: A request, idea, or new functionality
-title: '[ENHANCEMENT] '
-labels: enhancement
+title: ''
+labels: 'P1'
 assignees: ''
+type: Enhancement
 ---
 
-**Feature description**
-What would you like to see?
+**Description**
+What feature or improvement would you like?
 
-**Problem it solves**
-Why is this needed?
+**Desired Behavior**
+How should it work once implemented?
 
-**Proposed solution**
-How should it work?
-
-**Use case**
-When would you use this?
-
-**Acceptance criteria**
-- [ ] 
-- [ ] 
-- [ ] 
+**Example current / desired**
+Show current behavior (or lack thereof) vs. the desired usage

--- a/.github/ISSUE_TEMPLATE/housekeeping.md
+++ b/.github/ISSUE_TEMPLATE/housekeeping.md
@@ -1,35 +1,17 @@
 ---
 name: Housekeeping
 about: Bumping versions, packages, configs etc.
-title: '[HOUSEKEEPING] '
-labels: housekeeping
+title: ''
+labels: 'P1'
 assignees: ''
+type: Task
 ---
 
-**Type**
-- [ ] Dependency update
-- [ ] Version bump
-- [ ] Config update
-- [ ] Cleanup
-- [ ] Other
+**Description**
+What needs updating and why?
 
-**What needs updating**
+**Desired Behavior**
+What should the updated state look like?
 
-
-**Current version → New version**
-
-
-**Reason**
-Why is this needed?
-
-**Impact**
-- [ ] No breaking changes
-- [ ] Breaking changes (describe below)
-
-**Testing needed**
-
-
-**Acceptance criteria**
-- [ ] 
-- [ ] 
-- [ ] 
+**Example current / desired**
+Current version / config → new version / config

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,34 +1,17 @@
 ---
 name: Refactor
 about: Refactor code and/or upgrade packages
-title: '[REFACTOR] '
-labels: refactor
+title: ''
+labels: 'P1'
 assignees: ''
+type: Enhancement
 ---
 
-**What needs refactoring**
-Component, module, or package
+**Description**
+What component, module, or package needs refactoring and why?
 
-**Current state**
-What's the problem with current implementation?
+**Desired Behavior**
+What should the refactored state look like (performance, structure, API)?
 
-**Proposed changes**
-What should be refactored and how?
-
-**Benefits**
-- Performance improvement
-- Better maintainability
-- Code quality
-- Other:
-
-**Breaking changes**
-- [ ] Yes
-- [ ] No
-
-**Details**
-
-
-**Acceptance criteria**
-- [ ] 
-- [ ] 
-- [ ] 
+**Example current / desired**
+Current implementation snippet vs. proposed approach

--- a/.github/ISSUE_TEMPLATE/roadmap.md
+++ b/.github/ISSUE_TEMPLATE/roadmap.md
@@ -1,29 +1,17 @@
 ---
 name: Roadmap Item
-about: Large roadmap Deliverable
-title: '[ROADMAP] '
-labels: roadmap
+about: Large roadmap deliverable
+title: ''
+labels: 'P1'
 assignees: ''
+type: Enhancement
 ---
 
-**Initiative name**
-
-
-**Strategic goal**
-What business objective does this support?
-
 **Description**
-High-level overview
+What is the initiative and which strategic goal does it support?
 
-**Key deliverables**
-- [ ] 
-- [ ] 
-- [ ] 
+**Desired Behavior**
+What does success look like (key deliverables, target date, success metrics)?
 
-**Target quarter/date**
-
-
-**Success metrics**
-How will we measure success?
-
-**Dependencies & risks**
+**Example current / desired**
+Current state vs. target state, or dependencies and risks to highlight

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,26 +1,17 @@
 ---
 name: Task
 about: A specific piece of work
-title: '[TASK] '
-labels: task
+title: ''
+labels: 'P1'
 assignees: ''
+type: Task
 ---
 
-**Task description**
+**Description**
 What needs to be done?
 
-**Context**
-Why is this needed?
+**Desired Behavior**
+What does done look like?
 
-**Steps**
-- [ ] 
-- [ ] 
-- [ ] 
-
-**Related to**
-Links to related issues or PRs
-
-**Acceptance criteria**
-- [ ] 
-- [ ] 
-- [ ] 
+**Example current / desired**
+Context, related issues, or examples that illustrate the expected outcome

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -1,0 +1,23 @@
+name: Issue Management
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  manage-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Self-assign to reporter
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: ['mborodii-prog']
+            });


### PR DESCRIPTION
  Simplify issue templates and add auto-assign workflow (#1013)

  - Remove [TYPE] prefixes from all issue template titles
  - Replace type-based labels with priority labels (P0 for Bug, P1 for all others)
  - Add `type:` frontmatter field to all templates
  - Slim all 8 templates to 3 consistent sections: Description, Desired Behavior, Example current/desired
  - Add issue-management workflow to auto-assign new issues to mborodii-prog