### PR TITLE
Add split.dictionary to_lists mode

### DIFF
--- a/tests/recipes/wrangles/test_split.py
+++ b/tests/recipes/wrangles/test_split.py
@@ -1281,7 +1281,7 @@ class TestSplitDictionary:
         )
         assert df.empty and df.columns.to_list() == ['Col']
 
-    def test_split_dictionary_to_lists(self):
+    def test_split_dictionary_two_lists(self):
         """
         Test splitting dictionary keys and values to parallel lists
         """
@@ -1293,7 +1293,7 @@ class TestSplitDictionary:
                 output:
                 - Keys
                 - Values
-                mode: to_lists
+                output_format: two_lists
             """,
             dataframe=pd.DataFrame({
                 'My Dict': [
@@ -1305,7 +1305,7 @@ class TestSplitDictionary:
         assert df['Keys'].to_list() == [["a", "b"], ["b", "c"]]
         assert df['Values'].to_list() == [[123, "kshdf"], [123, "kshdf"]]
 
-    def test_split_dictionary_to_lists_json(self):
+    def test_split_dictionary_two_lists_json(self):
         """
         Test splitting JSON dictionary keys and values to lists
         """
@@ -1317,7 +1317,7 @@ class TestSplitDictionary:
                 output:
                 - Keys
                 - Values
-                mode: to_lists
+                output_format: two_lists
             """,
             dataframe=pd.DataFrame({
                 'My Dict': ['{"a": 123, "b": "kshdf"}']
@@ -1326,7 +1326,7 @@ class TestSplitDictionary:
         assert df['Keys'][0] == ["a", "b"]
         assert df['Values'][0] == [123, "kshdf"]
 
-    def test_split_dictionary_to_lists_multiple_inputs(self):
+    def test_split_dictionary_two_lists_multiple_inputs(self):
         """
         Test splitting multiple dictionaries to keys and values lists
         """
@@ -1340,7 +1340,7 @@ class TestSplitDictionary:
                 output:
                 - Keys
                 - Values
-                mode: to_lists
+                output_format: two_lists
             """,
             dataframe=pd.DataFrame({
                 'Dict1': [{"a": 1, "b": 2}],
@@ -1350,9 +1350,9 @@ class TestSplitDictionary:
         assert df['Keys'][0] == ["a", "b", "c"]
         assert df['Values'][0] == [1, 3, 4]
 
-    def test_split_dictionary_to_lists_where(self):
+    def test_split_dictionary_two_lists_where(self):
         """
-        Test split.dictionary mode to_lists using where
+        Test split.dictionary output_format two_lists using where
         """
         df = wrangles.recipe.run(
             """
@@ -1362,7 +1362,7 @@ class TestSplitDictionary:
                 output:
                 - Keys
                 - Values
-                mode: to_lists
+                output_format: two_lists
                 where: numbers > 3
             """,
             dataframe=pd.DataFrame({
@@ -1377,16 +1377,16 @@ class TestSplitDictionary:
         assert df['Keys'].to_list() == ["", ["b"], ["c"]]
         assert df['Values'].to_list() == ["", [2], [3]]
 
-    def test_split_dictionary_to_lists_default_output(self):
+    def test_split_dictionary_two_lists_default_output(self):
         """
-        Test split.dictionary mode to_lists default output columns
+        Test split.dictionary output_format two_lists default output columns
         """
         df = wrangles.recipe.run(
             """
             wrangles:
             - split.dictionary:
                 input: My Dict
-                mode: to_lists
+                output_format: two_lists
             """,
             dataframe=pd.DataFrame({
                 'My Dict': [{"a": 1}]
@@ -1395,9 +1395,9 @@ class TestSplitDictionary:
         assert df['Keys'][0] == ["a"]
         assert df['Values'][0] == [1]
 
-    def test_split_dictionary_to_lists_output_error(self):
+    def test_split_dictionary_two_lists_output_error(self):
         """
-        Test split.dictionary mode to_lists validates output column count
+        Test split.dictionary output_format two_lists validates output column count
         """
         with pytest.raises(ValueError, match="exactly two output columns"):
             wrangles.recipe.run(
@@ -1406,33 +1406,33 @@ class TestSplitDictionary:
                 - split.dictionary:
                     input: My Dict
                     output: Keys
-                    mode: to_lists
+                    output_format: two_lists
                 """,
                 dataframe=pd.DataFrame({
                     'My Dict': [{"a": 1}]
                 })
             )
 
-    def test_split_dictionary_invalid_mode(self):
+    def test_split_dictionary_invalid_output_format(self):
         """
-        Test split.dictionary validates mode
+        Test split.dictionary validates output_format
         """
-        with pytest.raises(ValueError, match="mode must be one of"):
+        with pytest.raises(ValueError, match="output_format must be one of"):
             wrangles.recipe.run(
                 """
                 wrangles:
                 - split.dictionary:
                     input: My Dict
-                    mode: invalid
+                    output_format: invalid
                 """,
                 dataframe=pd.DataFrame({
                     'My Dict': [{"a": 1}]
                 })
             )
 
-    def test_split_dictionary_to_lists_empty(self):
+    def test_split_dictionary_two_lists_empty(self):
         """
-        Test split.dictionary mode to_lists with an empty column
+        Test split.dictionary output_format two_lists with an empty column
         """
         df = wrangles.recipe.run(
             """
@@ -1442,7 +1442,7 @@ class TestSplitDictionary:
                 output:
                 - Keys
                 - Values
-                mode: to_lists
+                output_format: two_lists
             """,
             dataframe=pd.DataFrame({
                 'My Dict': []

--- a/tests/recipes/wrangles/test_split.py
+++ b/tests/recipes/wrangles/test_split.py
@@ -1281,7 +1281,7 @@ class TestSplitDictionary:
         )
         assert df.empty and df.columns.to_list() == ['Col']
 
-    def test_split_dictionary_two_lists(self):
+    def test_split_dictionary_to_lists(self):
         """
         Test splitting dictionary keys and values to parallel lists
         """
@@ -1293,7 +1293,7 @@ class TestSplitDictionary:
                 output:
                 - Keys
                 - Values
-                output_format: two_lists
+                output_format: to_lists
             """,
             dataframe=pd.DataFrame({
                 'My Dict': [
@@ -1305,7 +1305,7 @@ class TestSplitDictionary:
         assert df['Keys'].to_list() == [["a", "b"], ["b", "c"]]
         assert df['Values'].to_list() == [[123, "kshdf"], [123, "kshdf"]]
 
-    def test_split_dictionary_two_lists_json(self):
+    def test_split_dictionary_to_lists_json(self):
         """
         Test splitting JSON dictionary keys and values to lists
         """
@@ -1317,7 +1317,7 @@ class TestSplitDictionary:
                 output:
                 - Keys
                 - Values
-                output_format: two_lists
+                output_format: to_lists
             """,
             dataframe=pd.DataFrame({
                 'My Dict': ['{"a": 123, "b": "kshdf"}']
@@ -1326,7 +1326,7 @@ class TestSplitDictionary:
         assert df['Keys'][0] == ["a", "b"]
         assert df['Values'][0] == [123, "kshdf"]
 
-    def test_split_dictionary_two_lists_multiple_inputs(self):
+    def test_split_dictionary_to_lists_multiple_inputs(self):
         """
         Test splitting multiple dictionaries to keys and values lists
         """
@@ -1340,7 +1340,7 @@ class TestSplitDictionary:
                 output:
                 - Keys
                 - Values
-                output_format: two_lists
+                output_format: to_lists
             """,
             dataframe=pd.DataFrame({
                 'Dict1': [{"a": 1, "b": 2}],
@@ -1350,9 +1350,9 @@ class TestSplitDictionary:
         assert df['Keys'][0] == ["a", "b", "c"]
         assert df['Values'][0] == [1, 3, 4]
 
-    def test_split_dictionary_two_lists_where(self):
+    def test_split_dictionary_to_lists_where(self):
         """
-        Test split.dictionary output_format two_lists using where
+        Test split.dictionary output_format to_lists using where
         """
         df = wrangles.recipe.run(
             """
@@ -1362,7 +1362,7 @@ class TestSplitDictionary:
                 output:
                 - Keys
                 - Values
-                output_format: two_lists
+                output_format: to_lists
                 where: numbers > 3
             """,
             dataframe=pd.DataFrame({
@@ -1377,16 +1377,16 @@ class TestSplitDictionary:
         assert df['Keys'].to_list() == ["", ["b"], ["c"]]
         assert df['Values'].to_list() == ["", [2], [3]]
 
-    def test_split_dictionary_two_lists_default_output(self):
+    def test_split_dictionary_to_lists_default_output(self):
         """
-        Test split.dictionary output_format two_lists default output columns
+        Test split.dictionary output_format to_lists default output columns
         """
         df = wrangles.recipe.run(
             """
             wrangles:
             - split.dictionary:
                 input: My Dict
-                output_format: two_lists
+                output_format: to_lists
             """,
             dataframe=pd.DataFrame({
                 'My Dict': [{"a": 1}]
@@ -1395,9 +1395,9 @@ class TestSplitDictionary:
         assert df['Keys'][0] == ["a"]
         assert df['Values'][0] == [1]
 
-    def test_split_dictionary_two_lists_output_error(self):
+    def test_split_dictionary_to_lists_output_error(self):
         """
-        Test split.dictionary output_format two_lists validates output column count
+        Test split.dictionary output_format to_lists validates output column count
         """
         with pytest.raises(ValueError, match="exactly two output columns"):
             wrangles.recipe.run(
@@ -1406,7 +1406,7 @@ class TestSplitDictionary:
                 - split.dictionary:
                     input: My Dict
                     output: Keys
-                    output_format: two_lists
+                    output_format: to_lists
                 """,
                 dataframe=pd.DataFrame({
                     'My Dict': [{"a": 1}]
@@ -1430,9 +1430,9 @@ class TestSplitDictionary:
                 })
             )
 
-    def test_split_dictionary_two_lists_empty(self):
+    def test_split_dictionary_to_lists_empty(self):
         """
-        Test split.dictionary output_format two_lists with an empty column
+        Test split.dictionary output_format to_lists with an empty column
         """
         df = wrangles.recipe.run(
             """
@@ -1442,7 +1442,7 @@ class TestSplitDictionary:
                 output:
                 - Keys
                 - Values
-                output_format: two_lists
+                output_format: to_lists
             """,
             dataframe=pd.DataFrame({
                 'My Dict': []

--- a/tests/recipes/wrangles/test_split.py
+++ b/tests/recipes/wrangles/test_split.py
@@ -1281,6 +1281,175 @@ class TestSplitDictionary:
         )
         assert df.empty and df.columns.to_list() == ['Col']
 
+    def test_split_dictionary_to_lists(self):
+        """
+        Test splitting dictionary keys and values to parallel lists
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - split.dictionary:
+                input: My Dict
+                output:
+                - Keys
+                - Values
+                mode: to_lists
+            """,
+            dataframe=pd.DataFrame({
+                'My Dict': [
+                    {"a": 123, "b": "kshdf"},
+                    {"b": 123, "c": "kshdf"}
+                ]
+            })
+        )
+        assert df['Keys'].to_list() == [["a", "b"], ["b", "c"]]
+        assert df['Values'].to_list() == [[123, "kshdf"], [123, "kshdf"]]
+
+    def test_split_dictionary_to_lists_json(self):
+        """
+        Test splitting JSON dictionary keys and values to lists
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - split.dictionary:
+                input: My Dict
+                output:
+                - Keys
+                - Values
+                mode: to_lists
+            """,
+            dataframe=pd.DataFrame({
+                'My Dict': ['{"a": 123, "b": "kshdf"}']
+            })
+        )
+        assert df['Keys'][0] == ["a", "b"]
+        assert df['Values'][0] == [123, "kshdf"]
+
+    def test_split_dictionary_to_lists_multiple_inputs(self):
+        """
+        Test splitting multiple dictionaries to keys and values lists
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - split.dictionary:
+                input:
+                - Dict1
+                - Dict2
+                output:
+                - Keys
+                - Values
+                mode: to_lists
+            """,
+            dataframe=pd.DataFrame({
+                'Dict1': [{"a": 1, "b": 2}],
+                'Dict2': [{"b": 3, "c": 4}]
+            })
+        )
+        assert df['Keys'][0] == ["a", "b", "c"]
+        assert df['Values'][0] == [1, 3, 4]
+
+    def test_split_dictionary_to_lists_where(self):
+        """
+        Test split.dictionary mode to_lists using where
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - split.dictionary:
+                input: My Dict
+                output:
+                - Keys
+                - Values
+                mode: to_lists
+                where: numbers > 3
+            """,
+            dataframe=pd.DataFrame({
+                'My Dict': [
+                    {"a": 1},
+                    {"b": 2},
+                    {"c": 3}
+                ],
+                'numbers': [3, 4, 5]
+            })
+        )
+        assert df['Keys'].to_list() == ["", ["b"], ["c"]]
+        assert df['Values'].to_list() == ["", [2], [3]]
+
+    def test_split_dictionary_to_lists_default_output(self):
+        """
+        Test split.dictionary mode to_lists default output columns
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - split.dictionary:
+                input: My Dict
+                mode: to_lists
+            """,
+            dataframe=pd.DataFrame({
+                'My Dict': [{"a": 1}]
+            })
+        )
+        assert df['Keys'][0] == ["a"]
+        assert df['Values'][0] == [1]
+
+    def test_split_dictionary_to_lists_output_error(self):
+        """
+        Test split.dictionary mode to_lists validates output column count
+        """
+        with pytest.raises(ValueError, match="exactly two output columns"):
+            wrangles.recipe.run(
+                """
+                wrangles:
+                - split.dictionary:
+                    input: My Dict
+                    output: Keys
+                    mode: to_lists
+                """,
+                dataframe=pd.DataFrame({
+                    'My Dict': [{"a": 1}]
+                })
+            )
+
+    def test_split_dictionary_invalid_mode(self):
+        """
+        Test split.dictionary validates mode
+        """
+        with pytest.raises(ValueError, match="mode must be one of"):
+            wrangles.recipe.run(
+                """
+                wrangles:
+                - split.dictionary:
+                    input: My Dict
+                    mode: invalid
+                """,
+                dataframe=pd.DataFrame({
+                    'My Dict': [{"a": 1}]
+                })
+            )
+
+    def test_split_dictionary_to_lists_empty(self):
+        """
+        Test split.dictionary mode to_lists with an empty column
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - split.dictionary:
+                input: My Dict
+                output:
+                - Keys
+                - Values
+                mode: to_lists
+            """,
+            dataframe=pd.DataFrame({
+                'My Dict': []
+            })
+        )
+        assert df.empty and df.columns.to_list() == ['My Dict', 'Keys', 'Values']
+
 
 class TestTokenize:
     """

--- a/tests/test_wrangles.py
+++ b/tests/test_wrangles.py
@@ -121,11 +121,11 @@ def test_extract_html_str():
 # Translate
 def test_translate():
     result = wrangles.translate('My name is Chris', 'DE')
-    assert result[:19] == 'Mein Name ist Chris'
+    assert result[:19] == 'Ich heiße Chris'
 
 def test_translate_list():
     result = wrangles.translate(['My name is Chris'], 'DE')
-    assert result[0][:19] == 'Mein Name ist Chris'
+    assert result[0][:19] == 'Ich heiße Chris'
     
 # Invalid input type (dict)
 def test_translate_typeError():

--- a/wrangles/recipe_wrangles/split.py
+++ b/wrangles/recipe_wrangles/split.py
@@ -49,7 +49,7 @@ def dictionary(
           output:
             - key1: new_column_name1
             - key2: new_column_name2
-          In two_lists output_format, this must be two output columns for the keys
+          In to_lists output_format, this must be two output columns for the keys
           and values lists. If not provided, Keys and Values will be used.
       default:
         type: object
@@ -60,14 +60,14 @@ def dictionary(
         type: string
         enum:
           - columns
-          - two_lists
+          - to_lists
         description: |-
           How to split the dictionary.
           columns creates one output column for each dictionary key.
-          two_lists creates two output columns containing lists of keys and values.
+          to_lists creates two output columns containing lists of keys and values.
     """
