### PR TITLE
Update extract.custom parameter descriptions

### DIFF
--- a/wrangles/extract.py
+++ b/wrangles/extract.py
@@ -465,7 +465,17 @@ def custom(
 
     :param input: A string or list of strings to searched for information.
     :param model_id: The model to be used to search for information.
-    :return: A list of entities found.
+    :param first_element: Return only the first extracted value for each input. If the service returns
+        multiple values for one matched span, only the first value after sorting is kept.
+    :param use_labels: Return labeled output as a dictionary such as {'colour': ['blue']}.
+    :param case_sensitive: Match keywords and regex using case-sensitive behavior.
+    :param extract_raw: Return the raw matched input text instead of the standardized output.
+    :param use_spellcheck: Apply spellcheck before extraction.
+    :param sort: Sort mode used by the extract service.
+    :return: For a scalar input, returns that input's extracted values. For a list input, returns one
+        result per input. Results are lists by default, dictionaries when use_labels is true, or scalar
+        values when first_element is true. A single matched input span can contribute multiple values
+        when the model maps the same variant to multiple outputs.
     """
     if isinstance(input, str): 
         json_data = [input]

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -561,11 +561,11 @@ def custom(
     description: |-
       Extract data from the input using a DIY or bespoke extraction wrangle. Requires WrangleWorks Account and Subscription.
       Results are lists by default. A single matched input span can return multiple standardized values when
-      the model maps the same keyword variant to multiple outputs. Use first_element only when downstream
-      logic should keep the first sorted result and discard any remaining matches.
+      the model maps the same keyword variant to multiple outputs.
     required:
       - input
       - model_id
+      - output
     properties:
       input:
         type:
@@ -573,16 +573,16 @@ def custom(
           - integer
           - array
         description: Name or list of input columns.
-      output:
-        type:
-          - string
-          - array
-        description: Name or list of output columns
       model_id:
         type:
           - string
           - array
-        description: The ID of the wrangle to use
+        description: The ID of the wrangle to use.
+      output:
+        type:
+          - string
+          - array
+        description: Name or list of output columns.
       use_labels:
         type: boolean
         description: |-

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -558,7 +558,11 @@ def custom(
 ) -> _pd.DataFrame:
     """
     type: object
-    description: Extract data from the input using a DIY or bespoke extraction wrangle. Requires WrangleWorks Account and Subscription.
+    description: |-
+      Extract data from the input using a DIY or bespoke extraction wrangle. Requires WrangleWorks Account and Subscription.
+      Results are lists by default. A single matched input span can return multiple standardized values when
+      the model maps the same keyword variant to multiple outputs. Use first_element only when downstream
+      logic should keep the first sorted result and discard any remaining matches.
     required:
       - input
       - model_id
@@ -581,16 +585,22 @@ def custom(
         description: The ID of the wrangle to use
       use_labels:
         type: boolean
-        description: "Use Labels in the extract output {label: value}"
+        description: |-
+          Use labels in the extract output, for example {label: [value]}.
+          When multi-match produces multiple labeled outputs, values are grouped under their labels.
       first_element:
         type: boolean
-        description: Get the first element from results
+        description: |-
+          Get the first element from results.
+          If one matched span returns multiple values, only the first value after sorting is kept.
       case_sensitive:
         type: boolean
         description: Allows the wrangle to be case sensitive if set to True, default is False.
       extract_raw:
         type: boolean
-        description: Extract the raw data from the wrangle
+        description: |-
+          Extract the raw text matched in the input instead of the standardized output.
+          Multi-match standardized outputs collapse to the same raw span when this is true.
       use_spellcheck:
         type: boolean
         description: Use spellcheck to also find minor mispellings compared to the reference data


### PR DESCRIPTION
 - incorporated new multi-match capability into recipe wrangle schema
 - made output required --> can't image a case where extract (list) should be slotted into the input (str)
 - add other missing params to core wrangle doc strings
