### PR TITLE
1010 consistent response orientation for extracts

### DIFF
--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -1361,21 +1361,33 @@ class TestTrainLookup:
         assert 'Blade Runner Upsert' in df['City'].values
         assert 'New Value' in df['City'].values
     
-    def test_missing_columns_error_message(self):  
-        """  
-        Verify that INSERT/UPSERT/UPDATE raise the expected error  
-        when incoming columns are not present in the existing model.  
-        """  
+    def test_missing_columns_error_message(self, mocker):
+        """
+        Verify that INSERT/UPSERT/UPDATE raise the expected error
+        when incoming columns are not present in the existing model.
+        """
 
-        df = pd.DataFrame({  
-            "Key": ["k3"],  
-            "Value": ["v3"],  
-            "ExtraCol": ["x"]  # This column does not exist in the model  
-        })  
+        df = pd.DataFrame({
+            "Key": ["k3"],
+            "Value": ["v3"],
+            "ExtraCol": ["x"]  # This column does not exist in the model
+        })
 
-    
-        # Test each action that performs the column-alignment check  
-        for action in ("insert", "upsert", "update"):  
+        # Mock the existing model so the test does not depend on a real, live model
+        mocker.patch(
+            "wrangles.data.model_content",
+            return_value={
+                "Columns": ["Key", "Value"],
+                "Data": [["k1", "v1"]]
+            }
+        )
+        mocker.patch(
+            "wrangles.data.model",
+            return_value={"variant": "key"}
+        )
+
+        # Test each action that performs the column-alignment check
+        for action in ("insert", "upsert", "update"):
             recipe = f"""
                 write:
                     - train.lookup:

--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -3328,7 +3328,7 @@ class TestExtractAI:
     """
     All tests for extract.ai
     """
-    def test_ai_output_format_json_dictionary(self):
+    def test_ai_output_format_dictionary(self):
         df = pd.DataFrame({
             "data": ["wrench 25mm"]
         })
@@ -3343,7 +3343,7 @@ class TestExtractAI:
               type:
                 type: string
                 description: Type of item
-            output_format: JSON Dictionary
+            output_format: Dictionary
             output_column_name: result
         """
         with patch(

--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -681,6 +681,57 @@ class TestExtractCodes:
         df = wrangles.recipe.run(recipe, dataframe=data)
         assert df.iloc[0]['code'] == 'Z1ON0101'
 
+    def test_extract_codes_output_format_string_with_delimiter(self):
+        data = pd.DataFrame({
+            'col1': ['codes here']
+        })
+        recipe = """
+        wrangles:
+        - extract.codes:
+            input: col1
+            output: code
+            output_format: String
+            delimiter: " | "
+        """
+        with patch("wrangles.extract.codes", return_value=[["ABC123", "XYZ789"]]):
+            df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df.iloc[0]['code'] == 'ABC123 | XYZ789'
+
+    def test_extract_codes_output_format_columns(self):
+        data = pd.DataFrame({
+            'col1': ['codes here']
+        })
+        recipe = """
+        wrangles:
+        - extract.codes:
+            input: col1
+            output:
+              - Code 1
+              - Code 2
+            output_format: Columns
+        """
+        with patch("wrangles.extract.codes", return_value=[["ABC123", "XYZ789"]]):
+            df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df.iloc[0]['Code 1'] == 'ABC123'
+        assert df.iloc[0]['Code 2'] == 'XYZ789'
+
+    def test_extract_codes_output_format_columns_with_output_column_name(self):
+        data = pd.DataFrame({
+            'col1': ['codes here']
+        })
+        recipe = """
+        wrangles:
+        - extract.codes:
+            input: col1
+            output: ignored_base
+            output_format: Columns
+            output_column_name: code
+        """
+        with patch("wrangles.extract.codes", return_value=[["ABC123", "XYZ789"]]):
+            df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df.iloc[0]['code 1'] == 'ABC123'
+        assert df.iloc[0]['code 2'] == 'XYZ789'
+
     def test_extract_codes_where(self):
         """
         Test extract.codes with a where
@@ -1203,6 +1254,35 @@ class TestExtractCustom:
             'Charizard' in df['Fact Output'][0] and
             'Pikachu' in df['Fact Output'][0]
         )
+
+    def test_extract_custom_use_labels_output_format_columns_multi_input(self):
+        data = pd.DataFrame({
+            'col1': ['blue shirt', 'red hat'],
+            'col2': ['small shirt', 'large red hat']
+        })
+        recipe = """
+        wrangles:
+        - extract.custom:
+            input:
+              - col1
+              - col2
+            output: attributes
+            model_id: 829c1a73-1bfd-4ac0
+            use_labels: true
+            output_format: Columns
+        """
+        with patch(
+            "wrangles.extract.custom",
+            side_effect=[
+                [{'colour': ['blue']}, {'colour': ['red']}],
+                [{'size': ['small']}, {'colour': ['red'], 'size': ['large']}],
+            ]
+        ):
+            df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df.iloc[0]['colour'] == ['blue']
+        assert df.iloc[0]['size'] == ['small']
+        assert df.iloc[1]['colour'] == ['red']
+        assert df.iloc[1]['size'] == ['large']
 
     def test_extract_custom_mulit_input_output(self):
         """
@@ -2407,6 +2487,45 @@ class TestExtractProperties:
             info.typename == 'TypeError' and
             'first_element must be used with a specified property_type' in info.value.args[0]
         )
+
+    def test_extract_properties_output_format_columns(self):
+        data = pd.DataFrame({
+            'col': ['green cotton square']
+        })
+        recipe = """
+        wrangles:
+        - extract.properties:
+            input: col
+            output: properties
+            output_format: Columns
+        """
+        with patch(
+            "wrangles.extract.properties",
+            return_value=[{'Colours': ['green'], 'Materials': ['cotton']}]
+        ):
+            df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df.iloc[0]['Colours'] == ['green']
+        assert df.iloc[0]['Materials'] == ['cotton']
+
+    def test_extract_properties_output_format_string_with_delimiter(self):
+        data = pd.DataFrame({
+            'col': ['green blue']
+        })
+        recipe = """
+        wrangles:
+        - extract.properties:
+            input: col
+            output: colours
+            property_type: Colours
+            output_format: String
+            delimiter: "; "
+        """
+        with patch(
+            "wrangles.extract.properties",
+            return_value=[['green', 'blue']]
+        ):
+            df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df.iloc[0]['colours'] == 'green; blue'
         
     def test_extract_materials(self):
         recipe = """
@@ -3209,6 +3328,53 @@ class TestExtractAI:
     """
     All tests for extract.ai
     """
+    def test_ai_output_format_json_dictionary(self):
+        df = pd.DataFrame({
+            "data": ["wrench 25mm"]
+        })
+        recipe = """
+        wrangles:
+        - extract.ai:
+            api_key: dummy
+            output:
+              length:
+                type: string
+                description: Any lengths found in the data
+              type:
+                type: string
+                description: Type of item
+            output_format: JSON Dictionary
+            output_column_name: result
+        """
+        with patch(
+            "wrangles.extract.ai",
+            return_value=[{"length": "25mm", "type": "wrench"}]
+        ):
+            result = wrangles.recipe.run(recipe, dataframe=df)
+        assert result.iloc[0]["result"] == {"length": "25mm", "type": "wrench"}
+
+    def test_ai_output_format_string_with_delimiter(self):
+        df = pd.DataFrame({
+            "data": ["wrench 25mm"]
+        })
+        recipe = """
+        wrangles:
+        - extract.ai:
+            api_key: dummy
+            output:
+              tags:
+                type: array
+                description: Tags found in the data
+            output_format: String
+            delimiter: " | "
+        """
+        with patch(
+            "wrangles.extract.ai",
+            return_value=[{"tags": ["wrench", "25mm"]}]
+        ):
+            result = wrangles.recipe.run(recipe, dataframe=df)
+        assert result.iloc[0]["tags"] == "wrench | 25mm"
+
     def test_ai(self):
         """
         Test openai extract with a single input and output

