### PR TITLE
Fix inconsistent casing for Unlabeled key in extract.custom

### DIFF
--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -1145,6 +1145,40 @@ class TestExtractCustom:
             df['size'][0] == ['small']
         )
 
+    def test_extract_custom_labels_columns_format_unlabeled_consistent_casing(self):
+        """
+        Regression test for output_format: columns combined with include_empty_labels: true.
+
+        One row has an unlabeled match (the "Unlabeled" key is only returned by
+        the API when a row actually has an unmatched span), the other row has
+        none. Previously this produced two separate columns - "Unlabeled" and
+        "unlabeled" - because the empty-label fill-in used inconsistent casing
+        between rows, and pandas filled the resulting gaps with "" instead of [].
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - extract.custom:
+                input: col1
+                output: col2
+                model_id: 829c1a73-1bfd-4ac0
+                use_labels: true
+                output_format: columns
+            """,
+            dataframe = pd.DataFrame({
+                'col1': ['small blue', 'my color is red']
+            })
+        )
+
+        # Only a single "Unlabeled" column should exist, not both
+        # "Unlabeled" and "unlabeled".
+        assert 'Unlabeled' in df.columns and 'unlabeled' not in df.columns
+
+        # Row with no unlabeled match gets an empty list, not an empty string.
+        assert df['Unlabeled'][0] == []
+        # Row with an unlabeled match keeps its real value.
+        assert df['Unlabeled'][1] == ['red']
+
     def test_extract_custom_6(self):
         """
         Incorrect model_id - forget to use ${}

--- a/wrangles/extract.py
+++ b/wrangles/extract.py
@@ -541,18 +541,22 @@ def custom(
         
         if use_labels:
             if include_empty_labels:
-                # Ensure every label has a key, create empty keys if missing.
-                # Use both labels discovered from results and labels defined in the model.
-                all_labels = set(model_labels or [])
+                # Determine a single canonical casing per label (case-insensitive).
+                # Casing seen in the actual API results takes precedence over the
+                # model-defined casing, so labels like "Unlabeled" stay consistent
+                # across every row instead of varying between "Unlabeled"/"unlabeled".
+                canonical_labels = {}
+                for label in (model_labels or []):
+                    canonical_labels.setdefault(str(label).lower(), label)
                 for objs in results:
-                    all_labels.update([str(k).lower() for k in objs.keys()])
+                    for k in objs.keys():
+                        canonical_labels[str(k).lower()] = k
 
                 for objs in results:
-                    # Normalize existing keys to lower-case while preserving original keys
-                    existing = {str(k).lower(): k for k in objs.keys()}
-                    for label in all_labels:
-                        if label not in existing:
-                            objs[label] = []
+                    existing = {str(k).lower(): v for k, v in objs.items()}
+                    objs.clear()
+                    for label_lower, label in canonical_labels.items():
+                        objs[label] = existing.get(label_lower, [])
             if first_element:
                 results = [{k: v[0] if isinstance(v, list) and v else "" for k, v in objs.items()} for objs in results]
     else:


### PR DESCRIPTION
## Summary
- Port of the casing fix from #817's follow-up work onto `dev`, which already has the base `include_empty_labels`/`output_format: columns` feature (#1053) but not this fix.
- The empty-label fill-in for `include_empty_labels` added synthetic keys using lower-cased labels, while the API's real `Unlabeled` bucket keeps its original casing and is only present on rows with an actual unlabeled match. This produced two separate `Unlabeled`/`unlabeled` columns with `output_format: columns`, and pandas filled the resulting gaps with `""` instead of `[]`.
- Now a single canonical casing per label (preferring casing seen in actual API results) is used consistently across every row.

## Test plan
- [x] `pytest tests/recipes/wrangles/test_extract.py -k custom` — 87 passed
- [x] Added regression test `test_extract_custom_labels_columns_format_unlabeled_consistent_casing` covering mixed matched/unmatched rows with `output_format: columns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)