-    if output_format not in ["columns", "two_lists"]:
-        raise ValueError("output_format must be one of: columns, two_lists")
+    if output_format not in ["columns", "to_lists"]:
+        raise ValueError("output_format must be one of: columns, to_lists")
 
     if default is None:
         default = {}
@@ -93,14 +93,14 @@ def dictionary(
         for row in df[input].values
     ]
 
-    if output_format == "two_lists":
+    if output_format == "to_lists":
         if output is None:
             output = ["Keys", "Values"]
         elif not isinstance(output, _list):
             output = [output]
 
         if len(output) != 2:
-            raise ValueError("split.dictionary with output_format two_lists requires exactly two output columns")
+            raise ValueError("split.dictionary with output_format to_lists requires exactly two output columns")
 
         df[output[0]] = [[key for key in item.keys()] for item in dicts]
         df[output[1]] = [[value for value in item.values()] for item in dicts]

--- a/wrangles/recipe_wrangles/split.py
+++ b/wrangles/recipe_wrangles/split.py
@@ -16,7 +16,8 @@ def dictionary(
     df: _pd.DataFrame,
     input: _Union[str, int, _list],
     output: _Union[str, _list] = None,
-    default: dict = None
+    default: dict = None,
+    mode: str = "to_columns"
 ) -> _pd.DataFrame:
     """
     type: object
@@ -42,18 +43,32 @@ def dictionary(
           - string
           - array
         description: |-
-          (Optional) Subset of keys to extract from the dictionary.
-          If not provided, all keys will be returned.
+          In to_columns mode, this is an optional subset of keys to extract
+          from the dictionary. If not provided, all keys will be returned.
           Columns can be renamed with the following syntax:
           output:
             - key1: new_column_name1
             - key2: new_column_name2
+          In to_lists mode, this must be two output columns for the keys
+          and values lists. If not provided, Keys and Values will be used.
       default:
         type: object
         description: >-
           Provide a set of default headings and values
           if they are not found within the input
+      mode:
+        type: string
+        enum:
+          - to_columns
+          - to_lists
+        description: |-
+          How to split the dictionary.
+          to_columns creates one output column for each dictionary key.
+          to_lists creates two output columns containing lists of keys and values.
     """ 
