### PR TITLE
Add ability to trigger the deploy job directly from the wranglerspy

### DIFF
--- a/.github/workflows/publish-dev-rc.yml
+++ b/.github/workflows/publish-dev-rc.yml
@@ -108,7 +108,7 @@ jobs:
   # guarded to the 'dev' branch, and every commit on 'dev' is already tested by
   # publish-dev.yml 
   test-pip-install:
-    name: Smoke Test – pip install
+    name: smoke test
     runs-on: ubuntu-latest
     needs: [compute-version]
     permissions:
@@ -130,7 +130,7 @@ jobs:
 
   # ── 3. Publish Python package to CodeArtifact ────────────────────────────
   publish-codeartifact:
-    name: Publish RC to CodeArtifact
+    name: Publish RC Package
     runs-on: ubuntu-latest
     needs: [compute-version, test-pip-install]
     permissions:
@@ -174,3 +174,25 @@ jobs:
 
       - name: Publish to CodeArtifact
         run: twine upload --repository codeartifact dist/*
+
+  # ── 4. Trigger QA deployment in Lambda-Recipes ───────────────────────────
+  # CROSS_REPO_PAT: a GitHub PAT with Actions read/write on Lambda-Recipes,
+  # stored as a repository or org secret. Required to dispatch workflows across repositories.
+  trigger-deploy-qa:
+    name: Trigger QA Deploy
+    runs-on: ubuntu-latest
+    needs: [compute-version, publish-codeartifact]
+    steps:
+      - name: Deploy QA
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: wrangleworks
+          repo: Lambda-Recipes
+          workflow_file_name: deploy-qa.yml
+          github_token: ${{ secrets.CROSS_REPO_PAT }}
+          ref: main
+          wait_interval: 15
+          client_payload: '{"wrangles_version": "${{ needs.compute-version.outputs.rc_version }}"}'
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true


### PR DESCRIPTION
## Summary
- Added a `trigger-deploy-qa` job as the final stage of the `publish-dev-rc.yml` CI pipeline.
- The job runs after `publish-codeartifact` succeeds and triggers the `deploy-qa.yml` workflow in the `wrangleworks/Lambda-Recipes` repository using `convictional/trigger-workflow-and-wait@v1.6.5`.
- The computed RC version (e.g. `1.20.0rc3`) is forwarded to the QA deployment via `client_payload`.
- The job blocks until the remote workflow completes and propagates any failures back to this pipeline.
## Changes
- `.github/workflows/publish-dev-rc.yml`: appended `trigger-deploy-qa` job with the following characteristics:
  - `needs: [compute-version, publish-codeartifact]` — only runs after a successful CodeArtifact publish
  - Uses `secrets.CROSS_REPO_PAT` for cross-repository workflow dispatch (a GitHub PAT with Actions read/write on `Lambda-Recipes`, stored as a repository or org secret)
  - Polls every 15 seconds (`wait_interval: 15`) and waits for the remote run to complete before reporting status
## Prerequisites
- A GitHub secret named `CROSS_REPO_PAT` must be configured in this repository (or at org level) with a PAT that has **Actions: read/write** permission on `wrangleworks/Lambda-Recipes`.
- `Lambda-Recipes` must have a `deploy-qa.yml` workflow triggered via `workflow_dispatch` that accepts a `wrangles_version` input.
## Pipeline flow after this change
compute-version → test-pip-install → publish-codeartifact → trigger-deploy-qa