### PR TITLE
Simplify extract output_format: drop output_column_name, infer Columns from output list

### DIFF
--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -472,7 +472,11 @@ class TestExtractAttributes:
 
     def test_attributes_single_input_multi_output(self):
         """
-        If the input and output are different lengths
+        A single input with a multi-name output list implicitly
+        fans the results out across explicit columns. The number
+        of columns actually created is capped to however many
+        results were found - only one match here, so only the
+        first output column is created.
         """
         data = pd.DataFrame({
             'col1': ['13 something 13kg 13 random'],
@@ -482,18 +486,15 @@ class TestExtractAttributes:
         wrangles:
             - extract.attributes:
                 input: col1
-                output: 
+                output:
                 - out1
                 - out2
                 responseContent: span
                 attribute_type: mass
         """
-        with pytest.raises(ValueError) as info:
-            wrangles.recipe.run(recipe, dataframe=data)
-        assert (
-            info.typename == 'ValueError' and
-            'Extract must output to a single column or equal amount of columns as input.' in info.value.args[0]
-        )
+        df = wrangles.recipe.run(recipe, dataframe=data)
+        assert df.iloc[0]['out1'] == '13kg'
+        assert 'out2' not in df.columns
 
     def test_attributes_where(self):
         """
@@ -631,21 +632,24 @@ class TestExtractCodes:
         assert df.iloc[0]['out2'] == ['Z1ON0101-2', 'Z1ON0101']
 
     def test_extract_codes_one_input_multi_output(self):
+        """
+        A single input with a multi-name output list implicitly
+        fans results across explicit columns, without needing
+        output_format: Columns to be set.
+        """
         recipe = """
         wrangles:
         - extract.codes:
-            input: 
+            input:
                 - code1
             output:
                 - out1
                 - out2
         """
-        with pytest.raises(ValueError) as info:
-            wrangles.recipe.run(recipe, dataframe=self.df_multi_input)
-        assert (
-            info.typename == 'ValueError' and
-            'Extract must output to a single column or equal amount of columns as input.' in info.value.args[0]
-        )
+        with patch("wrangles.extract.codes", return_value=[["ABC123", "XYZ789"]]):
+            df = wrangles.recipe.run(recipe, dataframe=self.df_multi_input)
+        assert df.iloc[0]['out1'] == 'ABC123'
+        assert df.iloc[0]['out2'] == 'XYZ789'
 
     def test_extract_codes_first_element(self):
         """
@@ -714,23 +718,6 @@ class TestExtractCodes:
             df = wrangles.recipe.run(recipe, dataframe=data)
         assert df.iloc[0]['Code 1'] == 'ABC123'
         assert df.iloc[0]['Code 2'] == 'XYZ789'
-
-    def test_extract_codes_output_format_columns_with_output_column_name(self):
-        data = pd.DataFrame({
-            'col1': ['codes here']
-        })
-        recipe = """
-        wrangles:
-        - extract.codes:
-            input: col1
-            output: ignored_base
-            output_format: Columns
-            output_column_name: code
-        """
-        with patch("wrangles.extract.codes", return_value=[["ABC123", "XYZ789"]]):
-            df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['code 1'] == 'ABC123'
-        assert df.iloc[0]['code 2'] == 'XYZ789'
 
     def test_extract_codes_where(self):
         """
@@ -3414,14 +3401,13 @@ class TestExtractAI:
                 type: string
                 description: Type of item
             output_format: Dictionary
-            output_column_name: result
         """
         with patch(
             "wrangles.extract.ai",
             return_value=[{"length": "25mm", "type": "wrench"}]
         ):
             result = wrangles.recipe.run(recipe, dataframe=df)
-        assert result.iloc[0]["result"] == {"length": "25mm", "type": "wrench"}
+        assert result.iloc[0]["output"] == {"length": "25mm", "type": "wrench"}
 
     def test_ai_output_format_string_with_delimiter(self):
         df = pd.DataFrame({

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -52,8 +52,22 @@ def _ensure_list(value):
     return value if isinstance(value, list) else [value]
 
 
-def _is_columns_format(output_format):
-    return _normalize_output_format(output_format, "json_list") == "columns"
+def _is_columns_target(output, output_format):
+    """
+    Whether results should be split across explicit output columns.
+
+    An explicit output_format always wins. Otherwise, providing output
+    as a list of more than one column name implies Columns format.
+    """
+    if output_format is not None:
+        return _normalize_output_format(output_format, "json_list") == "columns"
+    return isinstance(output, list) and len(output) > 1
+
+
+def _resolve_output_format(output, output_format, default_format):
+    if output_format is None and isinstance(output, list) and len(output) > 1:
+        return "columns"
+    return _normalize_output_format(output_format, default_format)
 
 
 def _stringify_list(value, delimiter):
@@ -70,10 +84,9 @@ def _write_list_output(
     results,
     output_format,
     delimiter=", ",
-    default_format="json_list",
-    output_column_name=None
+    default_format="json_list"
 ):
-    output_format = _normalize_output_format(output_format, default_format)
+    output_format = _resolve_output_format(output, output_format, default_format)
 
     if output_format == "json_dictionary":
         raise ValueError("output_format Dictionary is only valid for dictionary-producing extracts")
@@ -83,14 +96,16 @@ def _write_list_output(
         return
 
     if output_format == "columns":
-        output_count = len(output) if len(output) > 1 else max(
+        max_result_len = max(
             [len(row) for row in results if isinstance(row, list)] or [1]
         )
-        output_columns = (
-            output
-            if len(output) > 1
-            else [f"{output_column_name or output[0]} {i + 1}" for i in range(output_count)]
-        )
+        if len(output) > 1:
+            # Cap the number of columns created to however many
+            # results were actually found, even if more output
+            # column names were provided
+            output_columns = output[:min(len(output), max_result_len)]
+        else:
+            output_columns = [f"{output[0]} {i + 1}" for i in range(max_result_len)]
         for i, output_column in enumerate(output_columns):
             df[output_column] = [
                 row[i] if isinstance(row, list) and len(row) > i else ""
@@ -112,7 +127,7 @@ def _dict_keys(results):
 
 
 def _write_dict_output(df, output, results, output_format, default_format="json_dictionary"):
-    output_format = _normalize_output_format(output_format, default_format)
+    output_format = _resolve_output_format(output, output_format, default_format)
 
     if output_format in ("json_list", "string"):
         raise ValueError("output_format List or String is only valid for list-producing extracts")
@@ -135,11 +150,10 @@ def _write_results(
     results,
     output_format,
     delimiter=", ",
-    default_format="json_list",
-    output_column_name=None
+    default_format="json_list"
 ):
     if default_format == "json_dictionary":
-        _write_dict_output(df, output, results, output_format)
+        _write_dict_output(df, output, results, output_format, default_format)
     else:
         _write_list_output(
             df,
@@ -147,8 +161,7 @@ def _write_results(
             results,
             output_format,
             delimiter,
-            default_format,
-            output_column_name
+            default_format
         )
 
 
@@ -179,7 +192,6 @@ def address(
     output: _Union[str, list],
     dataType: str,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
@@ -219,9 +231,6 @@ def address(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -231,23 +240,23 @@ def address(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         results = _extract.address(
             df[input[0]].astype(str).tolist(),
             dataType,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+        _write_list_output(df, output, results, output_format, delimiter)
     elif len(output) == 1 and len(input) > 1:
         results = _extract.address(
             df[input].astype(str).aggregate(' '.join, axis=1).tolist(),
             dataType,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+        _write_list_output(df, output, results, output_format, delimiter)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -256,7 +265,7 @@ def address(
                 dataType,
                 **kwargs
             )
-            _write_list_output(df, [output_column], results, output_format, delimiter, output_column_name=output_column_name)
+            _write_list_output(df, [output_column], results, output_format, delimiter)
   
     return df
 
@@ -268,7 +277,6 @@ def ai(
     output: _Union[dict, str, list] = None,
     model_id: str = None,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ):
@@ -369,9 +377,6 @@ def ai(
           - Dictionary
           - Columns
           - String
-      output_column_name:
-        type: string
-        description: Column name to use when output_format is Dictionary
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
@@ -450,17 +455,12 @@ def ai(
         exploded_df = _pd.json_normalize(results, max_level=0).fillna('').set_index(df.index)
 
         if output_format_normalized == "json_dictionary":
-            if output_column_name is None:
-                output_column_name = target_columns[0] if target_columns and len(target_columns) == 1 else "output"
+            output_column_name = target_columns[0] if target_columns and len(target_columns) == 1 else "output"
             df[output_column_name] = results
         elif output_format_normalized == "string":
             if target_columns and len(target_columns) != 1:
                 raise ValueError("output_format String can only be used with a single output column")
-            output_column = (
-                target_columns[0]
-                if target_columns
-                else output_column_name or "output"
-            )
+            output_column = target_columns[0] if target_columns else "output"
             if len(exploded_df.columns) == 1:
                 df[output_column] = [
                     _stringify_list(row, delimiter)
@@ -507,7 +507,6 @@ def attributes(
     bound: str = 'mid',
     first_element: bool = False,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
@@ -588,9 +587,6 @@ def attributes(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     $ref: "#/$defs/misc/unit_entity_map"
     """
     # If output is not specified, overwrite input columns in place
@@ -601,10 +597,10 @@ def attributes(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         results = _extract.attributes(
             df[input[0]].astype(str).tolist(),
             responseContent,
@@ -620,8 +616,7 @@ def attributes(
             results,
             output_format,
             delimiter,
-            "json_list" if attribute_type else "json_dictionary",
-            output_column_name
+            "json_list" if attribute_type else "json_dictionary"
         )
     elif len(output) == 1 and len(input) > 1:
         # df[output[0]] = _extract.attributes(df[input].astype(str).aggregate(' AAA '.join, axis=1).tolist())
@@ -640,8 +635,7 @@ def attributes(
             results,
             output_format,
             delimiter,
-            "json_list" if attribute_type else "json_dictionary",
-            output_column_name
+            "json_list" if attribute_type else "json_dictionary"
         )
     else:
         # Loop through and apply for all columns
@@ -661,10 +655,9 @@ def attributes(
                 results,
                 output_format,
                 delimiter,
-                "json_list" if attribute_type else "json_dictionary",
-                output_column_name
+                "json_list" if attribute_type else "json_dictionary"
             )
-        
+
     return df
 
 
@@ -675,7 +668,6 @@ def brackets(
     find: _Union[str, list] = 'all',
     include_brackets: bool = False,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", "
 ) -> _pd.DataFrame:
     """
@@ -715,9 +707,6 @@ def brackets(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -727,7 +716,7 @@ def brackets(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
     _logging.debug(f": Extracting from brackets :: input :: {input}")
@@ -741,9 +730,12 @@ def brackets(
         raise ValueError("find must only contain the elements: round, square, curly, angled")
 
     # If only only one output and multiple inputs, concatenate the inputs
-    return_data_type = "string" if output_format is None else "list"
+    # Also need list results (not a joined string) whenever a single input
+    # is being fanned out across multiple explicit output columns
+    implicit_columns = len(input) == 1 and len(output) > 1
+    return_data_type = "string" if output_format is None and not implicit_columns else "list"
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         results = _extract.brackets(
             df[input[0]].astype(str).tolist(),
             find,
@@ -756,8 +748,7 @@ def brackets(
             results,
             output_format,
             delimiter,
-            default_format="string",
-            output_column_name=output_column_name
+            default_format="string"
         )
     elif len(output) == 1 and len(input) > 1:
         results = _extract.brackets(
@@ -772,8 +763,7 @@ def brackets(
             results,
             output_format,
             delimiter,
-            default_format="string",
-            output_column_name=output_column_name
+            default_format="string"
         )
     else:
         # Loop through and apply for all columns
@@ -790,8 +780,7 @@ def brackets(
                 results,
                 output_format,
                 delimiter,
-                default_format="string",
-                output_column_name=output_column_name
+                default_format="string"
             )
 
     return df
@@ -803,7 +792,6 @@ def codes(
     output: _Union[str, list],
     first_element: bool = False,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
@@ -838,9 +826,6 @@ def codes(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
       min_length:
         type:
           - integer
@@ -883,23 +868,23 @@ def codes(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         results = _extract.codes(
             df[input[0]].astype(str).tolist(),
             False,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+        _write_list_output(df, output, results, output_format, delimiter)
     elif len(output) == 1 and len(input) > 1:
         results = _extract.codes(
             df[input].astype(str).aggregate(' AAA '.join, axis=1).tolist(),
             first_element if output_format is None else False,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+        _write_list_output(df, output, results, output_format, delimiter)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -908,7 +893,7 @@ def codes(
                 first_element if output_format is None else False,
                 **kwargs
             )
-            _write_list_output(df, [output_column], results, output_format, delimiter, output_column_name=output_column_name)
+            _write_list_output(df, [output_column], results, output_format, delimiter)
 
     return df
 
@@ -926,7 +911,6 @@ def custom(
     include_empty_labels: bool = True,
     sort: str = 'training_order',
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
@@ -994,23 +978,20 @@ def custom(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     """
     if output is None: output = input
-    
+
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
     if not isinstance(model_id, list): model_id = [model_id]
 
     default_format = "json_dictionary" if use_labels else "json_list"
-    
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_format(output_format) and len(model_id) == 1:
+    if len(input) == 1 and _is_columns_target(output, output_format) and len(model_id) == 1:
         results = _extract.custom(
             df[input[0]].astype(str).tolist(),
             model_id=model_id[0],
@@ -1023,7 +1004,7 @@ def custom(
             sort=sort,
             **kwargs
         )
-        _write_results(df, output, results, output_format, delimiter, default_format, output_column_name)
+        _write_results(df, output, results, output_format, delimiter, default_format)
 
     elif len(input) == len(output) and len(model_id) == 1:
         # if one model_id, then use that model for all columns inputs and outputs
@@ -1041,8 +1022,8 @@ def custom(
                 sort=sort,
                 **kwargs
             )
-            _write_results(df, [out_col], results, output_format, delimiter, default_format, output_column_name)
-    
+            _write_results(df, [out_col], results, output_format, delimiter, default_format)
+
     elif len(input) > 1 and len(output) == 1 and len(model_id) == 1:
         model_id = [model_id[0] for _ in range(len(input))]
         output = output[0]
@@ -1066,7 +1047,7 @@ def custom(
             results = [_combine_dict_rows(row) for row in df_temp.values.tolist()]
         else:
             results = [_combine_list_rows(row) for row in df_temp.values.tolist()]
-        _write_results(df, [output], results, output_format, delimiter, default_format, output_column_name)
+        _write_results(df, [output], results, output_format, delimiter, default_format)
 
     else:
         # Iterate through the inputs, outputs and model_ids
@@ -1083,7 +1064,7 @@ def custom(
                 sort=sort,
                 **kwargs
             )
-            _write_results(df, [out_col], results, output_format, delimiter, default_format, output_column_name)
+            _write_results(df, [out_col], results, output_format, delimiter, default_format)
 
     return df
 
@@ -1278,7 +1259,6 @@ def html(
     data_type: str,
     output: _Union[str, list] = None,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
@@ -1317,9 +1297,6 @@ def html(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -1329,18 +1306,18 @@ def html(
     if not isinstance(output, list): output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
     _logging.debug(f": Extracting from HTML :: input :: {input}")
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         results = _extract.html(
             df[input[0]].astype(str).tolist(),
             dataType=data_type,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_column_name=output_column_name)
+        _write_list_output(df, output, results, output_format, delimiter)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -1349,8 +1326,8 @@ def html(
                 dataType=data_type,
                 **kwargs
             )
-            _write_list_output(df, [output_column], results, output_format, delimiter, output_column_name=output_column_name)
-            
+            _write_list_output(df, [output_column], results, output_format, delimiter)
+
     return df
 
 
@@ -1362,7 +1339,6 @@ def properties(
     return_data_type: str = 'list',
     first_element: bool = False,
     output_format: str = None,
-    output_column_name: str = None,
     delimiter: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
@@ -1412,9 +1388,6 @@ def properties(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -1427,10 +1400,10 @@ def properties(
     if output_format is None and return_data_type == "string":
         output_format = "string"
 
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         results = _extract.properties(
             df[input[0]].astype(str).tolist(),
             type=property_type,
@@ -1444,8 +1417,7 @@ def properties(
             results,
             output_format,
             delimiter,
-            "json_list" if property_type else "json_dictionary",
-            output_column_name
+            "json_list" if property_type else "json_dictionary"
         )
     elif len(output) == 1 and len(input) > 1:
         results = _extract.properties(
@@ -1461,8 +1433,7 @@ def properties(
             results,
             output_format,
             delimiter,
-            "json_list" if property_type else "json_dictionary",
-            output_column_name
+            "json_list" if property_type else "json_dictionary"
         )
     else:
         # Loop through and apply for all columns
@@ -1480,10 +1451,9 @@ def properties(
                 results,
                 output_format,
                 delimiter,
-                "json_list" if property_type else "json_dictionary",
-                output_column_name
+                "json_list" if property_type else "json_dictionary"
             )
-    
+
     return df
 
 def regex(
@@ -1494,7 +1464,6 @@ def regex(
   output_pattern: str = None,
   first_element: bool = False,
   output_format: str = None,
-  output_column_name: str = None,
   delimiter: str = ", "
   ) -> _pd.DataFrame:
     r"""
@@ -1539,24 +1508,21 @@ def regex(
       delimiter:
         type: string
         description: Delimiter to use when output_format is String
-      output_column_name:
-        type: string
-        description: Base output column name to use when output_format is Columns
     """
     # If output is not specified, overwrite input columns in place
-    if output is None: 
+    if output is None:
         output = input
 
     # If a string is provided, convert to list
-    if not isinstance(input, list): 
+    if not isinstance(input, list):
         input = [input]
-    if not isinstance(output, list): 
+    if not isinstance(output, list):
         output = [output]
 
     # Ensure input and output lengths are compatible
-    if len(input) != len(output) and len(output) > 1 and not _is_columns_format(output_format):
+    if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
-    
+
     _logging.debug(f": Extracting regex patterns :: input :: {input}")
     find_pattern = _re.compile(find)
 
@@ -1569,12 +1535,12 @@ def regex(
 
     def _write_regex(input_column, output_columns):
         results = df[input_column].apply(_matches).tolist()
-        if output_format is None and first_element:
+        if output_format is None and first_element and len(output_columns) == 1:
             df[output_columns[0]] = [row[0] if len(row) >= 1 else "" for row in results]
         else:
-            _write_list_output(df, output_columns, results, output_format, delimiter, output_column_name=output_column_name)
+            _write_list_output(df, output_columns, results, output_format, delimiter)
 
-    if len(input) == 1 and _is_columns_format(output_format):
+    if len(input) == 1 and _is_columns_target(output, output_format):
         _write_regex(input[0], output)
     else:
         # Loop through and apply for all columns


### PR DESCRIPTION
## Summary
- Remove `output_column_name` from all extract wrangles (address, attributes, brackets, codes, custom, html, properties, regex, ai) - column naming is driven entirely by `output`.
- Passing `output` as a list of names now implies Columns format automatically, without needing `output_format: Columns`.
- The number of columns created is capped to however many results were actually found per row, even if more output names were supplied.
- Tightened input/output length validation so it only bypasses the mismatch check when the fan-out branch will actually consume the extra names; explicit String/Dictionary formats with a multi-name output list now raise instead of silently dropping columns.

## Test plan
- [x] `pytest tests/recipes/wrangles/test_extract.py` (211 passed, network-dependent live-AI tests excluded)