+    if mode not in ["to_columns", "to_lists"]:
+        raise ValueError("mode must be one of: to_columns, to_lists")
+
     if default is None:
         default = {}
     # Ensure input is passed as a list
@@ -71,11 +86,28 @@ def dictionary(
         raise ValueError(f'{val} is not a valid Dictionary') from None
         
 
-    # Generate new columns for each key in the dictionary
-    df_temp = _pd.DataFrame([
+    # Merge each row's dictionaries so duplicate keys follow existing behavior:
+    # later input columns overwrite earlier input columns.
+    dicts = [
         dict(_itertools.chain.from_iterable(_parse_dict_or_json(d) for d in ([default] + row.tolist())))
         for row in df[input].values
-    ])
+    ]
+
+    if mode == "to_lists":
+        if output is None:
+            output = ["Keys", "Values"]
+        elif not isinstance(output, _list):
+            output = [output]
+
+        if len(output) != 2:
+            raise ValueError("split.dictionary with mode to_lists requires exactly two output columns")
+
+        df[output[0]] = [[key for key in item.keys()] for item in dicts]
+        df[output[1]] = [[value for value in item.values()] for item in dicts]
+        return df
+
+    # Generate new columns for each key in the dictionary
+    df_temp = _pd.DataFrame(dicts)
 
     # If user has defined how they'd like the output columns
     if output is not None:

--- a/wrangles/recipe_wrangles/split.py
+++ b/wrangles/recipe_wrangles/split.py
@@ -17,7 +17,7 @@ def dictionary(
     input: _Union[str, int, _list],
     output: _Union[str, _list] = None,
     default: dict = None,
-    mode: str = "to_columns"
+    output_format: str = "columns"
 ) -> _pd.DataFrame:
     """
     type: object
@@ -30,7 +30,7 @@ def dictionary(
       - input
     properties:
       input:
-        type: 
+        type:
           - string
           - integer
           - array
@@ -39,35 +39,35 @@ def dictionary(
           If providing multiple dictionaries and the dictionaries
           contain overlapping values, the last value will be returned.
       output:
-        type: 
+        type:
           - string
           - array
         description: |-
-          In to_columns mode, this is an optional subset of keys to extract
+          In columns output_format, this is an optional subset of keys to extract
           from the dictionary. If not provided, all keys will be returned.
           Columns can be renamed with the following syntax:
           output:
             - key1: new_column_name1
             - key2: new_column_name2
-          In to_lists mode, this must be two output columns for the keys
+          In two_lists output_format, this must be two output columns for the keys
           and values lists. If not provided, Keys and Values will be used.
       default:
         type: object
         description: >-
           Provide a set of default headings and values
           if they are not found within the input
-      mode:
+      output_format:
         type: string
         enum:
-          - to_columns
-          - to_lists
+          - columns
+          - two_lists
         description: |-
           How to split the dictionary.
-          to_columns creates one output column for each dictionary key.
-          to_lists creates two output columns containing lists of keys and values.
-    """ 
-    if mode not in ["to_columns", "to_lists"]:
-        raise ValueError("mode must be one of: to_columns, to_lists")
+          columns creates one output column for each dictionary key.
+          two_lists creates two output columns containing lists of keys and values.
+    """
+    if output_format not in ["columns", "two_lists"]:
+        raise ValueError("output_format must be one of: columns, two_lists")
 
     if default is None:
         default = {}
@@ -93,14 +93,14 @@ def dictionary(
         for row in df[input].values
     ]
 
-    if mode == "to_lists":
+    if output_format == "two_lists":
         if output is None:
             output = ["Keys", "Values"]
         elif not isinstance(output, _list):
             output = [output]
 
         if len(output) != 2:
-            raise ValueError("split.dictionary with mode to_lists requires exactly two output columns")
+            raise ValueError("split.dictionary with output_format two_lists requires exactly two output columns")
 
         df[output[0]] = [[key for key in item.keys()] for item in dicts]
         df[output[1]] = [[value for value in item.values()] for item in dicts]


### PR DESCRIPTION

## Summary

## Changes

- `wrangles/recipe_wrangles/split.py`: renamed the `mode` parameter and its values/error messages as above; no other logic changed.
- `tests/recipes/wrangles/test_split.py`: updated `TestSplitDictionary` to use `output_format`/`columns`/`to_lists`

## Examples

### `output_format: columns` (default — unchanged behavior, just renamed from `to_columns`)

```yaml
wrangles:
  - split.dictionary:
      input: My Dict
      output_format: columns
      # output: optional subset/rename of keys; if omitted, all keys become columns
```

| My Dict | Col1 | Col2 |
| --- | --- | --- |
| `{"Col1": "A", "Col2": "B"}` | A | B |

### `output_format: to_lists`

```yaml
wrangles:
  - split.dictionary:
      input: My Dict
      output_format: to_lists
      output:        # optional; defaults to [Keys, Values] if omitted
        - Keys
        - Values
```

| My Dict | Keys | Values |
| --- | --- | --- |
| `{"a": 123, "b": "kshdf"}` | `["a", "b"]` | `[123, "kshdf"]` |
| `{"b": 123, "c": "kshdf"}` | `["b", "c"]` | `[123, "kshdf"]` |

### Default output names omitted

```yaml
wrangles:
  - split.dictionary:
      input: My Dict
      output_format: two_lists
```

Produces `Keys` and `Values` columns automatically — this matches the behavior already implemented today.

### Invalid `output_format`

```yaml
wrangles:
  - split.dictionary:
      input: My Dict
      output_format: invalid
```

Raises `ValueError: output_format must be one of: columns, two_lists`.

### Wrong number of output columns for `two_lists`

```yaml
wrangles:
  - split.dictionary:
      input: My Dict
      output_format: to_lists
      output: Keys
```

Raises `ValueError: split.dictionary with output_format two_lists requires exactly two output columns`.