--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -472,7 +472,11 @@ class TestExtractAttributes:
 
     def test_attributes_single_input_multi_output(self):
         """
-        If the input and output are different lengths
+        A single input with a multi-name output list implicitly
+        fans the results out across explicit columns. The number
+        of columns actually created is capped to however many
+        results were found - only one match here, so only the
+        first output column is created.
         """
         data = pd.DataFrame({
             'col1': ['13 something 13kg 13 random'],
@@ -482,18 +486,15 @@ class TestExtractAttributes:
         wrangles:
             - extract.attributes:
                 input: col1
-                output: 
+                output:
                 - out1
                 - out2
                 responseContent: span
                 attribute_type: mass
         """
-        with pytest.raises(ValueError) as info:
-            wrangles.recipe.run(recipe, dataframe=data)
-        assert (
-            info.typename == 'ValueError' and
-            'Extract must output to a single column or equal amount of columns as input.' in info.value.args[0]
-        )
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df.iloc[0]['out1'] == '13kg'
+        assert 'out2' not in df.columns
 
     def test_attributes_where(self):
         """
@@ -631,21 +632,24 @@ class TestExtractCodes:
         assert df.iloc[0]['out2'] == ['Z1ON0101-2', 'Z1ON0101']
 
     def test_extract_codes_one_input_multi_output(self):
+        """
+        A single input with a multi-name output list implicitly
+        fans results across explicit columns, without needing
+        output_format: Columns to be set.
+        """
         recipe = """
         wrangles:
         - extract.codes:
-            input: 
+            input:
                 - code1
             output:
                 - out1
                 - out2
         """
-        with pytest.raises(ValueError) as info:
-            wrangles.recipe.run(recipe, dataframe=self.df_multi_input)
-        assert (
-            info.typename == 'ValueError' and
-            'Extract must output to a single column or equal amount of columns as input.' in info.value.args[0]
-        )
+        with patch("wrangles.extract.codes", return_value=[["ABC123", "XYZ789"]]):
+            df = wrangles.recipe.run(recipe, dataframe=self.df_multi_input)
+        assert df.iloc[0]['out1'] == 'ABC123'
+        assert df.iloc[0]['out2'] == 'XYZ789'
 
     def test_extract_codes_first_element(self):
         """
@@ -714,23 +718,6 @@ class TestExtractCodes:
             df = wrangles.recipe.run(recipe, dataframe=data)
         assert df.iloc[0]['Code 1'] == 'ABC123'
         assert df.iloc[0]['Code 2'] == 'XYZ789'
-
-    def test_extract_codes_output_format_columns_with_output_column_name(self):
-        data = pd.DataFrame({
-            'col1': ['codes here']
-        })
-        recipe = """
-        wrangles:
-        - extract.codes:
-            input: col1
-            output: ignored_base
-            output_format: Columns
-            output_column_name: code
-        """
-        with patch("wrangles.extract.codes", return_value=[["ABC123", "XYZ789"]]):
-            df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['code 1'] == 'ABC123'
-        assert df.iloc[0]['code 2'] == 'XYZ789'
 
     def test_extract_codes_where(self):
         """
@@ -3344,14 +3331,13 @@ class TestExtractAI:
                 type: string
                 description: Type of item
             output_format: Dictionary
-            output_column_name: result
         """
         with patch(
             "wrangles.extract.ai",
             return_value=[{"length": "25mm", "type": "wrench"}]
         ):
             result = wrangles.recipe.run(recipe, dataframe=df)
-        assert result.iloc[0]["result"] == {"length": "25mm", "type": "wrench"}
+        assert result.iloc[0]["output"] == {"length": "25mm", "type": "wrench"}
 
     def test_ai_output_format_string_with_delimiter(self):
         df = pd.DataFrame({

--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -2756,7 +2756,7 @@ class TestExtractBrackets:
             output: no_brackets
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['no_brackets'] == '1234'
+        assert df.iloc[0]['no_brackets'] == ['1234']
 
     def test_extract_brackets_output_format_columns_caps_matches(self):
         """
@@ -2844,7 +2844,7 @@ class TestExtractBrackets:
                 - no_brackets2
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['no_brackets2'] == '1234'
+        assert df.iloc[0]['no_brackets2'] == ['1234']
 
     def test_extract_brackets_3(self):
         """
@@ -2863,7 +2863,7 @@ class TestExtractBrackets:
             output: output
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == '12345, 1234'
+        assert df.iloc[0]['output'] == ['12345', '1234']
 
     def test_extract_brackets_multi_input(self):
         """
@@ -2882,7 +2882,7 @@ class TestExtractBrackets:
             output: output
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == '12345, 6789'
+        assert df.iloc[0]['output'] == ['12345', '6789']
 
     def test_extract_brackets_multi_input_where(self):
         """
@@ -2903,7 +2903,7 @@ class TestExtractBrackets:
             where: numbers > 4
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == "" and df.iloc[1]['output'] == 'this is in brackets' and df.iloc[2]['output'] == 'more stuff in brackets, But this is'
+        assert df.iloc[0]['output'] == "" and df.iloc[1]['output'] == ['this is in brackets'] and df.iloc[2]['output'] == ['more stuff in brackets', 'But this is']
 
     def test_brackets_round(self):
         data = pd.DataFrame({
@@ -2917,8 +2917,8 @@ class TestExtractBrackets:
                 find: round
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == 'some'
-        assert df.iloc[1]['output'] == ''
+        assert df.iloc[0]['output'] == ['some']
+        assert df.iloc[1]['output'] == []
 
     def test_brackets_square(self):
         data = pd.DataFrame({
@@ -2932,8 +2932,8 @@ class TestExtractBrackets:
                 find: square
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == 'example'
-        assert df.iloc[1]['output'] == ''
+        assert df.iloc[0]['output'] == ['example']
+        assert df.iloc[1]['output'] == []
 
     def test_brackets_round_square(self):
         data = pd.DataFrame({
@@ -2949,8 +2949,8 @@ class TestExtractBrackets:
                     - square
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == 'some'
-        assert df.iloc[1]['output'] == 'example'
+        assert df.iloc[0]['output'] == ['some']
+        assert df.iloc[1]['output'] == ['example']
 
     def test_all_brackets(self):
         data = pd.DataFrame({
@@ -2968,7 +2968,7 @@ class TestExtractBrackets:
                     - angled
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['some', 'example', 'example', 'example']
+        assert df['output'].tolist() == [['some'], ['example'], ['example'], ['example']]
 
     def test_all_brackets_no_find(self):
         data = pd.DataFrame({
@@ -2981,7 +2981,7 @@ class TestExtractBrackets:
                 output: output
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['some, some2', 'example', 'example', 'example']
+        assert df['output'].tolist() == [['some', 'some2'], ['example'], ['example'], ['example']]
 
     def test_all_brackets_with_all_specified(self):
         data = pd.DataFrame({
@@ -2995,7 +2995,7 @@ class TestExtractBrackets:
                 find: all
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['some', 'example', 'example', 'example']
+        assert df['output'].tolist() == [['some'], ['example'], ['example'], ['example']]
 
     def test_multi_bracket_all_included(self):
         data = pd.DataFrame({
@@ -3012,7 +3012,7 @@ class TestExtractBrackets:
                     - all
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['some', 'example', '', '']
+        assert df['output'].tolist() == [['some'], ['example'], [], []]
 
     def test_all_brackets_no_find_raw(self):
         data = pd.DataFrame({
@@ -3026,7 +3026,7 @@ class TestExtractBrackets:
                 include_brackets: true
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['(some), (some2)', '[example]', '{example}', '<example>']
+        assert df['output'].tolist() == [['(some)', '(some2)'], ['[example]'], ['{example}'], ['<example>']]
 
     def test_all_brackets_raw(self):
         data = pd.DataFrame({
@@ -3045,7 +3045,7 @@ class TestExtractBrackets:
                 include_brackets: true
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['(some)', '[example]', '{example}', '<example>']
+        assert df['output'].tolist() == [['(some)'], ['[example]'], ['{example}'], ['<example>']]
 
     def test_two_bracket_types(self):
         data = pd.DataFrame({
@@ -3061,7 +3061,7 @@ class TestExtractBrackets:
                     - square
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['some', 'example', '', '']
+        assert df['output'].tolist() == [['some'], ['example'], [], []]
 
     def test_brackets_curly(self):
         data = pd.DataFrame({
@@ -3075,8 +3075,8 @@ class TestExtractBrackets:
                 find: curly
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == 'example'
-        assert df.iloc[1]['output'] == ''
+        assert df.iloc[0]['output'] == ['example']
+        assert df.iloc[1]['output'] == []
 
     def test_brackets_angled(self):
         data = pd.DataFrame({
@@ -3090,8 +3090,8 @@ class TestExtractBrackets:
                 find: angled
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == 'example'
-        assert df.iloc[1]['output'] == ''
+        assert df.iloc[0]['output'] == ['example']
+        assert df.iloc[1]['output'] == []
 
     def test_brackets_extract_raw(self):
         data = pd.DataFrame({
@@ -3105,9 +3105,9 @@ class TestExtractBrackets:
                 include_brackets: true
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == '(some)'
-        assert df.iloc[1]['output'] == '[example]'
-    
+        assert df.iloc[0]['output'] == ['(some)']
+        assert df.iloc[1]['output'] == ['[example]']
+
     def test_where(self):
         """
         Test using a where clause
@@ -3125,7 +3125,7 @@ class TestExtractBrackets:
                 'column': ['[x]', '[y]']
             })
         )
-        assert df['output'].values.tolist() == ['x', '']
+        assert df['output'].values.tolist() == [['x'], '']
 
     def test_brackets_empty(self):
         """

--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -99,7 +99,7 @@ class TestExtractAddress:
             where: elevation > 2000
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == "" and df.iloc[1]['output'][0] == '742 Evergreen St'
+        assert df.iloc[0]['output'] == "" and df.iloc[1]['output'] == '742 Evergreen St'
         
     
     def test_address_multi_input(self):
@@ -1091,7 +1091,7 @@ class TestExtractCustom:
             model_id: 1eddb7e8-1b2b-4a52
         """
         df =  wrangles.recipe.run(recipe, dataframe=data)
-        assert df['Fact Out'][0] == ['Charizard']
+        assert df['Fact Out'][0] == 'Charizard'
 
     def test_extract_custom_3(self):
         """
@@ -1313,7 +1313,7 @@ class TestExtractCustom:
             where: col1 LIKE col2
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output col'] == "" and df.iloc[2]['output col'] == ['Charizard', 'Pikachu']
+        assert df.iloc[0]['output col'] == "" and df.iloc[2]['output col'] == 'Charizard'
 
     def test_extract_custom_multi_io_where(self):
         """
@@ -2697,7 +2697,7 @@ class TestExtractHTML:
             data_type: links
         """
         df = wrangles.recipe.run(recipe, dataframe=self.df)
-        assert df.iloc[0]['Links'] == ['https://www.wrangleworks.com/']
+        assert df.iloc[0]['Links'] == 'https://www.wrangleworks.com/'
 
     def test_extract_html_where(self):
         """
@@ -2757,6 +2757,73 @@ class TestExtractBrackets:
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
         assert df.iloc[0]['no_brackets'] == '1234'
+
+    def test_extract_brackets_output_format_columns_caps_matches(self):
+        """
+        With explicit output_format: Columns and fewer named output
+        columns than matches found, only the first N matches (N =
+        number of output columns) are kept and the rest are dropped
+        """
+        data = pd.DataFrame({
+            'brackets_text': [
+                'Widget [SKU-123] (Qty: 5) {Location: A1}',
+                'Bolt <M6x20> [Steel] (Zinc Plated)'
+            ]
+        })
+        recipe = """
+        wrangles:
+        - extract.brackets:
+            input: brackets_text
+            output:
+                - col1
+                - col2
+            output_format: Columns
+            find: all
+            include_brackets: false
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert (
+            list(df.columns) == ['brackets_text', 'col1', 'col2'] and
+            df.iloc[0]['col1'] == 'SKU-123' and df.iloc[0]['col2'] == 'Qty: 5' and
+            df.iloc[1]['col1'] == 'M6x20' and df.iloc[1]['col2'] == 'Steel'
+        )
+
+    def test_extract_brackets_single_item_output_list(self):
+        """
+        Providing output as an explicit single-item list implies
+        Columns format - only as many matches as named columns are
+        kept, any additional matches are dropped
+        """
+        data = pd.DataFrame({
+            'col': ['(a) (b) (c)']
+        })
+        recipe = """
+        wrangles:
+        - extract.brackets:
+            input: col
+            output:
+                - col1
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df.iloc[0]['col1'] == 'a' and list(df.columns) == ['col', 'col1']
+
+    def test_extract_brackets_single_item_output_list_no_matches(self):
+        """
+        The explicitly named column should still be created, empty,
+        when no matches are found
+        """
+        data = pd.DataFrame({
+            'col': ['no brackets here']
+        })
+        recipe = """
+        wrangles:
+        - extract.brackets:
+            input: col
+            output:
+                - col1
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df.iloc[0]['col1'] == "" and 'col1' in df.columns
 
     def test_extract_brackets_2(self):
         """

--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -685,7 +685,7 @@ class TestExtractCodes:
         df = wrangles.recipe.run(recipe, dataframe=data)
         assert df.iloc[0]['code'] == 'Z1ON0101'
 
-    def test_extract_codes_output_format_string_with_delimiter(self):
+    def test_extract_codes_output_format_concatenate_with_char(self):
         data = pd.DataFrame({
             'col1': ['codes here']
         })
@@ -694,8 +694,8 @@ class TestExtractCodes:
         - extract.codes:
             input: col1
             output: code
