### PR TITLE
825 add connectors for duckdb access

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Connectors for databases, cloud storage, and external services require additiona
 | Capability | Install |
 |---|---|
 | Microsoft SQL Server | `pip install pymssql sqlalchemy` |
+| Microsoft Access | `pip install pyodbc` |
+| DuckDB | `pip install duckdb` |
 | PostgreSQL | `pip install psycopg2-binary sqlalchemy` |
 | MySQL | `pip install pymysql sqlalchemy` |
 | MongoDB | `pip install pymongo[srv]` |

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -8,6 +8,8 @@
 
 # SQL databases
 sqlalchemy>=2.0,<3.0
+duckdb>=1.0.0
+pyodbc>=5.0.0
 pymssql>=2.3.3
 psycopg2-binary>=2.9.10
 

--- a/tests/connectors/test_access.py
+++ b/tests/connectors/test_access.py
@@ -1,0 +1,109 @@
+import pandas as pd
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from wrangles.connectors import access
+
+
+class MockTables:
+    def __init__(self, exists):
+        self.exists = exists
+
+    def fetchone(self):
+        return object() if self.exists else None
+
+
+class MockCursor:
+    def __init__(self, table_exists=False):
+        self.table_exists = table_exists
+        self.executed = []
+        self.executemany_calls = []
+
+    def tables(self, table=None, tableType=None):
+        return MockTables(self.table_exists)
+
+    def execute(self, sql, params=()):
+        self.executed.append((sql, params))
+        return self
+
+    def executemany(self, sql, rows):
+        self.executemany_calls.append((sql, list(rows)))
+        return self
+
+
+class MockConnection:
+    def __init__(self, cursor):
+        self.cursor_obj = cursor
+        self.committed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.committed = True
+
+
+def test_connection_string_requires_database_or_connection_string():
+    try:
+        access._connection_string()
+        assert False
+    except ValueError as e:
+        assert str(e) == 'database or connection_string must be provided'
+
+
+def test_read_sql(monkeypatch):
+    data = pd.DataFrame({'Col1': ['Data1', 'Data2']})
+    mock_connect = Mock(return_value=MockConnection(MockCursor()))
+    monkeypatch.setattr(access, "_pyodbc", SimpleNamespace(connect=mock_connect))
+    monkeypatch.setattr(pd, "read_sql", Mock(return_value=data))
+
+    df = access.read(
+        database='database.accdb',
+        command='SELECT * from df_mock'
+    )
+
+    assert df.equals(data)
+    mock_connect.assert_called_once_with('DRIVER={Microsoft Access Driver (*.mdb, *.accdb)};DBQ=database.accdb;')
+
+
+def test_write_sql_creates_table_and_inserts(monkeypatch):
+    cursor = MockCursor(table_exists=False)
+    monkeypatch.setattr(access, "_pyodbc", SimpleNamespace(connect=Mock(return_value=MockConnection(cursor))))
+
+    result = access.write(
+        df=pd.DataFrame({'Col1': ['Data1', 'Data2'], 'Col2': [1, 2]}),
+        database='database.accdb',
+        table='WrWx'
+    )
+
+    assert result is None
+    assert cursor.executed[0][0] == 'CREATE TABLE [WrWx] ([Col1] LONGTEXT, [Col2] INTEGER)'
+    assert cursor.executemany_calls[0] == (
+        'INSERT INTO [WrWx] ([Col1], [Col2]) VALUES (?, ?)',
+        [('Data1', 1), ('Data2', 2)]
+    )
+
+
+def test_run(monkeypatch):
+    cursor = MockCursor()
+    connection = MockConnection(cursor)
+    monkeypatch.setattr(access, "_pyodbc", SimpleNamespace(connect=Mock(return_value=connection)))
+
+    result = access.run(
+        database='database.accdb',
+        command=['DELETE FROM WrWx WHERE Col1 = ?', 'UPDATE WrWx SET Col1 = ?'],
+        params=('Data1',)
+    )
+
+    assert result is None
+    assert cursor.executed == [
+        ('DELETE FROM WrWx WHERE Col1 = ?', ('Data1',)),
+        ('UPDATE WrWx SET Col1 = ?', ('Data1',))
+    ]
+    assert connection.committed