-            output_format: String
-            delimiter: " | "
+            output_format: Concatenate
+            char: " | "
         """
         with patch("wrangles.extract.codes", return_value=[["ABC123", "XYZ789"]]):
             df = wrangles.recipe.run(recipe, dataframe=data)
@@ -2494,7 +2494,7 @@ class TestExtractProperties:
         assert df.iloc[0]['Colours'] == ['green']
         assert df.iloc[0]['Materials'] == ['cotton']
 
-    def test_extract_properties_output_format_string_with_delimiter(self):
+    def test_extract_properties_output_format_concatenate_with_char(self):
         data = pd.DataFrame({
             'col': ['green blue']
         })
@@ -2504,8 +2504,8 @@ class TestExtractProperties:
             input: col
             output: colours
             property_type: Colours
-            output_format: String
-            delimiter: "; "
+            output_format: Concatenate
+            char: "; "
         """
         with patch(
             "wrangles.extract.properties",
@@ -3406,7 +3406,7 @@ class TestExtractAI:
             result = wrangles.recipe.run(recipe, dataframe=df)
         assert result.iloc[0]["output"] == {"length": "25mm", "type": "wrench"}
 
-    def test_ai_output_format_string_with_delimiter(self):
+    def test_ai_output_format_concatenate_with_char(self):
         df = pd.DataFrame({
             "data": ["wrench 25mm"]
         })
@@ -3418,8 +3418,8 @@ class TestExtractAI:
               tags:
                 type: array
                 description: Tags found in the data
-            output_format: String
-            delimiter: " | "
+            output_format: Concatenate
+            char: " | "
         """
         with patch(
             "wrangles.extract.ai",

--- a/wrangles/extract.py
+++ b/wrangles/extract.py
@@ -687,7 +687,8 @@ def remove_words(input: _Union[str, list], to_remove: list, tokenize_to_remove: 
 def brackets(
     input: str,
     find: list = _Union[str, list],
-    include_brackets: bool = False
+    include_brackets: bool = False,
+    return_data_type: str = "string"
     ) -> list:
     """
     Extract values in brackets, [], {}, (), <>
@@ -722,7 +723,9 @@ def brackets(
         # Traverse list and remove all brackets if include_brackets is False
         if include_brackets is False:
             re = [_re.sub(r'\[|\]|{|}|\(|\)|<|>', '', re[x]) for x in range(len(re))]
-            results.append(', '.join(re))
+
+        if return_data_type == "list":
+            results.append(re)
         else:
             results.append(', '.join(re))
         

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -6,8 +6,171 @@ import re as _re
 import logging as _logging
 import pandas as _pd
 from .. import extract as _extract
-from .. import format as _format
 from .. import data as _data
+
+
+_OUTPUT_FORMAT_ALIASES = {
+    "json": "json",
+    "json list": "json_list",
+    "json_list": "json_list",
+    "list": "json_list",
+    "array": "json_list",
+    "json dictionary": "json_dictionary",
+    "json dict": "json_dictionary",
+    "json_dictionary": "json_dictionary",
+    "json_dict": "json_dictionary",
+    "dict": "json_dictionary",
+    "dictionary": "json_dictionary",
+    "columns": "columns",
+    "column": "columns",
+    "string": "string",
+    "text": "string",
+}
+
+
+def _normalize_output_format(output_format, default):
+    if output_format is None:
+        return default
+
+    output_format = _OUTPUT_FORMAT_ALIASES.get(
+        str(output_format).strip().lower().replace("-", "_"),
+        output_format
+    )
+
+    if output_format == "json":
+        return default
+
+    if output_format not in ("json_list", "json_dictionary", "columns", "string"):
+        raise ValueError(
+            "output_format must be one of JSON List, JSON Dictionary, Columns, or String"
+        )
+
+    return output_format
+
+
+def _ensure_list(value):
+    return value if isinstance(value, list) else [value]
+
+
+def _is_columns_format(output_format):
+    return _normalize_output_format(output_format, "json_list") == "columns"
+
+
+def _stringify_list(value, delimiter):
+    if value in (None, ""):
+        return ""
+    if isinstance(value, list):
+        return delimiter.join([str(item) for item in value])
+    return str(value)
+
+
+def _write_list_output(
+    df,
+    output,
+    results,
+    output_format,
+    delimiter=", ",
+    default_format="json_list",
+    output_column_name=None
+):
+    output_format = _normalize_output_format(output_format, default_format)
+
+    if output_format == "json_dictionary":
+        raise ValueError("output_format JSON Dictionary is only valid for dictionary-producing extracts")
+
+    if output_format == "string":
+        df[output[0]] = [_stringify_list(row, delimiter) for row in results]
+        return
+
+    if output_format == "columns":
+        output_count = len(output) if len(output) > 1 else max(
+            [len(row) for row in results if isinstance(row, list)] or [1]
+        )
+        output_columns = (
+            output
+            if len(output) > 1
+            else [f"{output_column_name or output[0]} {i + 1}" for i in range(output_count)]
+        )
+        for i, output_column in enumerate(output_columns):
+            df[output_column] = [
+                row[i] if isinstance(row, list) and len(row) > i else ""
+                for row in results
+            ]
+        return
+
+    df[output[0]] = results
+
+
+def _dict_keys(results):
+    keys = []
+    for row in results:
+        if isinstance(row, dict):
+            for key in row:
+                if key not in keys:
+                    keys.append(key)
+    return keys
+
+
+def _write_dict_output(df, output, results, output_format, default_format="json_dictionary"):
+    output_format = _normalize_output_format(output_format, default_format)
+
+    if output_format in ("json_list", "string"):
+        raise ValueError("output_format JSON List or String is only valid for list-producing extracts")
+
+    if output_format == "columns":
+        output_columns = output if len(output) > 1 else (_dict_keys(results) or output)
+        for output_column in output_columns:
+            df[output_column] = [
+                row.get(output_column, "") if isinstance(row, dict) else ""
+                for row in results
+            ]
+        return
+
+    df[output[0]] = results
+
+
+def _write_results(
+    df,
+    output,
+    results,
+    output_format,
+    delimiter=", ",
+    default_format="json_list",
+    output_column_name=None
+):
+    if default_format == "json_dictionary":
+        _write_dict_output(df, output, results, output_format)
+    else:
+        _write_list_output(
+            df,
+            output,
+            results,
+            output_format,
+            delimiter,
+            default_format,
+            output_column_name
+        )
+
+
+def _combine_list_rows(rows):
+    combined = []
+    for row in rows:
+        if isinstance(row, list):
+            combined.extend(row)
+        elif row not in ("", None):
+            combined.append(row)
+    return list(dict.fromkeys(combined))
+
+
+def _combine_dict_rows(rows):
+    combined = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        for key, value in row.items():
+            values = value if isinstance(value, list) else [value]
+            combined[key] = _combine_list_rows([combined.get(key, []), values])
+    return combined
 
 
 def address(
@@ -15,6 +178,9 @@ def address(
     input: _Union[str, int, list],
     output: _Union[str, list],
     dataType: str,
+    output_format: str = None,
+    output_column_name: str = None,
+    delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -43,6 +209,19 @@ def address(
           - cities
           - regions
           - countries
+      output_format:
+        type: string
+        description: Format of the extract output
+        enum:
+          - JSON List
+          - Columns
+          - String
+      delimiter:
+        type: string
+        description: Delimiter to use when output_format is String
+      output_column_name:
+        type: string
+        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -52,24 +231,32 @@ def address(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1:
+    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    _logging.info(f": Extracting address {dataType} :: input :: {input}")
-    if len(output) == 1 and len(input) > 1:
-        df[output[0]] = _extract.address(
+    if len(input) == 1 and _is_columns_format(output_format):
+        results = _extract.address(
+            df[input[0]].astype(str).tolist(),
+            dataType,
+            **kwargs
+        )
+        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+    elif len(output) == 1 and len(input) > 1:
+        results = _extract.address(
             df[input].astype(str).aggregate(' '.join, axis=1).tolist(),
             dataType,
             **kwargs
         )
+        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
-            df[output_column] = _extract.address(
+            results = _extract.address(
                 df[input_column].astype(str).tolist(),
                 dataType,
                 **kwargs
             )
+            _write_list_output(df, [output_column], results, output_format, delimiter, output_column_name=output_column_name)
   
     return df
 
@@ -80,6 +267,9 @@ def ai(
     input: list = None,
     output: _Union[dict, str, list] = None,
     model_id: str = None,
+    output_format: str = None,
+    output_column_name: str = None,
+    delimiter: str = ", ",
     **kwargs
 ):
     """
@@ -172,8 +362,22 @@ def ai(
           Enable strict mode. Default False.
           If True, the function will be required to match the schema,
           but may be more limited in the schema it can return.
+      output_format:
+        type: string
+        description: Format of the extract output
+        enum:
+          - JSON Dictionary
+          - Columns
+          - String
+      output_column_name:
+        type: string
+        description: Column name to use when output_format is JSON Dictionary
+      delimiter:
+        type: string
+        description: Delimiter to use when output_format is String
     """
-    _logging.info(f": Extracting using AI :: model_id :: {model_id}, input :: {input}")
+    output_format_normalized = _normalize_output_format(output_format, "columns")
+
     # If input is provided, extract only those columns
     # Otherwise, provide the whole dataframe
     if input is not None:
@@ -245,7 +449,29 @@ def ai(
     try:
         exploded_df = _pd.json_normalize(results, max_level=0).fillna('').set_index(df.index)
 
-        if target_columns and len(target_columns) == 1:
+        if output_format_normalized == "json_dictionary":
+            if output_column_name is None:
+                output_column_name = target_columns[0] if target_columns and len(target_columns) == 1 else "output"
+            df[output_column_name] = results
+        elif output_format_normalized == "string":
+            if target_columns and len(target_columns) != 1:
+                raise ValueError("output_format String can only be used with a single output column")
+            output_column = (
+                target_columns[0]
+                if target_columns
+                else output_column_name or "output"
+            )
+            if len(exploded_df.columns) == 1:
+                df[output_column] = [
+                    _stringify_list(row, delimiter)
+                    for row in exploded_df[exploded_df.columns[0]].tolist()
+                ]
+            else:
+                df[output_column] = [
+                    delimiter.join([_stringify_list(value, delimiter) for value in row.values()])
+                    for row in results
+                ]
+        elif target_columns and len(target_columns) == 1:
             if len(exploded_df.columns) == 1:
                 # If the AI model only returns a single column
                 # then use the contents of that columns as the output
@@ -280,6 +506,9 @@ def attributes(
     desired_unit: str = None,
     bound: str = 'mid',
     first_element: bool = False,
+    output_format: str = None,
+    output_column_name: str = None,
+    delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -348,6 +577,20 @@ def attributes(
       first_element:
         type: boolean
         description: Get the first element from results
+      output_format:
+        type: string
+        description: Format of the extract output
+        enum:
+          - JSON List
+          - JSON Dictionary
+          - Columns
+          - String
+      delimiter:
+        type: string
+        description: Delimiter to use when output_format is String
+      output_column_name:
+        type: string
+        description: Base output column name to use when output_format is Columns
     $ref: "#/$defs/misc/unit_entity_map"
     """
     # If output is not specified, overwrite input columns in place
@@ -358,32 +601,68 @@ def attributes(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1:
+    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    _logging.info(f": Extracting attributes :: input :: {input}")
-    if len(output) == 1 and len(input) > 1:
+    if len(input) == 1 and _is_columns_format(output_format):
+        results = _extract.attributes(
+            df[input[0]].astype(str).tolist(),
+            responseContent,
+            attribute_type,
+            desired_unit,
+            bound,
+            False,
+            **kwargs
+        )
+        _write_results(
+            df,
+            output,
+            results,
+            output_format,
+            delimiter,
+            "json_list" if attribute_type else "json_dictionary",
+            output_column_name
+        )
+    elif len(output) == 1 and len(input) > 1:
         # df[output[0]] = _extract.attributes(df[input].astype(str).aggregate(' AAA '.join, axis=1).tolist())
-        df[output[0]] = _extract.attributes(
+        results = _extract.attributes(
             df[input].astype(str).aggregate(' AAA '.join, axis=1).tolist(),
             responseContent,
             attribute_type,
             desired_unit,
             bound,
-            first_element,
+            first_element if output_format is None else False,
             **kwargs
+        )
+        _write_results(
+            df,
+            output,
+            results,
+            output_format,
+            delimiter,
+            "json_list" if attribute_type else "json_dictionary",
+            output_column_name
         )
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
-            df[output_column] = _extract.attributes(
+            results = _extract.attributes(
                 df[input_column].astype(str).tolist(),
                 responseContent,
                 attribute_type,
                 desired_unit,
                 bound,
-                first_element,
+                first_element if output_format is None else False,
                 **kwargs
+            )
+            _write_results(
+                df,
+                [output_column],
+                results,
+                output_format,
+                delimiter,
+                "json_list" if attribute_type else "json_dictionary",
+                output_column_name
             )
         
     return df
@@ -394,7 +673,10 @@ def brackets(
     input: _Union[str, int, list],
     output: _Union[str, list],
     find: _Union[str, list] = 'all',
-    include_brackets: bool = False
+    include_brackets: bool = False,
+    output_format: str = None,
+    output_column_name: str = None,
+    delimiter: str = ", "
 ) -> _pd.DataFrame:
     """
     type: object
@@ -423,6 +705,19 @@ def brackets(
       include_brackets:
         type: boolean
         description: (Optional) Include the brackets in the output
+      output_format:
+        type: string
+        description: Format of the extract output
+        enum:
+          - JSON List
+          - Columns
+          - String
+      delimiter:
+        type: string
+        description: Delimiter to use when output_format is String
+      output_column_name:
+        type: string
+        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -432,7 +727,7 @@ def brackets(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1:
+    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
     _logging.debug(f": Extracting from brackets :: input :: {input}")
@@ -446,12 +741,58 @@ def brackets(
         raise ValueError("find must only contain the elements: round, square, curly, angled")
 
     # If only only one output and multiple inputs, concatenate the inputs
-    if len(output) == 1 and len(input) > 1:
-        df[output[0]] = _extract.brackets(df[input].astype(str).aggregate(' '.join, axis=1).tolist(), find, include_brackets)
+    return_data_type = "string" if output_format is None else "list"
+
+    if len(input) == 1 and _is_columns_format(output_format):
+        results = _extract.brackets(
+            df[input[0]].astype(str).tolist(),
+            find,
+            include_brackets,
+            return_data_type=return_data_type
+        )
+        _write_list_output(
+            df,
+            output,
+            results,
+            output_format,
+            delimiter,
+            default_format="string",
+            output_column_name=output_column_name
+        )
+    elif len(output) == 1 and len(input) > 1:
+        results = _extract.brackets(
+            df[input].astype(str).aggregate(' '.join, axis=1).tolist(),
+            find,
+            include_brackets,
+            return_data_type=return_data_type
+        )
+        _write_list_output(
+            df,
+            output,
+            results,
+            output_format,
+            delimiter,
+            default_format="string",
+            output_column_name=output_column_name
+        )
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
-            df[output_column] = _extract.brackets(df[input_column].astype(str).tolist(), find, include_brackets)
+            results = _extract.brackets(
+                df[input_column].astype(str).tolist(),
+                find,
+                include_brackets,
+                return_data_type=return_data_type
+            )
+            _write_list_output(
+                df,
+                [output_column],
+                results,
+                output_format,
+                delimiter,
+                default_format="string",
+                output_column_name=output_column_name
+            )
 
     return df
 
@@ -461,6 +802,9 @@ def codes(
     input: _Union[str, int, list],
     output: _Union[str, list],
     first_element: bool = False,
+    output_format: str = None,
+    output_column_name: str = None,
+    delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -484,6 +828,19 @@ def codes(
       first_element:
         type: boolean
         description: Get the first element from results
+      output_format:
+        type: string
+        description: Format of the extract output
+        enum:
+          - JSON List
+          - Columns
+          - String
+      delimiter:
+        type: string
+        description: Delimiter to use when output_format is String
+      output_column_name:
+        type: string
+        description: Base output column name to use when output_format is Columns
       min_length:
         type:
           - integer
@@ -522,23 +879,32 @@ def codes(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1:
+    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    _logging.info(f": Extracting codes :: input :: {input}")
-    if len(output) == 1 and len(input) > 1:
-        df[output[0]] = _extract.codes(
-            df[input].astype(str).aggregate(' AAA '.join, axis=1).tolist(),
+    if len(input) == 1 and _is_columns_format(output_format):
+        results = _extract.codes(
+            df[input[0]].astype(str).tolist(),
+            False,
             **kwargs
         )
+        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+    elif len(output) == 1 and len(input) > 1:
+        results = _extract.codes(
+            df[input].astype(str).aggregate(' AAA '.join, axis=1).tolist(),
+            first_element if output_format is None else False,
+            **kwargs
+        )
+        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
-            df[output_column] = _extract.codes(
+            results = _extract.codes(
                 df[input_column].astype(str).tolist(),
-                first_element,
+                first_element if output_format is None else False,
                 **kwargs
             )
+            _write_list_output(df, [output_column], results, output_format, delimiter, output_column_name=output_column_name)
 
     return df
 
@@ -554,6 +920,9 @@ def custom(
     extract_raw: bool = False,
     use_spellcheck: bool = False,
     sort: str = 'training_order',
+    output_format: str = None,
+    output_column_name: str = None,
+    delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -606,6 +975,20 @@ def custom(
           - reverse_alphabetical
           - ascending
           - descending
+      output_format:
+        type: string
+        description: Format of the extract output
+        enum:
+          - JSON List
+          - JSON Dictionary
+          - Columns
+          - String
+      delimiter:
+        type: string
+        description: Delimiter to use when output_format is String
+      output_column_name:
+        type: string
+        description: Base output column name to use when output_format is Columns
     """
     if output is None: output = input
     
@@ -613,15 +996,34 @@ def custom(
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
     if not isinstance(model_id, list): model_id = [model_id]
+
+    default_format = "json_dictionary" if use_labels else "json_list"
     
-    if len(input) == len(output) and len(model_id) == 1:
+    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+        raise ValueError('Extract must output to a single column or equal amount of columns as input.')
+
+    if len(input) == 1 and _is_columns_format(output_format) and len(model_id) == 1:
+        results = _extract.custom(
+            df[input[0]].astype(str).tolist(),
+            model_id=model_id[0],
+            first_element=False,
+            use_labels=use_labels,
+            case_sensitive=case_sensitive,
+            extract_raw=extract_raw,
+            use_spellcheck=use_spellcheck,
+            sort=sort,
+            **kwargs
+        )
+        _write_results(df, output, results, output_format, delimiter, default_format, output_column_name)
+
+    elif len(input) == len(output) and len(model_id) == 1:
         # if one model_id, then use that model for all columns inputs and outputs
         model_id = [model_id[0] for _ in range(len(input))]
         for in_col, out_col, model in zip(input, output, model_id):
-            df[out_col] = _extract.custom(
+            results = _extract.custom(
                 df[in_col].astype(str).tolist(),
                 model_id=model,
-                first_element=first_element,
+                first_element=first_element if output_format is None else False,
                 use_labels=use_labels,
                 case_sensitive=case_sensitive,
                 extract_raw=extract_raw,
@@ -629,6 +1031,7 @@ def custom(
                 sort=sort,
                 **kwargs
             )
+            _write_results(df, [out_col], results, output_format, delimiter, default_format, output_column_name)
     
     elif len(input) > 1 and len(output) == 1 and len(model_id) == 1:
         model_id = [model_id[0] for _ in range(len(input))]
@@ -639,7 +1042,7 @@ def custom(
             df_temp[output + str(i)] = _extract.custom(
                 df[in_col].astype(str).tolist(),
                 model_id=single_model_id,
-                first_element=first_element,
+                first_element=first_element if output_format is None else False,
                 use_labels=use_labels,
                 case_sensitive=case_sensitive,
                 extract_raw=extract_raw,
@@ -648,16 +1051,19 @@ def custom(
                 **kwargs
             )
 
-        # Concatenate the results into a single column
-        df[output] = [list(dict.fromkeys(_format.concatenate([x for x in row if x], ' '))) for row in df_temp.values.tolist()]
+        if use_labels:
+            results = [_combine_dict_rows(row) for row in df_temp.values.tolist()]
+        else:
+            results = [_combine_list_rows(row) for row in df_temp.values.tolist()]
+        _write_results(df, [output], results, output_format, delimiter, default_format, output_column_name)
 
     else:
         # Iterate through the inputs, outputs and model_ids
         for in_col, out_col, model in zip(input, output, model_id):
-            df[out_col] = _extract.custom(
+            results = _extract.custom(
                 df[in_col].astype(str).tolist(),
                 model_id=model,
-                first_element=first_element,
+                first_element=first_element if output_format is None else False,
                 use_labels=use_labels,
                 case_sensitive=case_sensitive,
                 extract_raw=extract_raw,
@@ -665,6 +1071,7 @@ def custom(
                 sort=sort,
                 **kwargs
             )
+            _write_results(df, [out_col], results, output_format, delimiter, default_format, output_column_name)
 
     return df
 
@@ -858,6 +1265,9 @@ def html(
     input: _Union[str, int, list],
     data_type: str,
     output: _Union[str, list] = None,
+    output_format: str = None,
+    output_column_name: str = None,
+    delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -885,9 +1295,19 @@ def html(
         enum:
           - text
           - links
-      first_element:
-        type: boolean
-        description: Get the first element from results
+      output_format:
+        type: string
+        description: Format of the extract output
+        enum:
+          - JSON List
+          - Columns
+          - String
+      delimiter:
+        type: string
+        description: Delimiter to use when output_format is String
+      output_column_name:
+        type: string
+        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -897,17 +1317,25 @@ def html(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1:
+    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    _logging.debug(f": Extracting from HTML :: input :: {input}")
-    # Loop through and apply for all columns
-    for input_column, output_column in zip(input, output):
-        df[output_column] = _extract.html(
-            df[input_column].astype(str).tolist(),
+    if len(input) == 1 and _is_columns_format(output_format):
+        results = _extract.html(
+            df[input[0]].astype(str).tolist(),
             dataType=data_type,
             **kwargs
         )
+        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+    else:
+        # Loop through and apply for all columns
+        for input_column, output_column in zip(input, output):
+            results = _extract.html(
+                df[input_column].astype(str).tolist(),
+                dataType=data_type,
+                **kwargs
+            )
+            _write_list_output(df, [output_column], results, output_format, delimiter, output_column_name=output_column_name)
             
     return df
 
@@ -919,6 +1347,9 @@ def properties(
     property_type: str = None,
     return_data_type: str = 'list',
     first_element: bool = False,
+    output_format: str = None,
+    output_column_name: str = None,
+    delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -949,13 +1380,27 @@ def properties(
           - Standards
       return_data_type:
         type: string
-        description: The format to return the data, as a list or as a string
+        description: Legacy format option. Prefer output_format.
         enum:
           - list
           - string
       first_element:
         type: boolean
         description: Get the first element from results
+      output_format:
+        type: string
+        description: Format of the extract output
+        enum:
+          - JSON List
+          - JSON Dictionary
+          - Columns
+          - String
+      delimiter:
+        type: string
+        description: Delimiter to use when output_format is String
+      output_column_name:
+        type: string
+        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -965,27 +1410,64 @@ def properties(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1:
+    if output_format is None and return_data_type == "string":
+        output_format = "string"
+
+    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    _logging.info(f": Extracting properties :: input :: {input}")
-    if len(output) == 1 and len(input) > 1:
-        df[output[0]] = _extract.properties(
+    if len(input) == 1 and _is_columns_format(output_format):
+        results = _extract.properties(
+            df[input[0]].astype(str).tolist(),
+            type=property_type,
+            return_data_type='list',
+            first_element=False,
+            **kwargs
+        )
+        _write_results(
+            df,
+            output,
+            results,
+            output_format,
+            delimiter,
+            "json_list" if property_type else "json_dictionary",
+            output_column_name
+        )
+    elif len(output) == 1 and len(input) > 1:
+        results = _extract.properties(
             df[input].astype(str).aggregate(' '.join, axis=1).tolist(),
             type=property_type,
-            return_data_type=return_data_type,
-            first_element=first_element,
+            return_data_type='list' if output_format is not None else return_data_type,
+            first_element=first_element if output_format is None else False,
             **kwargs
+        )
+        _write_results(
+            df,
+            output,
+            results,
+            output_format,
+            delimiter,
+            "json_list" if property_type else "json_dictionary",
+            output_column_name
         )
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
-            df[output_column] = _extract.properties(
+            results = _extract.properties(
                 df[input_column].astype(str).tolist(),
                 type=property_type,
-                return_data_type=return_data_type,
-                first_element=first_element,
+                return_data_type='list' if output_format is not None else return_data_type,
+                first_element=first_element if output_format is None else False,
                 **kwargs
+            )
+            _write_results(
+                df,
+                [output_column],
+                results,
+                output_format,
+                delimiter,
+                "json_list" if property_type else "json_dictionary",
+                output_column_name
             )
     
     return df
@@ -996,7 +1478,10 @@ def regex(
   find: str,
   output: _Union[str, list],
   output_pattern: str = None,
-  first_element: bool = False
+  first_element: bool = False,
+  output_format: str = None,
+  output_column_name: str = None,
+  delimiter: str = ", "
   ) -> _pd.DataFrame:
     r"""
     type: object
@@ -1030,6 +1515,19 @@ def regex(
       first_element:
         type: boolean
         description: Get the first element from results
+      output_format:
+        type: string
+        description: Format of the extract output
+        enum:
+          - JSON List
+          - Columns
+          - String
+      delimiter:
+        type: string
+        description: Delimiter to use when output_format is String
+      output_column_name:
+        type: string
+        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: 
@@ -1042,36 +1540,32 @@ def regex(
         output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1:
+    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
     
     _logging.debug(f": Extracting regex patterns :: input :: {input}")
     find_pattern = _re.compile(find)
 
-    # Loop through and apply for all columns
-    for input_column, output_column in zip(input, output):
-        if output_pattern is None and first_element:
-            # Return entire matches
-            df[output_column] = df[input_column].apply(
-                lambda x: ([match.group(0) for match in _re.finditer(find_pattern, str(x) if x is not None else "")][0]
-                           if len([match.group(0) for match in _re.finditer(find_pattern, str(x) if x is not None else "")]) >= 1
-                           else "")
-                          )
-        elif output_pattern is None and not first_element:
-            # Return entire matches
-            df[output_column] = df[input_column].apply(lambda x: [match.group(0) for match in _re.finditer(find_pattern, str(x) if x is not None else "")])
-        elif output_pattern and first_element:
-            # Return specific capture groups in the pattern the were passed
-            df[output_column] = df[input_column].apply(
-                lambda x: (
-                    [find_pattern.sub(output_pattern, match.group(0)) for match in find_pattern.finditer(str(x) if x is not None else "")][0]
-                    if len([find_pattern.sub(output_pattern, match.group(0)) for match in find_pattern.finditer(str(x) if x is not None else "")]) >= 1
-                    else ""
-                    )
-                )
+    def _matches(value):
+        value = str(value) if value is not None else ""
+        matches = [match.group(0) for match in _re.finditer(find_pattern, value)]
+        if output_pattern:
+            matches = [find_pattern.sub(output_pattern, match) for match in matches]
+        return matches
+
+    def _write_regex(input_column, output_columns):
+        results = df[input_column].apply(_matches).tolist()
+        if output_format is None and first_element:
+            df[output_columns[0]] = [row[0] if len(row) >= 1 else "" for row in results]
         else:
-            # Return specific capture groups in the pattern the were passed
-            df[output_column] = df[input_column].apply(lambda x: [find_pattern.sub(output_pattern, match.group(0)) for match in find_pattern.finditer(str(x) if x is not None else "")])
+            _write_list_output(df, output_columns, results, output_format, delimiter, output_column_name=output_column_name)
+
+    if len(input) == 1 and _is_columns_format(output_format):
+        _write_regex(input[0], output)
+    else:
+        # Loop through and apply for all columns
+        for input_column, output_column in zip(input, output):
+            _write_regex(input_column, [output_column])
 
     return df
 

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -1320,6 +1320,8 @@ def html(
     if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
+    _logging.debug(f": Extracting from HTML :: input :: {input}")
+
     if len(input) == 1 and _is_columns_format(output_format):
         results = _extract.html(
             df[input[0]].astype(str).tolist(),

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -42,7 +42,7 @@ def _normalize_output_format(output_format, default):
 
     if output_format not in ("json_list", "json_dictionary", "columns", "string"):
         raise ValueError(
-            "output_format must be one of JSON List, JSON Dictionary, Columns, or String"
+            "output_format must be one of List, Dictionary, Columns, or String"
         )
 
     return output_format
@@ -76,7 +76,7 @@ def _write_list_output(
     output_format = _normalize_output_format(output_format, default_format)
 
     if output_format == "json_dictionary":
-        raise ValueError("output_format JSON Dictionary is only valid for dictionary-producing extracts")
+        raise ValueError("output_format Dictionary is only valid for dictionary-producing extracts")
 
     if output_format == "string":
         df[output[0]] = [_stringify_list(row, delimiter) for row in results]
@@ -115,7 +115,7 @@ def _write_dict_output(df, output, results, output_format, default_format="json_
     output_format = _normalize_output_format(output_format, default_format)
 
     if output_format in ("json_list", "string"):
-        raise ValueError("output_format JSON List or String is only valid for list-producing extracts")
+        raise ValueError("output_format List or String is only valid for list-producing extracts")
 
     if output_format == "columns":
         output_columns = output if len(output) > 1 else (_dict_keys(results) or output)
@@ -213,7 +213,7 @@ def address(
         type: string
         description: Format of the extract output
         enum:
-          - JSON List
+          - List
           - Columns
           - String
       delimiter:
@@ -366,12 +366,12 @@ def ai(
         type: string
         description: Format of the extract output
         enum:
-          - JSON Dictionary
+          - Dictionary
           - Columns
           - String
       output_column_name:
         type: string
-        description: Column name to use when output_format is JSON Dictionary
+        description: Column name to use when output_format is Dictionary
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
@@ -581,8 +581,8 @@ def attributes(
         type: string
         description: Format of the extract output
         enum:
-          - JSON List
-          - JSON Dictionary
+          - List
+          - Dictionary
           - Columns
           - String
       delimiter:
@@ -709,7 +709,7 @@ def brackets(
         type: string
         description: Format of the extract output
         enum:
-          - JSON List
+          - List
           - Columns
           - String
       delimiter:
@@ -832,7 +832,7 @@ def codes(
         type: string
         description: Format of the extract output
         enum:
-          - JSON List
+          - List
           - Columns
           - String
       delimiter:
@@ -979,8 +979,8 @@ def custom(
         type: string
         description: Format of the extract output
         enum:
-          - JSON List
-          - JSON Dictionary
+          - List
+          - Dictionary
           - Columns
           - String
       delimiter:
@@ -1299,7 +1299,7 @@ def html(
         type: string
         description: Format of the extract output
         enum:
-          - JSON List
+          - List
           - Columns
           - String
       delimiter:
@@ -1391,8 +1391,8 @@ def properties(
         type: string
         description: Format of the extract output
         enum:
-          - JSON List
-          - JSON Dictionary
+          - List
+          - Dictionary
           - Columns
           - String
       delimiter:
@@ -1519,7 +1519,7 @@ def regex(
         type: string
         description: Format of the extract output
         enum:
-          - JSON List
+          - List
           - Columns
           - String
       delimiter:

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -23,8 +23,8 @@ _OUTPUT_FORMAT_ALIASES = {
     "dictionary": "json_dictionary",
     "columns": "columns",
     "column": "columns",
-    "string": "string",
-    "text": "string",
+    "concatenate": "concatenate",
+    "concat": "concatenate",
 }
 
 
@@ -40,9 +40,9 @@ def _normalize_output_format(output_format, default):
     if output_format == "json":
         return default
 
-    if output_format not in ("json_list", "json_dictionary", "columns", "string"):
+    if output_format not in ("json_list", "json_dictionary", "columns", "concatenate"):
         raise ValueError(
-            "output_format must be one of List, Dictionary, Columns, or String"
+            "output_format must be one of list, dictionary, columns, or concatenate"
         )
 
     return output_format
@@ -70,11 +70,11 @@ def _resolve_output_format(output, output_format, default_format, output_is_list
     return _normalize_output_format(output_format, default_format)
 
 
-def _stringify_list(value, delimiter):
+def _stringify_list(value, char):
     if value in (None, ""):
         return ""
     if isinstance(value, list):
-        return delimiter.join([str(item) for item in value])
+        return char.join([str(item) for item in value])
     return str(value)
 
 
@@ -83,17 +83,17 @@ def _write_list_output(
     output,
     results,
     output_format,
-    delimiter=", ",
+    char=", ",
     default_format="json_list",
     output_is_list=False
 ):
     output_format = _resolve_output_format(output, output_format, default_format, output_is_list)
 
     if output_format == "json_dictionary":
-        raise ValueError("output_format Dictionary is only valid for dictionary-producing extracts")
+        raise ValueError("output_format dictionary is only valid for dictionary-producing extracts")
 
-    if output_format == "string":
-        df[output[0]] = [_stringify_list(row, delimiter) for row in results]
+    if output_format == "concatenate":
+        df[output[0]] = [_stringify_list(row, char) for row in results]
         return
 
     if output_format == "columns":
@@ -137,8 +137,8 @@ def _dict_keys(results):
 def _write_dict_output(df, output, results, output_format, default_format="json_dictionary", output_is_list=False):
     output_format = _resolve_output_format(output, output_format, default_format, output_is_list)
 
-    if output_format in ("json_list", "string"):
-        raise ValueError("output_format List or String is only valid for list-producing extracts")
+    if output_format in ("json_list", "concatenate"):
+        raise ValueError("output_format list or concatenate is only valid for list-producing extracts")
 
     if output_format == "columns":
         output_columns = (
@@ -161,7 +161,7 @@ def _write_results(
     output,
     results,
     output_format,
-    delimiter=", ",
+    char=", ",
     default_format="json_list",
     output_is_list=False
 ):
@@ -173,7 +173,7 @@ def _write_results(
             output,
             results,
             output_format,
-            delimiter,
+            char,
             default_format,
             output_is_list
         )
@@ -206,7 +206,7 @@ def address(
     output: _Union[str, list],
     dataType: str,
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -239,12 +239,12 @@ def address(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Columns
-          - String
-      delimiter:
+          - list
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -266,14 +266,14 @@ def address(
             dataType,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
+        _write_list_output(df, output, results, output_format, char, output_is_list=output_is_list)
     elif len(output) == 1 and len(input) > 1:
         results = _extract.address(
             df[input].astype(str).aggregate(' '.join, axis=1).tolist(),
             dataType,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
+        _write_list_output(df, output, results, output_format, char, output_is_list=output_is_list)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -282,7 +282,7 @@ def address(
                 dataType,
                 **kwargs
             )
-            _write_list_output(df, [output_column], results, output_format, delimiter)
+            _write_list_output(df, [output_column], results, output_format, char)
 
     return df
 
@@ -294,7 +294,7 @@ def ai(
     output: _Union[dict, str, list] = None,
     model_id: str = None,
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ):
     """
@@ -391,12 +391,12 @@ def ai(
         type: string
         description: Format of the extract output
         enum:
-          - Dictionary
-          - Columns
-          - String
-      delimiter:
+          - dictionary
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     output_format_normalized = _normalize_output_format(output_format, "columns")
 
@@ -474,18 +474,18 @@ def ai(
         if output_format_normalized == "json_dictionary":
             output_column_name = target_columns[0] if target_columns and len(target_columns) == 1 else "output"
             df[output_column_name] = results
-        elif output_format_normalized == "string":
+        elif output_format_normalized == "concatenate":
             if target_columns and len(target_columns) != 1:
-                raise ValueError("output_format String can only be used with a single output column")
+                raise ValueError("output_format concatenate can only be used with a single output column")
             output_column = target_columns[0] if target_columns else "output"
             if len(exploded_df.columns) == 1:
                 df[output_column] = [
-                    _stringify_list(row, delimiter)
+                    _stringify_list(row, char)
                     for row in exploded_df[exploded_df.columns[0]].tolist()
                 ]
             else:
                 df[output_column] = [
-                    delimiter.join([_stringify_list(value, delimiter) for value in row.values()])
+                    char.join([_stringify_list(value, char) for value in row.values()])
                     for row in results
                 ]
         elif target_columns and len(target_columns) == 1:
@@ -524,7 +524,7 @@ def attributes(
     bound: str = 'mid',
     first_element: bool = False,
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -597,13 +597,13 @@ def attributes(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Dictionary
-          - Columns
-          - String
-      delimiter:
+          - list
+          - dictionary
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     $ref: "#/$defs/misc/unit_entity_map"
     """
     # If output is not specified, overwrite input columns in place
@@ -635,7 +635,7 @@ def attributes(
             output,
             results,
             output_format,
-            delimiter,
+            char,
             "json_list" if attribute_type else "json_dictionary",
             output_is_list
         )
@@ -655,7 +655,7 @@ def attributes(
             output,
             results,
             output_format,
-            delimiter,
+            char,
             "json_list" if attribute_type else "json_dictionary",
             output_is_list
         )
@@ -676,7 +676,7 @@ def attributes(
                 [output_column],
                 results,
                 output_format,
-                delimiter,
+                char,
                 "json_list" if attribute_type else "json_dictionary"
             )
 
@@ -690,7 +690,7 @@ def brackets(
     find: _Union[str, list] = 'all',
     include_brackets: bool = False,
     output_format: str = None,
-    delimiter: str = ", "
+    char: str = ", "
 ) -> _pd.DataFrame:
     """
     type: object
@@ -723,12 +723,12 @@ def brackets(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Columns
-          - String
-      delimiter:
+          - list
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -772,8 +772,8 @@ def brackets(
             output,
             results,
             output_format,
-            delimiter,
-            default_format="string",
+            char,
+            default_format="concatenate",
             output_is_list=output_is_list
         )
     elif len(output) == 1 and len(input) > 1:
@@ -788,8 +788,8 @@ def brackets(
             output,
             results,
             output_format,
-            delimiter,
-            default_format="string",
+            char,
+            default_format="concatenate",
             output_is_list=output_is_list
         )
     else:
@@ -806,8 +806,8 @@ def brackets(
                 [output_column],
                 results,
                 output_format,
-                delimiter,
-                default_format="string"
+                char,
+                default_format="concatenate"
             )
 
     return df
@@ -819,7 +819,7 @@ def codes(
     output: _Union[str, list],
     first_element: bool = False,
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -847,12 +847,12 @@ def codes(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Columns
-          - String
-      delimiter:
+          - list
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
       min_length:
         type:
           - integer
@@ -903,14 +903,14 @@ def codes(
             False,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
+        _write_list_output(df, output, results, output_format, char, output_is_list=output_is_list)
     elif len(output) == 1 and len(input) > 1:
         results = _extract.codes(
             df[input].astype(str).aggregate(' AAA '.join, axis=1).tolist(),
             first_element if output_format is None else False,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
+        _write_list_output(df, output, results, output_format, char, output_is_list=output_is_list)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -919,7 +919,7 @@ def codes(
                 first_element if output_format is None else False,
                 **kwargs
             )
-            _write_list_output(df, [output_column], results, output_format, delimiter)
+            _write_list_output(df, [output_column], results, output_format, char)
 
     return df
 
@@ -936,7 +936,7 @@ def custom(
     use_spellcheck: bool = False,
     sort: str = 'training_order',
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -993,13 +993,13 @@ def custom(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Dictionary
-          - Columns
-          - String
-      delimiter:
+          - list
+          - dictionary
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     if output is None: output = input
 
@@ -1028,7 +1028,7 @@ def custom(
             sort=sort,
             **kwargs
         )
-        _write_results(df, output, results, output_format, delimiter, default_format, output_is_list)
+        _write_results(df, output, results, output_format, char, default_format, output_is_list)
 
     elif len(input) == len(output) and len(model_id) == 1:
         # if one model_id, then use that model for all columns inputs and outputs
@@ -1045,7 +1045,7 @@ def custom(
                 sort=sort,
                 **kwargs
             )
-            _write_results(df, [out_col], results, output_format, delimiter, default_format)
+            _write_results(df, [out_col], results, output_format, char, default_format)
 
     elif len(input) > 1 and len(output) == 1 and len(model_id) == 1:
         model_id = [model_id[0] for _ in range(len(input))]
@@ -1069,7 +1069,7 @@ def custom(
             results = [_combine_dict_rows(row) for row in df_temp.values.tolist()]
         else:
             results = [_combine_list_rows(row) for row in df_temp.values.tolist()]
-        _write_results(df, [output], results, output_format, delimiter, default_format, output_is_list)
+        _write_results(df, [output], results, output_format, char, default_format, output_is_list)
 
     else:
         # Iterate through the inputs, outputs and model_ids
@@ -1085,7 +1085,7 @@ def custom(
                 sort=sort,
                 **kwargs
             )
-            _write_results(df, [out_col], results, output_format, delimiter, default_format)
+            _write_results(df, [out_col], results, output_format, char, default_format)
 
     return df
 
@@ -1280,7 +1280,7 @@ def html(
     data_type: str,
     output: _Union[str, list] = None,
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -1312,12 +1312,12 @@ def html(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Columns
-          - String
-      delimiter:
+          - list
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -1341,7 +1341,7 @@ def html(
             dataType=data_type,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
+        _write_list_output(df, output, results, output_format, char, output_is_list=output_is_list)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -1350,7 +1350,7 @@ def html(
                 dataType=data_type,
                 **kwargs
             )
-            _write_list_output(df, [output_column], results, output_format, delimiter)
+            _write_list_output(df, [output_column], results, output_format, char)
 
     return df
 
@@ -1363,7 +1363,7 @@ def properties(
     return_data_type: str = 'list',
     first_element: bool = False,
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -1405,13 +1405,13 @@ def properties(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Dictionary
-          - Columns
-          - String
-      delimiter:
+          - list
+          - dictionary
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -1425,7 +1425,7 @@ def properties(
 
     # Ensure input and output lengths are compatible
     if output_format is None and return_data_type == "string":
-        output_format = "string"
+        output_format = "concatenate"
 
     if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format, output_is_list)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
@@ -1443,7 +1443,7 @@ def properties(
             output,
             results,
             output_format,
-            delimiter,
+            char,
             "json_list" if property_type else "json_dictionary",
             output_is_list
         )
@@ -1460,7 +1460,7 @@ def properties(
             output,
             results,
             output_format,
-            delimiter,
+            char,
             "json_list" if property_type else "json_dictionary",
             output_is_list
         )
@@ -1479,7 +1479,7 @@ def properties(
                 [output_column],
                 results,
                 output_format,
-                delimiter,
+                char,
                 "json_list" if property_type else "json_dictionary"
             )
 
@@ -1493,7 +1493,7 @@ def regex(
   output_pattern: str = None,
   first_element: bool = False,
   output_format: str = None,
-  delimiter: str = ", "
+  char: str = ", "
   ) -> _pd.DataFrame:
     r"""
     type: object
@@ -1531,12 +1531,12 @@ def regex(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Columns
-          - String
-      delimiter:
+          - list
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     # If output is not specified, overwrite input columns in place
     if output is None:
@@ -1570,7 +1570,7 @@ def regex(
         if output_format is None and first_element and len(output_columns) == 1 and not columns_is_list:
             df[output_columns[0]] = [row[0] if len(row) >= 1 else "" for row in results]
         else:
-            _write_list_output(df, output_columns, results, output_format, delimiter, output_is_list=columns_is_list)
+            _write_list_output(df, output_columns, results, output_format, char, output_is_list=columns_is_list)
 
     if len(input) == 1 and _is_columns_target(output, output_format, output_is_list):
         _write_regex(input[0], output, output_is_list)

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -52,20 +52,20 @@ def _ensure_list(value):
     return value if isinstance(value, list) else [value]
 
 
-def _is_columns_target(output, output_format):
+def _is_columns_target(output, output_format, output_is_list=False):
     """
     Whether results should be split across explicit output columns.
 
     An explicit output_format always wins. Otherwise, providing output
-    as a list of more than one column name implies Columns format.
+    as a list of one or more column names implies Columns format.
     """
     if output_format is not None:
         return _normalize_output_format(output_format, "json_list") == "columns"
-    return isinstance(output, list) and len(output) > 1
+    return output_is_list or (isinstance(output, list) and len(output) > 1)
 
 
-def _resolve_output_format(output, output_format, default_format):
-    if output_format is None and isinstance(output, list) and len(output) > 1:
+def _resolve_output_format(output, output_format, default_format, output_is_list=False):
+    if output_format is None and (output_is_list or (isinstance(output, list) and len(output) > 1)):
         return "columns"
     return _normalize_output_format(output_format, default_format)
 
@@ -84,9 +84,10 @@ def _write_list_output(
     results,
     output_format,
     delimiter=", ",
-    default_format="json_list"
+    default_format="json_list",
+    output_is_list=False
 ):
-    output_format = _resolve_output_format(output, output_format, default_format)
+    output_format = _resolve_output_format(output, output_format, default_format, output_is_list)
 
     if output_format == "json_dictionary":
         raise ValueError("output_format Dictionary is only valid for dictionary-producing extracts")
@@ -96,19 +97,26 @@ def _write_list_output(
         return
 
     if output_format == "columns":
+        # A scalar (non-list) result counts as a single match.
+        # Always create at least one column, even if no rows
+        # produced any results
         max_result_len = max(
-            [len(row) for row in results if isinstance(row, list)] or [1]
+            [len(row) if isinstance(row, list) else 1 for row in results] + [1]
         )
-        if len(output) > 1:
+        if len(output) > 1 or output_is_list:
             # Cap the number of columns created to however many
-            # results were actually found, even if more output
-            # column names were provided
+            # output column names were explicitly provided, dropping
+            # any results beyond that even if more were found
             output_columns = output[:min(len(output), max_result_len)]
         else:
+            # No explicit column names given (a bare string output)
+            # with Columns format requested - auto-number columns
+            # for however many results were found
             output_columns = [f"{output[0]} {i + 1}" for i in range(max_result_len)]
         for i, output_column in enumerate(output_columns):
             df[output_column] = [
-                row[i] if isinstance(row, list) and len(row) > i else ""
+                (row[i] if len(row) > i else "") if isinstance(row, list)
+                else (row if i == 0 else "")
                 for row in results
             ]
         return
@@ -126,14 +134,18 @@ def _dict_keys(results):
     return keys
 
 
-def _write_dict_output(df, output, results, output_format, default_format="json_dictionary"):
-    output_format = _resolve_output_format(output, output_format, default_format)
+def _write_dict_output(df, output, results, output_format, default_format="json_dictionary", output_is_list=False):
+    output_format = _resolve_output_format(output, output_format, default_format, output_is_list)
 
     if output_format in ("json_list", "string"):
         raise ValueError("output_format List or String is only valid for list-producing extracts")
 
     if output_format == "columns":
-        output_columns = output if len(output) > 1 else (_dict_keys(results) or output)
+        output_columns = (
+            output
+            if len(output) > 1 or output_is_list
+            else (_dict_keys(results) or output)
+        )
         for output_column in output_columns:
             df[output_column] = [
                 row.get(output_column, "") if isinstance(row, dict) else ""
@@ -150,10 +162,11 @@ def _write_results(
     results,
     output_format,
     delimiter=", ",
-    default_format="json_list"
+    default_format="json_list",
+    output_is_list=False
 ):
     if default_format == "json_dictionary":
-        _write_dict_output(df, output, results, output_format, default_format)
+        _write_dict_output(df, output, results, output_format, default_format, output_is_list)
     else:
         _write_list_output(
             df,
@@ -161,7 +174,8 @@ def _write_results(
             results,
             output_format,
             delimiter,
-            default_format
+            default_format,
+            output_is_list
         )
 
 
@@ -235,28 +249,31 @@ def address(
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
 
+    # Whether output was explicitly given as a list of column names
+    output_is_list = isinstance(output, list)
+
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format, output_is_list)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_target(output, output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format, output_is_list):
         results = _extract.address(
             df[input[0]].astype(str).tolist(),
             dataType,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter)
+        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
     elif len(output) == 1 and len(input) > 1:
         results = _extract.address(
             df[input].astype(str).aggregate(' '.join, axis=1).tolist(),
             dataType,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter)
+        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -266,7 +283,7 @@ def address(
                 **kwargs
             )
             _write_list_output(df, [output_column], results, output_format, delimiter)
-  
+
     return df
 
 
@@ -592,15 +609,18 @@ def attributes(
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
 
+    # Whether output was explicitly given as a list of column names
+    output_is_list = isinstance(output, list)
+
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format, output_is_list)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_target(output, output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format, output_is_list):
         results = _extract.attributes(
             df[input[0]].astype(str).tolist(),
             responseContent,
@@ -616,7 +636,8 @@ def attributes(
             results,
             output_format,
             delimiter,
-            "json_list" if attribute_type else "json_dictionary"
+            "json_list" if attribute_type else "json_dictionary",
+            output_is_list
         )
     elif len(output) == 1 and len(input) > 1:
         # df[output[0]] = _extract.attributes(df[input].astype(str).aggregate(' AAA '.join, axis=1).tolist())
@@ -635,7 +656,8 @@ def attributes(
             results,
             output_format,
             delimiter,
-            "json_list" if attribute_type else "json_dictionary"
+            "json_list" if attribute_type else "json_dictionary",
+            output_is_list
         )
     else:
         # Loop through and apply for all columns
@@ -711,12 +733,15 @@ def brackets(
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
 
+    # Whether output was explicitly given as a list of column names
+    output_is_list = isinstance(output, list)
+
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format, output_is_list)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
     _logging.debug(f": Extracting from brackets :: input :: {input}")
@@ -732,10 +757,10 @@ def brackets(
     # If only only one output and multiple inputs, concatenate the inputs
     # Also need list results (not a joined string) whenever a single input
     # is being fanned out across multiple explicit output columns
-    implicit_columns = len(input) == 1 and len(output) > 1
+    implicit_columns = len(input) == 1 and (len(output) > 1 or output_is_list)
     return_data_type = "string" if output_format is None and not implicit_columns else "list"
 
-    if len(input) == 1 and _is_columns_target(output, output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format, output_is_list):
         results = _extract.brackets(
             df[input[0]].astype(str).tolist(),
             find,
@@ -748,7 +773,8 @@ def brackets(
             results,
             output_format,
             delimiter,
-            default_format="string"
+            default_format="string",
+            output_is_list=output_is_list
         )
     elif len(output) == 1 and len(input) > 1:
         results = _extract.brackets(
@@ -763,7 +789,8 @@ def brackets(
             results,
             output_format,
             delimiter,
-            default_format="string"
+            default_format="string",
+            output_is_list=output_is_list
         )
     else:
         # Loop through and apply for all columns
@@ -859,28 +886,31 @@ def codes(
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
 
+    # Whether output was explicitly given as a list of column names
+    output_is_list = isinstance(output, list)
+
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format, output_is_list)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_target(output, output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format, output_is_list):
         results = _extract.codes(
             df[input[0]].astype(str).tolist(),
             False,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter)
+        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
     elif len(output) == 1 and len(input) > 1:
         results = _extract.codes(
             df[input].astype(str).aggregate(' AAA '.join, axis=1).tolist(),
             first_element if output_format is None else False,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter)
+        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -973,6 +1003,9 @@ def custom(
     """
     if output is None: output = input
 
+    # Whether output was explicitly given as a list of column names
+    output_is_list = isinstance(output, list)
+
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
@@ -980,10 +1013,10 @@ def custom(
 
     default_format = "json_dictionary" if use_labels else "json_list"
 
-    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format, output_is_list)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_target(output, output_format) and len(model_id) == 1:
+    if len(input) == 1 and _is_columns_target(output, output_format, output_is_list) and len(model_id) == 1:
         results = _extract.custom(
             df[input[0]].astype(str).tolist(),
             model_id=model_id[0],
@@ -995,7 +1028,7 @@ def custom(
             sort=sort,
             **kwargs
         )
-        _write_results(df, output, results, output_format, delimiter, default_format)
+        _write_results(df, output, results, output_format, delimiter, default_format, output_is_list)
 
     elif len(input) == len(output) and len(model_id) == 1:
         # if one model_id, then use that model for all columns inputs and outputs
@@ -1036,7 +1069,7 @@ def custom(
             results = [_combine_dict_rows(row) for row in df_temp.values.tolist()]
         else:
             results = [_combine_list_rows(row) for row in df_temp.values.tolist()]
-        _write_results(df, [output], results, output_format, delimiter, default_format)
+        _write_results(df, [output], results, output_format, delimiter, default_format, output_is_list)
 
     else:
         # Iterate through the inputs, outputs and model_ids
@@ -1289,23 +1322,26 @@ def html(
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
 
+    # Whether output was explicitly given as a list of column names
+    output_is_list = isinstance(output, list)
+
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format, output_is_list)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
     _logging.debug(f": Extracting from HTML :: input :: {input}")
 
-    if len(input) == 1 and _is_columns_target(output, output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format, output_is_list):
         results = _extract.html(
             df[input[0]].astype(str).tolist(),
             dataType=data_type,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter)
+        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -1380,6 +1416,9 @@ def properties(
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
 
+    # Whether output was explicitly given as a list of column names
+    output_is_list = isinstance(output, list)
+
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
@@ -1388,10 +1427,10 @@ def properties(
     if output_format is None and return_data_type == "string":
         output_format = "string"
 
-    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format, output_is_list)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_target(output, output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format, output_is_list):
         results = _extract.properties(
             df[input[0]].astype(str).tolist(),
             type=property_type,
@@ -1405,14 +1444,15 @@ def properties(
             results,
             output_format,
             delimiter,
-            "json_list" if property_type else "json_dictionary"
+            "json_list" if property_type else "json_dictionary",
+            output_is_list
         )
     elif len(output) == 1 and len(input) > 1:
         results = _extract.properties(
             df[input].astype(str).aggregate(' '.join, axis=1).tolist(),
             type=property_type,
-            return_data_type='list' if output_format is not None else return_data_type,
-            first_element=first_element if output_format is None else False,
+            return_data_type='list' if (output_format is not None or output_is_list) else return_data_type,
+            first_element=first_element if (output_format is None and not output_is_list) else False,
             **kwargs
         )
         _write_results(
@@ -1421,7 +1461,8 @@ def properties(
             results,
             output_format,
             delimiter,
-            "json_list" if property_type else "json_dictionary"
+            "json_list" if property_type else "json_dictionary",
+            output_is_list
         )
     else:
         # Loop through and apply for all columns
@@ -1501,6 +1542,9 @@ def regex(
     if output is None:
         output = input
 
+    # Whether output was explicitly given as a list of column names
+    output_is_list = isinstance(output, list)
+
     # If a string is provided, convert to list
     if not isinstance(input, list):
         input = [input]
@@ -1508,7 +1552,7 @@ def regex(
         output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format, output_is_list)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
     _logging.debug(f": Extracting regex patterns :: input :: {input}")
@@ -1521,15 +1565,15 @@ def regex(
             matches = [find_pattern.sub(output_pattern, match) for match in matches]
         return matches
 
-    def _write_regex(input_column, output_columns):
+    def _write_regex(input_column, output_columns, columns_is_list=False):
         results = df[input_column].apply(_matches).tolist()
-        if output_format is None and first_element and len(output_columns) == 1:
+        if output_format is None and first_element and len(output_columns) == 1 and not columns_is_list:
             df[output_columns[0]] = [row[0] if len(row) >= 1 else "" for row in results]
         else:
-            _write_list_output(df, output_columns, results, output_format, delimiter)
+            _write_list_output(df, output_columns, results, output_format, delimiter, output_is_list=columns_is_list)
 
-    if len(input) == 1 and _is_columns_target(output, output_format):
-        _write_regex(input[0], output)
+    if len(input) == 1 and _is_columns_target(output, output_format, output_is_list):
+        _write_regex(input[0], output, output_is_list)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -754,18 +754,12 @@ def brackets(
     if not all(element in bracket_types for element in find):
         raise ValueError("find must only contain the elements: round, square, curly, angled")
 
-    # If only only one output and multiple inputs, concatenate the inputs
-    # Also need list results (not a joined string) whenever a single input
-    # is being fanned out across multiple explicit output columns
-    implicit_columns = len(input) == 1 and (len(output) > 1 or output_is_list)
-    return_data_type = "string" if output_format is None and not implicit_columns else "list"
-
     if len(input) == 1 and _is_columns_target(output, output_format, output_is_list):
         results = _extract.brackets(
             df[input[0]].astype(str).tolist(),
             find,
             include_brackets,
-            return_data_type=return_data_type
+            return_data_type="list"
         )
         _write_list_output(
             df,
@@ -773,7 +767,6 @@ def brackets(
             results,
             output_format,
             char,
-            default_format="concatenate",
             output_is_list=output_is_list
         )
     elif len(output) == 1 and len(input) > 1:
@@ -781,7 +774,7 @@ def brackets(
             df[input].astype(str).aggregate(' '.join, axis=1).tolist(),
             find,
             include_brackets,
-            return_data_type=return_data_type
+            return_data_type="list"
         )
         _write_list_output(
             df,
@@ -789,7 +782,6 @@ def brackets(
             results,
             output_format,
             char,
-            default_format="concatenate",
             output_is_list=output_is_list
         )
     else:
@@ -799,15 +791,14 @@ def brackets(
                 df[input_column].astype(str).tolist(),
                 find,
                 include_brackets,
-                return_data_type=return_data_type
+                return_data_type="list"
             )
             _write_list_output(
                 df,
                 [output_column],
                 results,
                 output_format,
-                char,
-                default_format="concatenate"
+                char
             )
 
     return df

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -52,8 +52,22 @@ def _ensure_list(value):
     return value if isinstance(value, list) else [value]
 
 
-def _is_columns_format(output_format):
-    return _normalize_output_format(output_format, "json_list") == "columns"
+def _is_columns_target(output, output_format):
+    """
+    Whether results should be split across explicit output columns.
+
+    An explicit output_format always wins. Otherwise, providing output
+    as a list of more than one column name implies Columns format.
+    """
+    if output_format is not None:
+        return _normalize_output_format(output_format, "json_list") == "columns"
+    return isinstance(output, list) and len(output) > 1
+
+
+def _resolve_output_format(output, output_format, default_format):
+    if output_format is None and isinstance(output, list) and len(output) > 1:
+        return "columns"
+    return _normalize_output_format(output_format, default_format)
 
 
 def _stringify_list(value, delimiter):
@@ -70,10 +84,9 @@ def _write_list_output(
     results,
     output_format,
     delimiter=", ",
-    default_format="json_list",
-    output_column_name=None
+    default_format="json_list"
 ):
-    output_format = _normalize_output_format(output_format, default_format)
+    output_format = _resolve_output_format(output, output_format, default_format)
 
     if output_format == "json_dictionary":
         raise ValueError("output_format Dictionary is only valid for dictionary-producing extracts")
@@ -83,14 +96,16 @@ def _write_list_output(
         return
 
     if output_format == "columns":
-        output_count = len(output) if len(output) > 1 else max(
+        max_result_len = max(
             [len(row) for row in results if isinstance(row, list)] or [1]
         )
-        output_columns = (
-            output
-            if len(output) > 1
-            else [f"{output_column_name or output[0]} {i + 1}" for i in range(output_count)]
-        )
+        if len(output) > 1:
+            # Cap the number of columns created to however many
+            # results were actually found, even if more output
+            # column names were provided
+            output_columns = output[:min(len(output), max_result_len)]
+        else:
+            output_columns = [f"{output[0]} {i + 1}" for i in range(max_result_len)]
         for i, output_column in enumerate(output_columns):
             df[output_column] = [
                 row[i] if isinstance(row, list) and len(row) > i else ""
@@ -112,7 +127,7 @@ def _dict_keys(results):
 
 
 def _write_dict_output(df, output, results, output_format, default_format="json_dictionary"):
-    output_format = _normalize_output_format(output_format, default_format)
+    output_format = _resolve_output_format(output, output_format, default_format)
 
     if output_format in ("json_list", "string"):
         raise ValueError("output_format List or String is only valid for list-producing extracts")
@@ -135,11 +150,10 @@ def _write_results(
     results,
     output_format,
     delimiter=", ",
-    default_format="json_list",
-    output_column_name=None
+    default_format="json_list"
 ):
     if default_format == "json_dictionary":
-        _write_dict_output(df, output, results, output_format)
+        _write_dict_output(df, output, results, output_format, default_format)
     else:
         _write_list_output(
             df,
@@ -147,8 +161,7 @@ def _write_results(
             results,
             output_format,
             delimiter,
-            default_format,
-            output_column_name
+            default_format
         )
 
 
@@ -179,7 +192,6 @@ def address(
     output: _Union[str, list],
     dataType: str,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
@@ -219,9 +231,6 @@ def address(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -231,23 +240,23 @@ def address(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         results = _extract.address(
             df[input[0]].astype(str).tolist(),
             dataType,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+        _write_list_output(df, output, results, output_format, delimiter)
     elif len(output) == 1 and len(input) > 1:
         results = _extract.address(
             df[input].astype(str).aggregate(' '.join, axis=1).tolist(),
             dataType,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+        _write_list_output(df, output, results, output_format, delimiter)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -256,7 +265,7 @@ def address(
                 dataType,
                 **kwargs
             )
-            _write_list_output(df, [output_column], results, output_format, delimiter, output_column_name=output_column_name)
+            _write_list_output(df, [output_column], results, output_format, delimiter)
   
     return df
 
@@ -268,7 +277,6 @@ def ai(
     output: _Union[dict, str, list] = None,
     model_id: str = None,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ):
@@ -369,9 +377,6 @@ def ai(
           - Dictionary
           - Columns
           - String
-      output_column_name:
-        type: string
-        description: Column name to use when output_format is Dictionary
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
@@ -450,17 +455,12 @@ def ai(
         exploded_df = _pd.json_normalize(results, max_level=0).fillna('').set_index(df.index)
 
         if output_format_normalized == "json_dictionary":
-            if output_column_name is None:
-                output_column_name = target_columns[0] if target_columns and len(target_columns) == 1 else "output"
+            output_column_name = target_columns[0] if target_columns and len(target_columns) == 1 else "output"
             df[output_column_name] = results
         elif output_format_normalized == "string":
             if target_columns and len(target_columns) != 1:
                 raise ValueError("output_format String can only be used with a single output column")
-            output_column = (
-                target_columns[0]
-                if target_columns
-                else output_column_name or "output"
-            )
+            output_column = target_columns[0] if target_columns else "output"
             if len(exploded_df.columns) == 1:
                 df[output_column] = [
                     _stringify_list(row, delimiter)
@@ -507,7 +507,6 @@ def attributes(
     bound: str = 'mid',
     first_element: bool = False,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
@@ -588,9 +587,6 @@ def attributes(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     $ref: "#/$defs/misc/unit_entity_map"
     """
     # If output is not specified, overwrite input columns in place
@@ -601,10 +597,10 @@ def attributes(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         results = _extract.attributes(
             df[input[0]].astype(str).tolist(),
             responseContent,
@@ -620,8 +616,7 @@ def attributes(
             results,
             output_format,
             delimiter,
-            "json_list" if attribute_type else "json_dictionary",
-            output_column_name
+            "json_list" if attribute_type else "json_dictionary"
         )
     elif len(output) == 1 and len(input) > 1:
         # df[output[0]] = _extract.attributes(df[input].astype(str).aggregate(' AAA '.join, axis=1).tolist())
@@ -640,8 +635,7 @@ def attributes(
             results,
             output_format,
             delimiter,
-            "json_list" if attribute_type else "json_dictionary",
-            output_column_name
+            "json_list" if attribute_type else "json_dictionary"
         )
     else:
         # Loop through and apply for all columns
@@ -661,10 +655,9 @@ def attributes(
                 results,
                 output_format,
                 delimiter,
-                "json_list" if attribute_type else "json_dictionary",
-                output_column_name
+                "json_list" if attribute_type else "json_dictionary"
             )
-        
+
     return df
 
 
@@ -675,7 +668,6 @@ def brackets(
     find: _Union[str, list] = 'all',
     include_brackets: bool = False,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", "
 ) -> _pd.DataFrame:
     """
@@ -715,9 +707,6 @@ def brackets(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -727,7 +716,7 @@ def brackets(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
     _logging.debug(f": Extracting from brackets :: input :: {input}")
@@ -741,9 +730,12 @@ def brackets(
         raise ValueError("find must only contain the elements: round, square, curly, angled")
 
     # If only only one output and multiple inputs, concatenate the inputs
-    return_data_type = "string" if output_format is None else "list"
+    # Also need list results (not a joined string) whenever a single input
+    # is being fanned out across multiple explicit output columns
+    implicit_columns = len(input) == 1 and len(output) > 1
+    return_data_type = "string" if output_format is None and not implicit_columns else "list"
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         results = _extract.brackets(
             df[input[0]].astype(str).tolist(),
             find,
@@ -756,8 +748,7 @@ def brackets(
             results,
             output_format,
             delimiter,
-            default_format="string",
-            output_column_name=output_column_name
+            default_format="string"
         )
     elif len(output) == 1 and len(input) > 1:
         results = _extract.brackets(
@@ -772,8 +763,7 @@ def brackets(
             results,
             output_format,
             delimiter,
-            default_format="string",
-            output_column_name=output_column_name
+            default_format="string"
         )
     else:
         # Loop through and apply for all columns
@@ -790,8 +780,7 @@ def brackets(
                 results,
                 output_format,
                 delimiter,
-                default_format="string",
-                output_column_name=output_column_name
+                default_format="string"
             )
 
     return df
@@ -803,7 +792,6 @@ def codes(
     output: _Union[str, list],
     first_element: bool = False,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
@@ -838,9 +826,6 @@ def codes(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
       min_length:
         type:
           - integer
@@ -879,23 +864,23 @@ def codes(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         results = _extract.codes(
             df[input[0]].astype(str).tolist(),
             False,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+        _write_list_output(df, output, results, output_format, delimiter)
     elif len(output) == 1 and len(input) > 1:
         results = _extract.codes(
             df[input].astype(str).aggregate(' AAA '.join, axis=1).tolist(),
             first_element if output_format is None else False,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+        _write_list_output(df, output, results, output_format, delimiter)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -904,7 +889,7 @@ def codes(
                 first_element if output_format is None else False,
                 **kwargs
             )
-            _write_list_output(df, [output_column], results, output_format, delimiter, output_column_name=output_column_name)
+            _write_list_output(df, [output_column], results, output_format, delimiter)
 
     return df
 
@@ -921,7 +906,6 @@ def custom(
     use_spellcheck: bool = False,
     sort: str = 'training_order',
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
@@ -986,23 +970,20 @@ def custom(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     """
     if output is None: output = input
-    
+
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
     if not isinstance(model_id, list): model_id = [model_id]
 
     default_format = "json_dictionary" if use_labels else "json_list"
-    
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_format(output_format) and len(model_id) == 1:
+    if len(input) == 1 and _is_columns_target(output, output_format) and len(model_id) == 1:
         results = _extract.custom(
             df[input[0]].astype(str).tolist(),
             model_id=model_id[0],
@@ -1014,7 +995,7 @@ def custom(
             sort=sort,
             **kwargs
         )
-        _write_results(df, output, results, output_format, delimiter, default_format, output_column_name)
+        _write_results(df, output, results, output_format, delimiter, default_format)
 
     elif len(input) == len(output) and len(model_id) == 1:
         # if one model_id, then use that model for all columns inputs and outputs
@@ -1031,8 +1012,8 @@ def custom(
                 sort=sort,
                 **kwargs
             )
-            _write_results(df, [out_col], results, output_format, delimiter, default_format, output_column_name)
-    
+            _write_results(df, [out_col], results, output_format, delimiter, default_format)
+
     elif len(input) > 1 and len(output) == 1 and len(model_id) == 1:
         model_id = [model_id[0] for _ in range(len(input))]
         output = output[0]
@@ -1055,7 +1036,7 @@ def custom(
             results = [_combine_dict_rows(row) for row in df_temp.values.tolist()]
         else:
             results = [_combine_list_rows(row) for row in df_temp.values.tolist()]
-        _write_results(df, [output], results, output_format, delimiter, default_format, output_column_name)
+        _write_results(df, [output], results, output_format, delimiter, default_format)
 
     else:
         # Iterate through the inputs, outputs and model_ids
@@ -1071,7 +1052,7 @@ def custom(
                 sort=sort,
                 **kwargs
             )
-            _write_results(df, [out_col], results, output_format, delimiter, default_format, output_column_name)
+            _write_results(df, [out_col], results, output_format, delimiter, default_format)
 
     return df
 
@@ -1266,7 +1247,6 @@ def html(
     data_type: str,
     output: _Union[str, list] = None,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
@@ -1305,9 +1285,6 @@ def html(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -1317,18 +1294,18 @@ def html(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
     _logging.debug(f": Extracting from HTML :: input :: {input}")
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         results = _extract.html(
             df[input[0]].astype(str).tolist(),
             dataType=data_type,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+        _write_list_output(df, output, results, output_format, delimiter)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -1337,8 +1314,8 @@ def html(
                 dataType=data_type,
                 **kwargs
             )
-            _write_list_output(df, [output_column], results, output_format, delimiter, output_column_name=output_column_name)
-            
+            _write_list_output(df, [output_column], results, output_format, delimiter)
+
     return df
 
 
@@ -1350,7 +1327,6 @@ def properties(
     return_data_type: str = 'list',
     first_element: bool = False,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
@@ -1400,9 +1376,6 @@ def properties(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -1415,10 +1388,10 @@ def properties(
     if output_format is None and return_data_type == "string":
         output_format = "string"
 
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         results = _extract.properties(
             df[input[0]].astype(str).tolist(),
             type=property_type,
@@ -1432,8 +1405,7 @@ def properties(
             results,
             output_format,
             delimiter,
-            "json_list" if property_type else "json_dictionary",
-            output_column_name
+            "json_list" if property_type else "json_dictionary"
         )
     elif len(output) == 1 and len(input) > 1:
         results = _extract.properties(
@@ -1449,8 +1421,7 @@ def properties(
             results,
             output_format,
             delimiter,
-            "json_list" if property_type else "json_dictionary",
-            output_column_name
+            "json_list" if property_type else "json_dictionary"
         )
     else:
         # Loop through and apply for all columns
@@ -1468,10 +1439,9 @@ def properties(
                 results,
                 output_format,
                 delimiter,
-                "json_list" if property_type else "json_dictionary",
-                output_column_name
+                "json_list" if property_type else "json_dictionary"
             )
-    
+
     return df
 
 def regex(
@@ -1482,7 +1452,6 @@ def regex(
   output_pattern: str = None,
   first_element: bool = False,
   output_format: str = None,
-  output_column_name: str = None,
   delimiter: str = ", "
   ) -> _pd.DataFrame:
     r"""
@@ -1527,24 +1496,21 @@ def regex(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
-    if output is None: 
+    if output is None:
         output = input
 
     # If a string is provided, convert to list
-    if not isinstance(input, list): 
+    if not isinstance(input, list):
         input = [input]
-    if not isinstance(output, list): 
+    if not isinstance(output, list):
         output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
-    
+
     _logging.debug(f": Extracting regex patterns :: input :: {input}")
     find_pattern = _re.compile(find)
 
@@ -1557,12 +1523,12 @@ def regex(
 
     def _write_regex(input_column, output_columns):
         results = df[input_column].apply(_matches).tolist()
-        if output_format is None and first_element:
+        if output_format is None and first_element and len(output_columns) == 1:
             df[output_columns[0]] = [row[0] if len(row) >= 1 else "" for row in results]
         else:
-            _write_list_output(df, output_columns, results, output_format, delimiter, output_column_name=output_column_name)
+            _write_list_output(df, output_columns, results, output_format, delimiter)
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         _write_regex(input[0], output)
     else:
         # Loop through and apply for all columns

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -1020,6 +1020,7 @@ def custom(
             case_sensitive=case_sensitive,
             extract_raw=extract_raw,
             use_spellcheck=use_spellcheck,
+            include_empty_labels=include_empty_labels,
             sort=sort,
             **kwargs
         )
@@ -1037,6 +1038,7 @@ def custom(
                 case_sensitive=case_sensitive,
                 extract_raw=extract_raw,
                 use_spellcheck=use_spellcheck,
+                include_empty_labels=include_empty_labels,
                 sort=sort,
                 **kwargs
             )
@@ -1056,6 +1058,7 @@ def custom(
                 case_sensitive=case_sensitive,
                 extract_raw=extract_raw,
                 use_spellcheck=use_spellcheck,
+                include_empty_labels=include_empty_labels,
                 sort=sort,
                 **kwargs
             )
@@ -1077,6 +1080,7 @@ def custom(
                 case_sensitive=case_sensitive,
                 extract_raw=extract_raw,
                 use_spellcheck=use_spellcheck,
+                include_empty_labels=include_empty_labels,
                 sort=sort,
                 **kwargs
             )


### PR DESCRIPTION
## Summary

Implements consistent recipe-level output formatting for extract wrangles.

Adds one user-facing option, `output_format`, across extract recipes with common choices:

- list-producing extracts: `List`, `Columns`, `String`
- dictionary-producing extracts: `Dictionary`, `Columns`

The implementation keeps old behavior as the default where possible, while allowing users to choose the output shape directly at the wrangle level.

## Changes

- Added shared output-format helpers in `wrangles/recipe_wrangles/extract.py`.
- Added `output_format` to extract recipes that produce list or dictionary-style results.
- Added `delimiter` for `String` output, defaulting to `", "`.
- Added `output_column_name` for generated column names when expanding list output to columns.
- Kept backward-compatible aliases, including `json list`, `json dictionary`, `dict`, and `dictionary`.
- Updated user-facing labels from `JSON List` / `JSON Dictionary` to `List` / `Dictionary`.
- Added column expansion for dictionary-producing extracts using discovered dictionary keys.
- Added support for multi-input labeled custom extracts to merge dictionary outputs before column expansion.
- Updated `extract.html` to expose real output-format options instead of the previous no-op `first_element`.
- Updated `wrangles.extract.brackets` so recipe-level `String` remains backward-compatible while `List` and `Columns` can work from list-shaped data.

## Extract Behavior

For list-producing extracts:

- `List` writes the extracted list to the output column.
- `Columns` expands list elements into separate columns.
- `String` joins list elements using `delimiter`.

For dictionary-producing extracts:

- `Dictionary` writes the full dictionary to one output column.
- `Columns` expands dictionary keys into separate columns.

## Usage Examples

List-producing extract as a delimited string:

```yaml
wrangles:
  - extract.codes:
      input: description
      output: codes
      output_format: String
      delimiter: " | "
```

List-producing extract expanded to columns:

```yaml
wrangles:
  - extract.codes:
      input: description
      output:
        - Code 1
        - Code 2
      output_format: Columns
```

Dictionary-producing extract kept as one dictionary column:

```yaml
wrangles:
  - extract.ai:
      input: description
      output:
        length:
          type: string
          description: Any lengths found in the data
        item_type:
          type: string
          description: Type of item
      output_format: Dictionary
      output_column_name: result
```

Dictionary-producing extract expanded to columns:

```yaml
wrangles:
  - extract.properties:
      input: description
      output: properties
      output_format: Columns
```