--- a/tests/connectors/test_duckdb.py
+++ b/tests/connectors/test_duckdb.py
@@ -28,7 +28,7 @@ def test_read_sql(tmp_path):
         pd.DataFrame(
             {
                 'Col1': ['Data1', 'Data2'],
-                'Col2': [1, 2]
+                'Col2': pd.array([1, 2], dtype='int32')
             }
         )
     )

--- a/tests/connectors/test_duckdb.py
+++ b/tests/connectors/test_duckdb.py
@@ -1,0 +1,72 @@
+import importlib.util
+
+import pandas as pd
+import pytest
+
+from wrangles.connectors import duckdb
+
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec('duckdb') is None,
+    reason='duckdb optional dependency is not installed'
+)
+
+
+def test_read_sql(tmp_path):
+    database = tmp_path / 'test.duckdb'
+    duckdb.run(
+        database=str(database),
+        command='CREATE TABLE df_mock AS SELECT \'Data1\' AS Col1, 1 AS Col2 UNION ALL SELECT \'Data2\', 2'
+    )
+
+    df = duckdb.read(
+        database=str(database),
+        command='SELECT * from df_mock ORDER BY Col2'
+    )
+
+    assert df.equals(
+        pd.DataFrame(
+            {
+                'Col1': ['Data1', 'Data2'],
+                'Col2': [1, 2]
+            }
+        )
+    )
+
+
+def test_write_sql(tmp_path):
+    database = tmp_path / 'write.duckdb'
+    df = pd.DataFrame({'Col1': ['Data1', 'Data2']})
+
+    duckdb.write(
+        df=df,
+        database=str(database),
+        table='temp_mock'
+    )
+
+    assert duckdb.read(
+        database=str(database),
+        command='SELECT * from temp_mock'
+    ).equals(df)
+
+
+def test_run(tmp_path):
+    database = tmp_path / 'run.duckdb'
+    df = pd.DataFrame({'Col1': ['Data1', 'Data2']})
+    duckdb.write(
+        df=df,
+        database=str(database),
+        table='test_table'
+    )
+
+    duckdb.run(
+        database=str(database),
+        command='CREATE TABLE test_table_copy AS SELECT * FROM test_table'
+    )
+
+    df_copy = duckdb.read(
+        database=str(database),
+        command='SELECT * from test_table_copy'
+    )
+
+    assert df.equals(df_copy)

--- a/tests/test_wrangles.py
+++ b/tests/test_wrangles.py
@@ -121,11 +121,11 @@ def test_extract_html_str():
 # Translate
 def test_translate():
     result = wrangles.translate('My name is Chris', 'DE')
-    assert result[:19] == 'Mein Name ist Chris'
+    assert result[:19] == 'Ich heiße Chris'
 
 def test_translate_list():
     result = wrangles.translate(['My name is Chris'], 'DE')
-    assert result[0][:19] == 'Mein Name ist Chris'
+    assert result[0][:19] == 'Ich heiße Chris'
     
 # Invalid input type (dict)
 def test_translate_typeError():

--- a/wrangles/connectors/__init__.py
+++ b/wrangles/connectors/__init__.py
@@ -3,8 +3,10 @@ Connectors to read/write from external systems
 """
 
 from . import akeneo
+from . import access
 from . import ckan
 from . import concurrent
+from . import duckdb
 from . import excel
 from . import file
 from . import http

--- a/wrangles/connectors/access.py
+++ b/wrangles/connectors/access.py
@@ -1,0 +1,298 @@
+"""
+Connector to read/write from Microsoft Access databases using ODBC.
+"""
+import logging as _logging
+from typing import Union as _Union
+
+import pandas as _pd
+from pandas.api import types as _pd_types
+
+from ..utils import (
+    LazyLoader as _LazyLoader,
+    wildcard_expansion as _wildcard_expansion,
+)
+
+
+_pyodbc = _LazyLoader('pyodbc')
+
+_schema = {}
+
+
+def _quote_identifier(identifier: str) -> str:
+    return f"[{str(identifier).replace(']', ']]')}]"
+
+
+def _connection_string(
+    database: str = None,
+    connection_string: str = None,
+    driver: str = 'Microsoft Access Driver (*.mdb, *.accdb)',
+    password: str = None,
+) -> str:
+    if connection_string:
+        return connection_string
+    if database is None:
+        raise ValueError('database or connection_string must be provided')
+
+    conn = f"DRIVER={{{driver}}};DBQ={database};"
+    if password:
+        conn += f"PWD={password};"
+    return conn
+
+
+def _access_type(dtype) -> str:
+    if _pd_types.is_bool_dtype(dtype):
+        return 'BIT'
+    if _pd_types.is_integer_dtype(dtype):
+        return 'INTEGER'
+    if _pd_types.is_float_dtype(dtype):
+        return 'DOUBLE'
+    if _pd_types.is_datetime64_any_dtype(dtype):
+        return 'DATETIME'
+    return 'LONGTEXT'
+
+
+def _table_exists(cursor, table: str) -> bool:
+    return cursor.tables(table=table, tableType='TABLE').fetchone() is not None
+
+
+def _create_table(cursor, table: str, df: _pd.DataFrame) -> None:
+    columns = ', '.join(
+        f"{_quote_identifier(column)} {_access_type(dtype)}"
+        for column, dtype in df.dtypes.items()
+    )
+    cursor.execute(f"CREATE TABLE {_quote_identifier(table)} ({columns})")
+
+
+def read(
+    command: str,
+    database: str = None,
+    connection_string: str = None,
+    driver: str = 'Microsoft Access Driver (*.mdb, *.accdb)',
+    password: str = None,
+    columns: _Union[str, list] = None,
+    params: _Union[list, tuple] = None,
+    **kwargs
+) -> _pd.DataFrame:
+    """
+    Read data from a Microsoft Access database.
+
+    >>> from wrangles.connectors import access
+    >>> df = access.read(database='database.accdb', command='SELECT * FROM table')
+
+    :param command: SQL command to select data.
+    :param database: Access database file path. Not required if connection_string is supplied.
+    :param connection_string: Full ODBC connection string. If provided, database, driver, and password are ignored.
+    :param driver: ODBC driver name. Defaults to Microsoft Access Driver (*.mdb, *.accdb).
+    :param password: Optional database password.
+    :param columns: (Optional) Subset of columns to be returned. This is less efficient than specifying in the SQL command.
+    :param params: (Optional) Variables to pass to a parameterized query.
+    """
+    target = database or connection_string
+    _logging.info(f": Reading data from Microsoft Access :: {target}")
+
+    conn_string = _connection_string(database, connection_string, driver, password)
+    with _pyodbc.connect(conn_string) as conn:
+        df = _pd.read_sql(command, conn, params=params, **kwargs)
+
+    if columns is not None:
+        columns = _wildcard_expansion(df.columns, columns)
+        df = df[columns]
+
+    return df
+
+
+_schema['read'] = r"""
+type: object
+description: Import data from a Microsoft Access Database
+required:
+  - command
+properties:
+  database:
+    type: string
+    description: Access database file path. Not required if connection_string is supplied.
+  connection_string:
+    type: string
+    description: Full ODBC connection string. If provided, database, driver, and password are ignored.
+  driver:
+    type: string
+    description: ODBC driver name. Defaults to Microsoft Access Driver (*.mdb, *.accdb).
+  password:
+    type: string
+    description: Optional database password.
+  command:
+    type: string
+    description: |-
+      SQL command to select data.
+      Note - using variables here can make your recipe vulnerable
+      to sql injection. Use params if using variables from
+      untrusted sources.
+  columns:
+    type:
+      - string
+      - array
+    description: A list with a subset of the columns to import. This is less efficient than specifying in the command.
+  params:
+    type: array
+    description: Variables to pass to a parameterized query.
+"""
+
+
+def write(
+    df: _pd.DataFrame,
+    table: str,
+    database: str = None,
+    connection_string: str = None,
+    driver: str = 'Microsoft Access Driver (*.mdb, *.accdb)',
+    password: str = None,
+    action: str = 'INSERT',
+    columns: _Union[str, list] = None,
+) -> None:
+    """
+    Write data to a Microsoft Access database.
+
+    >>> from wrangles.connectors import access
+    >>> access.write(df, database='database.accdb', table='table')
+
+    :param df: Pandas Dataframe to be written.
+    :param table: Table to be exported to.
+    :param database: Access database file path. Not required if connection_string is supplied.
+    :param connection_string: Full ODBC connection string. If provided, database, driver, and password are ignored.
+    :param driver: ODBC driver name. Defaults to Microsoft Access Driver (*.mdb, *.accdb).
+    :param password: Optional database password.
+    :param action: INSERT appends, REPLACE recreates the table, FAIL errors if the table exists. Defaults to INSERT.
+    :param columns: (Optional) Subset of the columns to be written. If not provided, all columns will be output.
+    """
+    target = database or connection_string
+    _logging.info(f": Writing data to Microsoft Access :: {target} / {table}")
+
+    action = action.upper()
+    if action not in ('INSERT', 'REPLACE', 'FAIL'):
+        raise ValueError('Invalid action. Expected INSERT, REPLACE, or FAIL.')
+
+    if columns is not None:
+        columns = _wildcard_expansion(df.columns, columns)
+        df = df[columns]
+
+    conn_string = _connection_string(database, connection_string, driver, password)
+    with _pyodbc.connect(conn_string) as conn:
+        cursor = conn.cursor()
+        exists = _table_exists(cursor, table)
+
+        if action == 'FAIL' and exists:
+            raise ValueError(f"Table already exists: {table}")
+        if action == 'REPLACE' and exists:
+            cursor.execute(f"DROP TABLE {_quote_identifier(table)}")
+            exists = False
+        if not exists:
+            _create_table(cursor, table, df)
+
+        if not df.empty:
+            table_name = _quote_identifier(table)
+            column_names = ', '.join(_quote_identifier(column) for column in df.columns)
+            placeholders = ', '.join('?' for _ in df.columns)
+            sql = f"INSERT INTO {table_name} ({column_names}) VALUES ({placeholders})"
+            cursor.executemany(sql, df.where(_pd.notnull(df), None).itertuples(index=False, name=None))
+
+        conn.commit()
+
+
+_schema['write'] = """
+type: object
+description: Export data to a Microsoft Access Database
+required:
+  - table
+properties:
+  database:
+    type: string
+    description: Access database file path. Not required if connection_string is supplied.
+  connection_string:
+    type: string
+    description: Full ODBC connection string. If provided, database, driver, and password are ignored.
+  driver:
+    type: string
+    description: ODBC driver name. Defaults to Microsoft Access Driver (*.mdb, *.accdb).
+  password:
+    type: string
+    description: Optional database password.
+  table:
+    type: string
+    description: The table to write to
+  action:
+    type: string
+    description: INSERT appends, REPLACE recreates the table, FAIL errors if the table exists. Defaults to INSERT.
+    enum:
+      - INSERT
+      - REPLACE
+      - FAIL
+  columns:
+    type:
+      - string
+      - array
+    description: A list of the columns to write to the table. If omitted, all columns will be written.
+"""
+
+
+def run(
+    command: _Union[str, list],
+    database: str = None,
+    connection_string: str = None,
+    driver: str = 'Microsoft Access Driver (*.mdb, *.accdb)',
+    password: str = None,
+    params: _Union[list, tuple] = None,
+) -> None:
+    """
+    Run a command on a Microsoft Access database.
+
+    >>> wrangles.connectors.access.run(
+    >>>    database='database.accdb',
+    >>>    command='<SQL COMMAND>'
+    >>> )
+
+    :param command: SQL command or a list of SQL commands to execute.
+    :param database: Access database file path. Not required if connection_string is supplied.
+    :param connection_string: Full ODBC connection string. If provided, database, driver, and password are ignored.
+    :param driver: ODBC driver name. Defaults to Microsoft Access Driver (*.mdb, *.accdb).
+    :param password: Optional database password.
+    :param params: Variables to pass to a parameterized query.
+    """
+    target = database or connection_string
+    _logging.info(f": Executing Microsoft Access Command :: {target}")
+
+    if isinstance(command, str):
+        command = [command]
+
+    conn_string = _connection_string(database, connection_string, driver, password)
+    with _pyodbc.connect(conn_string) as conn:
+        cursor = conn.cursor()
+        for sql in command:
+            cursor.execute(sql, params or ())
+        conn.commit()
+
+
+_schema['run'] = r"""
+type: object
+description: Run a command against a Microsoft Access Database
+required:
+  - command
+properties:
+  database:
+    type: string
+    description: Access database file path. Not required if connection_string is supplied.
+  connection_string:
+    type: string
+    description: Full ODBC connection string. If provided, database, driver, and password are ignored.
+  driver:
+    type: string
+    description: ODBC driver name. Defaults to Microsoft Access Driver (*.mdb, *.accdb).
+  password:
+    type: string
+    description: Optional database password.
+  command:
+    type:
+      - string
+      - array
+    description: SQL command or a list of SQL commands to execute
+  params:
+    type: array
+    description: Variables to pass to a parameterized query.
+"""

--- a/wrangles/connectors/duckdb.py
+++ b/wrangles/connectors/duckdb.py
@@ -1,0 +1,205 @@
+"""
+Connector to read/write from DuckDB database files.
+"""
+import logging as _logging
+from typing import Union as _Union
+
+import pandas as _pd
+
+from ..utils import (
+    LazyLoader as _LazyLoader,
+    wildcard_expansion as _wildcard_expansion,
+)
+
+
+_duckdb = _LazyLoader('duckdb')
+
+_schema = {}
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '.'.join(
+        f'"{part.replace(chr(34), chr(34) * 2)}"'
+        for part in str(identifier).split('.')
+    )
+
+
+def read(
+    database: str,
+    command: str,
+    columns: _Union[str, list] = None,
+    params: _Union[list, tuple, dict] = None,
+    **kwargs
+) -> _pd.DataFrame:
+    """
+    Read data from a DuckDB database.
+
+    >>> from wrangles.connectors import duckdb
+    >>> df = duckdb.read(database='database.duckdb', command='SELECT * FROM table')
+
+    :param database: The database to connect to including the file path. Use ':memory:' for an in-memory database.
+    :param command: SQL command to select data.
+    :param columns: (Optional) Subset of columns to be returned. This is less efficient than specifying in the SQL command.
+    :param params: (Optional) Variables to pass to a parameterized query.
+    """
+    _logging.info(f": Reading data from DuckDB :: {database}")
+
+    with _duckdb.connect(database=database, **kwargs) as conn:
+        df = conn.execute(command, params or ()).fetchdf()
+
+    if columns is not None:
+        columns = _wildcard_expansion(df.columns, columns)
+        df = df[columns]
+
+    return df
+
+
+_schema['read'] = r"""
+type: object
+description: Import data from a DuckDB Database
+required:
+  - database
+  - command
+properties:
+  database:
+    type: string
+    description: The database to connect to including the file path. Use ':memory:' for an in-memory database.
+  command:
+    type: string
+    description: |-
+      SQL command to select data.
+      Note - using variables here can make your recipe vulnerable
+      to sql injection. Use params if using variables from
+      untrusted sources.
+  columns:
+    type:
+      - string
+      - array
+    description: A list with a subset of the columns to import. This is less efficient than specifying in the command.
+  params:
+    type:
+      - array
+      - object
+    description: Variables to pass to a parameterized query.
+"""
+
+
+def write(
+    df: _pd.DataFrame,
+    database: str,
+    table: str,
+    action: str = 'INSERT',
+    columns: _Union[str, list] = None,
+    **kwargs
+) -> None:
+    """
+    Write data to a DuckDB database.
+
+    >>> from wrangles.connectors import duckdb
+    >>> duckdb.write(df, database='database.duckdb', table='table')
+
+    :param df: Pandas Dataframe to be written.
+    :param database: The database to connect to including the file path. Use ':memory:' for an in-memory database.
+    :param table: Table to be exported to.
+    :param action: INSERT appends, REPLACE recreates the table, FAIL errors if the table exists. Defaults to INSERT.
+    :param columns: (Optional) Subset of the columns to be written. If not provided, all columns will be output.
+    """
+    _logging.info(f": Writing data to DuckDB :: {database} / {table}")
+
+    action = action.upper()
+    if columns is not None:
+        columns = _wildcard_expansion(df.columns, columns)
+        df = df[columns]
+
+    table_name = _quote_identifier(table)
+    with _duckdb.connect(database=database, **kwargs) as conn:
+        conn.register('_wrangles_df', df)
+
+        if action == 'FAIL':
+            conn.execute(f'CREATE TABLE {table_name} AS SELECT * FROM _wrangles_df')
+        elif action == 'REPLACE':
+            conn.execute(f'CREATE OR REPLACE TABLE {table_name} AS SELECT * FROM _wrangles_df')
+        elif action == 'INSERT':
+            conn.execute(f'CREATE TABLE IF NOT EXISTS {table_name} AS SELECT * FROM _wrangles_df WHERE false')
+            conn.execute(f'INSERT INTO {table_name} SELECT * FROM _wrangles_df')
+        else:
+            raise ValueError('Invalid action. Expected INSERT, REPLACE, or FAIL.')
+
+
+_schema['write'] = """
+type: object
+description: Export data to a DuckDB Database
+required:
+  - database
+  - table
+properties:
+  database:
+    type: string
+    description: The database to connect to including the file path. Use ':memory:' for an in-memory database.
+  table:
+    type: string
+    description: The table to write to
+  action:
+    type: string
+    description: INSERT appends, REPLACE recreates the table, FAIL errors if the table exists. Defaults to INSERT.
+    enum:
+      - INSERT
+      - REPLACE
+      - FAIL
+  columns:
+    type:
+      - string
+      - array
+    description: A list of the columns to write to the table. If omitted, all columns will be written.
+"""
+
+
+def run(
+    database: str,
+    command: _Union[str, list],
+    params: _Union[list, tuple, dict] = None,
+    **kwargs
+) -> None:
+    """
+    Run a command on a DuckDB database.
+
+    >>> wrangles.connectors.duckdb.run(
+    >>>    database='database.duckdb',
+    >>>    command='<SQL COMMAND>'
+    >>> )
+
+    :param database: The database to connect to including the file path. Use ':memory:' for an in-memory database.
+    :param command: SQL command or a list of SQL commands to execute.
+    :param params: Variables to pass to a parameterized query.
+    """
+    _logging.info(f": Executing DuckDB Command :: {database}")
+
+    if isinstance(command, str):
+        command = [command]
+
+    with _duckdb.connect(database=database, **kwargs) as conn:
+        for sql in command:
+            conn.execute(sql, params or ())
+
+
+_schema['run'] = r"""
+type: object
+description: Run a command against a DuckDB Database
+required:
+  - database
+  - command
+properties:
+  database:
+    type: string
+    description: The database to connect to including the file path. Use ':memory:' for an in-memory database.
+  command:
+    type:
+      - string
+      - array
+    description: SQL command or a list of SQL commands to execute
+  params:
+    type:
+      - array
+      - object
+    description: Variables to pass to a parameterized query.
+"""


### PR DESCRIPTION
# Add DuckDB and Microsoft Access connectors

## Summary
- Adds a `duckdb` connector (`wrangles/connectors/duckdb.py`) with `read`/`write`/`run` operations, backed by the `duckdb` package.
- Adds an `access` connector (`wrangles/connectors/access.py`) for Microsoft Access databases with `read`/`write`/`run` operations, backed by `pyodbc`.
- Registers both connectors in `wrangles/connectors/__init__.py` so they're usable from recipes (`duckdb:` / `access:` keys) and from the Python API.
- Documents the new optional dependencies in `README.md` and `requirements-full.txt` (`duckdb>=1.0.0`, `pyodbc>=5.0.0`).
- Adds connector tests (`tests/connectors/test_duckdb.py`, `tests/connectors/test_access.py`), skipped automatically if the optional dependency isn't installed.



## Usage

### DuckDB — Python API
```python
from wrangles.connectors import duckdb

# Read
df = duckdb.read(database='database.duckdb', command='SELECT * FROM table')

# Write (INSERT / REPLACE / FAIL)
duckdb.write(df, database='database.duckdb', table='table', action='REPLACE')

# Run arbitrary SQL (single command or list)
duckdb.run(database='database.duckdb', command='CREATE INDEX idx ON table(col)')
```

### DuckDB — Recipe YAML
```yaml
read:
  duckdb:
    database: database.duckdb
    command: SELECT * FROM table

wrangles:
  - ...

write:
  duckdb:
    database: database.duckdb
    table: output_table
    action: REPLACE
```

### Microsoft Access — Python API
```python
from wrangles.connectors import access

# Read (via database file or full connection string)
df = access.read(database='database.accdb', command='SELECT * FROM table')

# Write — auto-creates the table if it doesn't exist
access.write(df, database='database.accdb', table='table', action='INSERT')

# Run arbitrary SQL
access.run(database='database.accdb', command='DELETE FROM table WHERE id = ?', params=[42])
```

### Microsoft Access — Recipe YAML
```yaml
read:
  access:
    database: database.accdb
    command: SELECT * FROM table

wrangles:
  - ...

write:
  access:
    database: database.accdb
    table: output_table
    action: REPLACE
```

Both connectors also support `:memory:` (DuckDB) and a raw `connection_string` (Access) for advanced configuration, and a `params` argument for parameterized queries to avoid SQL injection.

## New optional dependencies
| Capability | Install |
|---|---|
| DuckDB | `pip install duckdb` |
| Microsoft Access | `pip install pyodbc` |
