### PR TITLE
985 enhancement allow list of one/multiple defaults

### DIFF
--- a/.github/workflows/publish-dev-rc.yml
+++ b/.github/workflows/publish-dev-rc.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Test pip install
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements-full.txt
           pip install .
           wrangles.recipe tests/samples/generate-data.wrgl.yml
 
@@ -161,12 +162,6 @@ jobs:
 
       - name: Install build tooling
         run: python -m pip install build twine --user
-
-      - name: Patch setup.py to use requirements-full.txt
-        run: |
-          sed -i "s/requirements\.txt/requirements-full.txt/" setup.py
-          echo "setup.py requirements line after patch:"
-          grep "requirements" setup.py
 
       - name: Build sdist and wheel
         run: python -m build --sdist --wheel --outdir dist/ .

--- a/.github/workflows/publish-dev-rc.yml
+++ b/.github/workflows/publish-dev-rc.yml
@@ -108,7 +108,7 @@ jobs:
   # guarded to the 'dev' and 'main' branches, and every commit on those branches
   # is already tested by publish-dev.yml / publish-main.yml respectively.
   test-pip-install:
-    name: Smoke Test – pip install
+    name: smoke test
     runs-on: ubuntu-latest
     needs: [compute-version]
     permissions:
@@ -130,7 +130,7 @@ jobs:
 
   # ── 3. Publish Python package to CodeArtifact ────────────────────────────
   publish-codeartifact:
-    name: Publish RC to CodeArtifact
+    name: Publish RC Package
     runs-on: ubuntu-latest
     needs: [compute-version, test-pip-install]
     permissions:
@@ -174,3 +174,25 @@ jobs:
 
       - name: Publish to CodeArtifact
         run: twine upload --repository codeartifact dist/*
+
+  # ── 4. Trigger QA deployment in Lambda-Recipes ───────────────────────────
+  # CROSS_REPO_PAT: a GitHub PAT with Actions read/write on Lambda-Recipes,
+  # stored as a repository or org secret. Required to dispatch workflows across repositories.
+  trigger-deploy-qa:
+    name: Trigger QA Deploy
+    runs-on: ubuntu-latest
+    needs: [compute-version, publish-codeartifact]
+    steps:
+      - name: Deploy QA
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: wrangleworks
+          repo: Lambda-Recipes
+          workflow_file_name: deploy-qa.yml
+          github_token: ${{ secrets.CROSS_REPO_PAT }}
+          ref: main
+          wait_interval: 15
+          client_payload: '{"wrangles_version": "${{ needs.compute-version.outputs.rc_version }}"}'
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true

--- a/.github/workflows/publish-dev-rc.yml
+++ b/.github/workflows/publish-dev-rc.yml
@@ -162,6 +162,12 @@ jobs:
       - name: Install build tooling
         run: python -m pip install build twine --user
 
+      - name: Patch setup.py to use requirements-full.txt
+        run: |
+          sed -i "s/requirements\.txt/requirements-full.txt/" setup.py
+          echo "setup.py requirements line after patch:"
+          grep "requirements" setup.py
+
       - name: Build sdist and wheel
         run: python -m build --sdist --wheel --outdir dist/ .
 

--- a/.github/workflows/publish-dev-rc.yml
+++ b/.github/workflows/publish-dev-rc.yml
@@ -23,10 +23,10 @@ jobs:
     outputs:
       rc_version: ${{ steps.compute.outputs.rc_version }}
     steps:
-      - name: Guard – dev branch only
-        if: github.ref != 'refs/heads/dev'
+      - name: Guard – dev or main branch only
+        if: github.ref != 'refs/heads/dev' && github.ref != 'refs/heads/main'
         run: |
-          echo "::error::This workflow may only be triggered from the 'dev' branch. Current ref: ${{ github.ref }}"
+          echo "::error::This workflow may only be triggered from the 'dev' or 'main' branch. Current ref: ${{ github.ref }}"
           exit 1
 
       - name: Validate version input format
@@ -105,8 +105,8 @@ jobs:
 
   # ── 2. Pip-install smoke test ─────────────────────────────────────────────
   # NOTE: The full pytest suite is intentionally NOT run here. This workflow is
-  # guarded to the 'dev' branch, and every commit on 'dev' is already tested by
-  # publish-dev.yml 
+  # guarded to the 'dev' and 'main' branches, and every commit on those branches
+  # is already tested by publish-dev.yml / publish-main.yml respectively.
   test-pip-install:
     name: Smoke Test – pip install
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Connectors for databases, cloud storage, and external services require additiona
 | Capability | Install |
 |---|---|
 | Microsoft SQL Server | `pip install pymssql sqlalchemy` |
+| Microsoft Access | `pip install pyodbc` |
+| DuckDB | `pip install duckdb` |
 | PostgreSQL | `pip install psycopg2-binary sqlalchemy` |
 | MySQL | `pip install pymysql sqlalchemy` |
 | MongoDB | `pip install pymongo[srv]` |

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -8,5 +8,7 @@
 
 # SQL databases
 sqlalchemy>=2.0,<3.0
+duckdb>=1.0.0
+pyodbc>=5.0.0
 pymssql>=2.3.3
 psycopg2-binary>=2.9.10

--- a/tests/connectors/test_access.py
+++ b/tests/connectors/test_access.py
@@ -1,0 +1,109 @@
+import pandas as pd
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from wrangles.connectors import access
+
+
+class MockTables:
+    def __init__(self, exists):
+        self.exists = exists
+
+    def fetchone(self):
+        return object() if self.exists else None
+
+
+class MockCursor:
+    def __init__(self, table_exists=False):
+        self.table_exists = table_exists
+        self.executed = []
+        self.executemany_calls = []
+
+    def tables(self, table=None, tableType=None):
+        return MockTables(self.table_exists)
+
+    def execute(self, sql, params=()):
+        self.executed.append((sql, params))
+        return self
+
+    def executemany(self, sql, rows):
+        self.executemany_calls.append((sql, list(rows)))
+        return self
+
+
+class MockConnection:
+    def __init__(self, cursor):
+        self.cursor_obj = cursor
+        self.committed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.committed = True
+
+
+def test_connection_string_requires_database_or_connection_string():
+    try:
+        access._connection_string()
+        assert False
+    except ValueError as e:
+        assert str(e) == 'database or connection_string must be provided'
+
+
+def test_read_sql(monkeypatch):
+    data = pd.DataFrame({'Col1': ['Data1', 'Data2']})
+    mock_connect = Mock(return_value=MockConnection(MockCursor()))
+    monkeypatch.setattr(access, "_pyodbc", SimpleNamespace(connect=mock_connect))
+    monkeypatch.setattr(pd, "read_sql", Mock(return_value=data))
+
+    df = access.read(
+        database='database.accdb',
+        command='SELECT * from df_mock'
+    )
+
+    assert df.equals(data)
+    mock_connect.assert_called_once_with('DRIVER={Microsoft Access Driver (*.mdb, *.accdb)};DBQ=database.accdb;')
+
+
+def test_write_sql_creates_table_and_inserts(monkeypatch):
+    cursor = MockCursor(table_exists=False)
+    monkeypatch.setattr(access, "_pyodbc", SimpleNamespace(connect=Mock(return_value=MockConnection(cursor))))
+
+    result = access.write(
+        df=pd.DataFrame({'Col1': ['Data1', 'Data2'], 'Col2': [1, 2]}),
+        database='database.accdb',
+        table='WrWx'
+    )
+
+    assert result is None
+    assert cursor.executed[0][0] == 'CREATE TABLE [WrWx] ([Col1] LONGTEXT, [Col2] INTEGER)'
+    assert cursor.executemany_calls[0] == (
+        'INSERT INTO [WrWx] ([Col1], [Col2]) VALUES (?, ?)',
+        [('Data1', 1), ('Data2', 2)]
+    )
+
+
+def test_run(monkeypatch):
+    cursor = MockCursor()
+    connection = MockConnection(cursor)
+    monkeypatch.setattr(access, "_pyodbc", SimpleNamespace(connect=Mock(return_value=connection)))
+
+    result = access.run(
+        database='database.accdb',
+        command=['DELETE FROM WrWx WHERE Col1 = ?', 'UPDATE WrWx SET Col1 = ?'],
+        params=('Data1',)
+    )
+
+    assert result is None
+    assert cursor.executed == [
+        ('DELETE FROM WrWx WHERE Col1 = ?', ('Data1',)),
+        ('UPDATE WrWx SET Col1 = ?', ('Data1',))
+    ]
+    assert connection.committed

--- a/tests/connectors/test_duckdb.py
+++ b/tests/connectors/test_duckdb.py
@@ -1,0 +1,72 @@
+import importlib.util
+
+import pandas as pd
+import pytest
+
+from wrangles.connectors import duckdb
+
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec('duckdb') is None,
+    reason='duckdb optional dependency is not installed'
+)
+
+
+def test_read_sql(tmp_path):
+    database = tmp_path / 'test.duckdb'
+    duckdb.run(
+        database=str(database),
+        command='CREATE TABLE df_mock AS SELECT \'Data1\' AS Col1, 1 AS Col2 UNION ALL SELECT \'Data2\', 2'
+    )
+
+    df = duckdb.read(
+        database=str(database),
+        command='SELECT * from df_mock ORDER BY Col2'
+    )
+
+    assert df.equals(
+        pd.DataFrame(
+            {
+                'Col1': ['Data1', 'Data2'],
+                'Col2': pd.array([1, 2], dtype='int32')
+            }
+        )
+    )
+
+
+def test_write_sql(tmp_path):
+    database = tmp_path / 'write.duckdb'
+    df = pd.DataFrame({'Col1': ['Data1', 'Data2']})
+
+    duckdb.write(
+        df=df,
+        database=str(database),
+        table='temp_mock'
+    )
+
+    assert duckdb.read(
+        database=str(database),
+        command='SELECT * from temp_mock'
+    ).equals(df)
+
+
+def test_run(tmp_path):
+    database = tmp_path / 'run.duckdb'
+    df = pd.DataFrame({'Col1': ['Data1', 'Data2']})
+    duckdb.write(
+        df=df,
+        database=str(database),
+        table='test_table'
+    )
+
+    duckdb.run(
+        database=str(database),
+        command='CREATE TABLE test_table_copy AS SELECT * FROM test_table'
+    )
+
+    df_copy = duckdb.read(
+        database=str(database),
+        command='SELECT * from test_table_copy'
+    )
+
+    assert df.equals(df_copy)

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -935,6 +935,61 @@ class TestConvertFromJSON:
             df["out2"][1] == [4, 5, 6]
         )
 
+    def test_default_list_one_applied_to_all_columns(self):
+        """
+        Test that a list of one default is unwrapped and applied to all columns
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_json:
+                input:
+                  - header1
+                  - header2
+                default:
+                  - {}
+                output:
+                  - out1
+                  - out2
+            """,
+            dataframe=pd.DataFrame({
+                "header1": ["", '[1,2,3]'],
+                "header2": ["", '[4,5,6]']
+            })
+        )
+        assert (
+            df["out1"][0] == {} and
+            df["out1"][1] == [1, 2, 3] and
+            df["out2"][0] == {} and
+            df["out2"][1] == [4, 5, 6]
+        )
+
+    def test_default_list_length_mismatch_raises(self):
+        """
+        Test that a default list whose length doesn't match input raises an error
+        """
+        with pytest.raises(ValueError, match="same length"):
+            wrangles.recipe.run(
+                """
+                wrangles:
+                - convert.from_json:
+                    input:
+                      - header1
+                      - header2
+                    default:
+                      - {}
+                      - []
+                      - null
+                    output:
+                      - out1
+                      - out2
+                """,
+                dataframe=pd.DataFrame({
+                    "header1": [""],
+                    "header2": [""]
+                })
+            )
+
 
 class TestConvertFromYAML:
     """
@@ -1118,6 +1173,61 @@ class TestConvertFromYAML:
             df["out2"][0] == [] and
             df["out2"][1] == ["item1"]
         )
+
+    def test_default_list_one_applied_to_all_columns(self):
+        """
+        Test that a list of one default is unwrapped and applied to all columns
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_yaml:
+                input:
+                  - col1
+                  - col2
+                default:
+                  - {}
+                output:
+                  - out1
+                  - out2
+            """,
+            dataframe=pd.DataFrame({
+                "col1": ["", "key: val\n"],
+                "col2": ["", "- item1\n"]
+            })
+        )
+        assert (
+            df["out1"][0] == {} and
+            df["out1"][1] == {"key": "val"} and
+            df["out2"][0] == {} and
+            df["out2"][1] == ["item1"]
+        )
+
+    def test_default_list_length_mismatch_raises(self):
+        """
+        Test that a default list whose length doesn't match input raises an error
+        """
+        with pytest.raises(ValueError, match="same length"):
+            wrangles.recipe.run(
+                """
+                wrangles:
+                - convert.from_yaml:
+                    input:
+                      - col1
+                      - col2
+                    default:
+                      - {}
+                      - []
+                      - null
+                    output:
+                      - out1
+                      - out2
+                """,
+                dataframe=pd.DataFrame({
+                    "col1": [""],
+                    "col2": [""]
+                })
+            )
 
 
 class TestConvertToJSON:

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -884,6 +884,57 @@ class TestConvertFromJSON:
         )
         assert df.empty and df.columns.to_list() == ['header1', 'output column']
 
+    def test_default_list_single_column(self):
+        """
+        Test that a list of one default applies correctly when input is a list of one column
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_json:
+                input:
+                  - header1
+                default:
+                  - {}
+                output:
+                  - out1
+            """,
+            dataframe=pd.DataFrame({
+                "header1": ["", '[1,2,3]']
+            })
+        )
+        assert df["out1"][0] == {} and df["out1"][1] == [1, 2, 3]
+
+    def test_default_list_multiple_columns(self):
+        """
+        Test that a list of defaults applies one default per column
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_json:
+                input:
+                  - header1
+                  - header2
+                default:
+                  - {}
+                  - []
+                output:
+                  - out1
+                  - out2
+            """,
+            dataframe=pd.DataFrame({
+                "header1": ["", '[1,2,3]'],
+                "header2": ["", '[4,5,6]']
+            })
+        )
+        assert (
+            df["out1"][0] == {} and
+            df["out1"][1] == [1, 2, 3] and
+            df["out2"][0] == [] and
+            df["out2"][1] == [4, 5, 6]
+        )
+
 
 class TestConvertFromYAML:
     """
@@ -1016,6 +1067,57 @@ class TestConvertFromYAML:
             })
         )
         assert df.empty and df.columns.to_list() == ['column', 'output column']
+
+    def test_default_list_single_column(self):
+        """
+        Test that a list of one default applies correctly when input is a list of one column
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_yaml:
+                input:
+                  - column
+                default:
+                  - {}
+                output:
+                  - out1
+            """,
+            dataframe=pd.DataFrame({
+                "column": ["", "key: val\n"]
+            })
+        )
+        assert df["out1"][0] == {} and df["out1"][1] == {"key": "val"}
+
+    def test_default_list_multiple_columns(self):
+        """
+        Test that a list of defaults applies one default per column
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_yaml:
+                input:
+                  - col1
+                  - col2
+                default:
+                  - {}
+                  - []
+                output:
+                  - out1
+                  - out2
+            """,
+            dataframe=pd.DataFrame({
+                "col1": ["", "key: val\n"],
+                "col2": ["", "- item1\n"]
+            })
+        )
+        assert (
+            df["out1"][0] == {} and
+            df["out1"][1] == {"key": "val"} and
+            df["out2"][0] == [] and
+            df["out2"][1] == ["item1"]
+        )
 
 
 class TestConvertToJSON:

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -924,13 +924,13 @@ class TestConvertFromJSON:
                   - out2
             """,
             dataframe=pd.DataFrame({
-                "header1": ["", '[1,2,3]'],
+                "header1": ["", '{"a": 1}'],
                 "header2": ["", '[4,5,6]']
             })
         )
         assert (
             df["out1"][0] == {} and
-            df["out1"][1] == [1, 2, 3] and
+            df["out1"][1] == {"a": 1} and
             df["out2"][0] == [] and
             df["out2"][1] == [4, 5, 6]
         )
@@ -953,15 +953,15 @@ class TestConvertFromJSON:
                   - out2
             """,
             dataframe=pd.DataFrame({
-                "header1": ["", '[1,2,3]'],
-                "header2": ["", '[4,5,6]']
+                "header1": ["", '{"a": 1}'],
+                "header2": ["", '{"b": 2}']
             })
         )
         assert (
             df["out1"][0] == {} and
-            df["out1"][1] == [1, 2, 3] and
+            df["out1"][1] == {"a": 1} and
             df["out2"][0] == {} and
-            df["out2"][1] == [4, 5, 6]
+            df["out2"][1] == {"b": 2}
         )
 
     def test_default_list_length_mismatch_raises(self):
@@ -1223,14 +1223,14 @@ class TestConvertFromYAML:
             """,
             dataframe=pd.DataFrame({
                 "col1": ["", "key: val\n"],
-                "col2": ["", "- item1\n"]
+                "col2": ["", "key2: val2\n"]
             })
         )
         assert (
             df["out1"][0] == {} and
             df["out1"][1] == {"key": "val"} and
             df["out2"][0] == {} and
-            df["out2"][1] == ["item1"]
+            df["out2"][1] == {"key2": "val2"}
         )
 
     def test_default_list_length_mismatch_raises(self):

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -990,6 +990,36 @@ class TestConvertFromJSON:
                 })
             )
 
+    def test_default_list_complex_values_no_output(self):
+        """
+        Test a list of complex defaults (dict and list) with no output specified,
+        overwriting the input columns
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_json:
+                input:
+                  - header1
+                  - header2
+                default:
+                  - my_output:
+                      key1: Val1
+                      key2: Val2
+                  - [this, is, a, list]
+            """,
+            dataframe=pd.DataFrame({
+                "header1": ["", '{"a": 1}'],
+                "header2": ["", '[1,2,3]']
+            })
+        )
+        assert (
+            df["header1"][0] == {"my_output": {"key1": "Val1", "key2": "Val2"}} and
+            df["header1"][1] == {"a": 1} and
+            df["header2"][0] == ["this", "is", "a", "list"] and
+            df["header2"][1] == [1, 2, 3]
+        )
+
 
 class TestConvertFromYAML:
     """
@@ -1228,6 +1258,36 @@ class TestConvertFromYAML:
                     "col2": [""]
                 })
             )
+
+    def test_default_list_complex_values_no_output(self):
+        """
+        Test a list of complex defaults (dict and list) with no output specified,
+        overwriting the input columns
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+            - convert.from_yaml:
+                input:
+                  - col1
+                  - col2
+                default:
+                  - my_output:
+                      key1: Val1
+                      key2: Val2
+                  - [this, is, a, list]
+            """,
+            dataframe=pd.DataFrame({
+                "col1": ["", "a: 1\n"],
+                "col2": ["", "- 1\n- 2\n- 3\n"]
+            })
+        )
+        assert (
+            df["col1"][0] == {"my_output": {"key1": "Val1", "key2": "Val2"}} and
+            df["col1"][1] == {"a": 1} and
+            df["col2"][0] == ["this", "is", "a", "list"] and
+            df["col2"][1] == [1, 2, 3]
+        )
 
 
 class TestConvertToJSON:

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -1289,6 +1289,89 @@ class TestConvertFromYAML:
             df["col2"][1] == [1, 2, 3]
         )
 
+    def test_from_yaml_to_yaml_roundtrip_reported_data(self):
+        """
+        Regression test for a reported round-trip bug (PR #987 review):
+        convert.from_yaml -> convert.to_yaml on multiple wildcard-matched
+        columns with per-column defaults should be idempotent - running
+        from_yaml again on the round-tripped output must reproduce the
+        same parsed values, for every row, including a row with a
+        malformed/empty cell that must fall back to its column's default.
+        """
+        df = pd.DataFrame({
+            "Top 1": [
+                "Score: 0.295\nValue: Blade Runner",
+                "Score: 0.234\nValue: Interstellar",
+                "Score: 0.291\nValue: Interstellar",
+            ],
+            "Top 2": [
+                "[]",
+                "Score: 0.22\nValue: Westworld",
+                "Score: 0.248\nValue: Blade Runner",
+            ],
+            "Top 3": [
+                "Score: 0.174\nValue: Westworld",
+                "'",
+                "Score: 0.195\nValue: Westworld",
+            ],
+        })
+        recipe = """
+        wrangles:
+          - convert.from_yaml:
+              input:
+                - Top *
+              default:
+                - {}
+                - []
+                - ''
+        """
+        parsed = wrangles.recipe.run(recipe, dataframe=df.copy())
+
+        assert parsed.to_dict(orient="records") == [
+            {
+                "Top 1": {"Score": 0.295, "Value": "Blade Runner"},
+                "Top 2": [],
+                "Top 3": {"Score": 0.174, "Value": "Westworld"},
+            },
+            {
+                "Top 1": {"Score": 0.234, "Value": "Interstellar"},
+                "Top 2": {"Score": 0.22, "Value": "Westworld"},
+                # Malformed cell ("'") fails to parse and falls back to the default
+                "Top 3": "",
+            },
+            {
+                "Top 1": {"Score": 0.291, "Value": "Interstellar"},
+                "Top 2": {"Score": 0.248, "Value": "Blade Runner"},
+                "Top 3": {"Score": 0.195, "Value": "Westworld"},
+            },
+        ]
+
+        roundtripped = wrangles.recipe.run(
+            """
+            wrangles:
+              - convert.from_yaml:
+                  input:
+                    - Top *
+                  default:
+                    - {}
+                    - []
+                    - ''
+              - convert.to_yaml:
+                  input:
+                    - Top *
+              - convert.from_yaml:
+                  input:
+                    - Top *
+                  default:
+                    - {}
+                    - []
+                    - ''
+            """,
+            dataframe=df.copy()
+        )
+
+        assert parsed.to_dict(orient="records") == roundtripped.to_dict(orient="records")
+
 
 class TestConvertToJSON:
     """

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -7523,11 +7523,14 @@ class TestConcurrent:
 
         end = datetime.now()
 
+        # Upper bound is wider than the threaded test to allow for
+        # process-spawn overhead (e.g. Windows uses spawn rather than fork,
+        # which re-imports the full dependency graph in each worker process).
         assert (
             df['column_a'][0] == 'aa' and
             df['column_b'][0] == 'ab' and
             df['column_c'][0] == 'ac' and
-            5 <= (end - start).seconds < 10
+            5 <= (end - start).seconds < 20
         )
 
     def test_output_error(self):

--- a/tests/test_wrangles.py
+++ b/tests/test_wrangles.py
@@ -121,11 +121,11 @@ def test_extract_html_str():
 # Translate
 def test_translate():
     result = wrangles.translate('My name is Chris', 'DE')
-    assert result[:19] == 'Mein Name ist Chris'
+    assert result[:19] == 'Ich heiße Chris'
 
 def test_translate_list():
     result = wrangles.translate(['My name is Chris'], 'DE')
-    assert result[0][:19] == 'Mein Name ist Chris'
+    assert result[0][:19] == 'Ich heiße Chris'
     
 # Invalid input type (dict)
 def test_translate_typeError():

--- a/wrangles/connectors/__init__.py
+++ b/wrangles/connectors/__init__.py
@@ -3,8 +3,10 @@ Connectors to read/write from external systems
 """
 
 from . import akeneo
+from . import access
 from . import ckan
 from . import concurrent
+from . import duckdb
 from . import excel
 from . import file
 from . import http

--- a/wrangles/connectors/access.py
+++ b/wrangles/connectors/access.py
@@ -1,0 +1,298 @@
+"""
+Connector to read/write from Microsoft Access databases using ODBC.
+"""
+import logging as _logging
+from typing import Union as _Union
+
+import pandas as _pd
+from pandas.api import types as _pd_types
+
+from ..utils import (
+    LazyLoader as _LazyLoader,
+    wildcard_expansion as _wildcard_expansion,
+)
+
+
+_pyodbc = _LazyLoader('pyodbc')
+
+_schema = {}
+
+
+def _quote_identifier(identifier: str) -> str:
+    return f"[{str(identifier).replace(']', ']]')}]"
+
+
+def _connection_string(
+    database: str = None,
+    connection_string: str = None,
+    driver: str = 'Microsoft Access Driver (*.mdb, *.accdb)',
+    password: str = None,
+) -> str:
+    if connection_string:
+        return connection_string
+    if database is None:
+        raise ValueError('database or connection_string must be provided')
+
+    conn = f"DRIVER={{{driver}}};DBQ={database};"
+    if password:
+        conn += f"PWD={password};"
+    return conn
+
+
+def _access_type(dtype) -> str:
+    if _pd_types.is_bool_dtype(dtype):
+        return 'BIT'
+    if _pd_types.is_integer_dtype(dtype):
+        return 'INTEGER'
+    if _pd_types.is_float_dtype(dtype):
+        return 'DOUBLE'
+    if _pd_types.is_datetime64_any_dtype(dtype):
+        return 'DATETIME'
+    return 'LONGTEXT'
+
+
+def _table_exists(cursor, table: str) -> bool:
+    return cursor.tables(table=table, tableType='TABLE').fetchone() is not None
+
+
+def _create_table(cursor, table: str, df: _pd.DataFrame) -> None:
+    columns = ', '.join(
+        f"{_quote_identifier(column)} {_access_type(dtype)}"
+        for column, dtype in df.dtypes.items()
+    )
+    cursor.execute(f"CREATE TABLE {_quote_identifier(table)} ({columns})")
+
+
+def read(
+    command: str,
+    database: str = None,
+    connection_string: str = None,
+    driver: str = 'Microsoft Access Driver (*.mdb, *.accdb)',
+    password: str = None,
+    columns: _Union[str, list] = None,
+    params: _Union[list, tuple] = None,
+    **kwargs
+) -> _pd.DataFrame:
+    """
+    Read data from a Microsoft Access database.
+
+    >>> from wrangles.connectors import access
+    >>> df = access.read(database='database.accdb', command='SELECT * FROM table')
+
+    :param command: SQL command to select data.
+    :param database: Access database file path. Not required if connection_string is supplied.
+    :param connection_string: Full ODBC connection string. If provided, database, driver, and password are ignored.
+    :param driver: ODBC driver name. Defaults to Microsoft Access Driver (*.mdb, *.accdb).
+    :param password: Optional database password.
+    :param columns: (Optional) Subset of columns to be returned. This is less efficient than specifying in the SQL command.
+    :param params: (Optional) Variables to pass to a parameterized query.
+    """
+    target = database or connection_string
+    _logging.info(f": Reading data from Microsoft Access :: {target}")
+
+    conn_string = _connection_string(database, connection_string, driver, password)
+    with _pyodbc.connect(conn_string) as conn:
+        df = _pd.read_sql(command, conn, params=params, **kwargs)
+
+    if columns is not None:
+        columns = _wildcard_expansion(df.columns, columns)
+        df = df[columns]
+
+    return df
+
+
+_schema['read'] = r"""
+type: object
+description: Import data from a Microsoft Access Database
+required:
+  - command
+properties:
+  database:
+    type: string
+    description: Access database file path. Not required if connection_string is supplied.
+  connection_string:
+    type: string
+    description: Full ODBC connection string. If provided, database, driver, and password are ignored.
+  driver:
+    type: string
+    description: ODBC driver name. Defaults to Microsoft Access Driver (*.mdb, *.accdb).
+  password:
+    type: string
+    description: Optional database password.
+  command:
+    type: string
+    description: |-
+      SQL command to select data.
+      Note - using variables here can make your recipe vulnerable
+      to sql injection. Use params if using variables from
+      untrusted sources.
+  columns:
+    type:
+      - string
+      - array
+    description: A list with a subset of the columns to import. This is less efficient than specifying in the command.
+  params:
+    type: array
+    description: Variables to pass to a parameterized query.
+"""
+
+
+def write(
+    df: _pd.DataFrame,
+    table: str,
+    database: str = None,
+    connection_string: str = None,
+    driver: str = 'Microsoft Access Driver (*.mdb, *.accdb)',
+    password: str = None,
+    action: str = 'INSERT',
+    columns: _Union[str, list] = None,
+) -> None:
+    """
+    Write data to a Microsoft Access database.
+
+    >>> from wrangles.connectors import access
+    >>> access.write(df, database='database.accdb', table='table')
+
+    :param df: Pandas Dataframe to be written.
+    :param table: Table to be exported to.
+    :param database: Access database file path. Not required if connection_string is supplied.
+    :param connection_string: Full ODBC connection string. If provided, database, driver, and password are ignored.
+    :param driver: ODBC driver name. Defaults to Microsoft Access Driver (*.mdb, *.accdb).
+    :param password: Optional database password.
+    :param action: INSERT appends, REPLACE recreates the table, FAIL errors if the table exists. Defaults to INSERT.
+    :param columns: (Optional) Subset of the columns to be written. If not provided, all columns will be output.
+    """
+    target = database or connection_string
+    _logging.info(f": Writing data to Microsoft Access :: {target} / {table}")
+
+    action = action.upper()
+    if action not in ('INSERT', 'REPLACE', 'FAIL'):
+        raise ValueError('Invalid action. Expected INSERT, REPLACE, or FAIL.')
+
+    if columns is not None:
+        columns = _wildcard_expansion(df.columns, columns)
+        df = df[columns]
+
+    conn_string = _connection_string(database, connection_string, driver, password)
+    with _pyodbc.connect(conn_string) as conn:
+        cursor = conn.cursor()
+        exists = _table_exists(cursor, table)
+
+        if action == 'FAIL' and exists:
+            raise ValueError(f"Table already exists: {table}")
+        if action == 'REPLACE' and exists:
+            cursor.execute(f"DROP TABLE {_quote_identifier(table)}")
+            exists = False
+        if not exists:
+            _create_table(cursor, table, df)
+
+        if not df.empty:
+            table_name = _quote_identifier(table)
+            column_names = ', '.join(_quote_identifier(column) for column in df.columns)
+            placeholders = ', '.join('?' for _ in df.columns)
+            sql = f"INSERT INTO {table_name} ({column_names}) VALUES ({placeholders})"
+            cursor.executemany(sql, df.where(_pd.notnull(df), None).itertuples(index=False, name=None))
+
+        conn.commit()
+
+
+_schema['write'] = """
+type: object
+description: Export data to a Microsoft Access Database
+required:
+  - table
+properties:
+  database:
+    type: string
+    description: Access database file path. Not required if connection_string is supplied.
+  connection_string:
+    type: string
+    description: Full ODBC connection string. If provided, database, driver, and password are ignored.
+  driver:
+    type: string
+    description: ODBC driver name. Defaults to Microsoft Access Driver (*.mdb, *.accdb).
+  password:
+    type: string
+    description: Optional database password.
+  table:
+    type: string
+    description: The table to write to
+  action:
+    type: string
+    description: INSERT appends, REPLACE recreates the table, FAIL errors if the table exists. Defaults to INSERT.
+    enum:
+      - INSERT
+      - REPLACE
+      - FAIL
+  columns:
+    type:
+      - string
+      - array
+    description: A list of the columns to write to the table. If omitted, all columns will be written.
+"""
+
+
+def run(
+    command: _Union[str, list],
+    database: str = None,
+    connection_string: str = None,
+    driver: str = 'Microsoft Access Driver (*.mdb, *.accdb)',
+    password: str = None,
+    params: _Union[list, tuple] = None,
+) -> None:
+    """
+    Run a command on a Microsoft Access database.
+
+    >>> wrangles.connectors.access.run(
+    >>>    database='database.accdb',
+    >>>    command='<SQL COMMAND>'
+    >>> )
+
+    :param command: SQL command or a list of SQL commands to execute.
+    :param database: Access database file path. Not required if connection_string is supplied.
+    :param connection_string: Full ODBC connection string. If provided, database, driver, and password are ignored.
+    :param driver: ODBC driver name. Defaults to Microsoft Access Driver (*.mdb, *.accdb).
+    :param password: Optional database password.
+    :param params: Variables to pass to a parameterized query.
+    """
+    target = database or connection_string
+    _logging.info(f": Executing Microsoft Access Command :: {target}")
+
+    if isinstance(command, str):
+        command = [command]
+
+    conn_string = _connection_string(database, connection_string, driver, password)
+    with _pyodbc.connect(conn_string) as conn:
+        cursor = conn.cursor()
+        for sql in command:
+            cursor.execute(sql, params or ())
+        conn.commit()
+
+
+_schema['run'] = r"""
+type: object
+description: Run a command against a Microsoft Access Database
+required:
+  - command
+properties:
+  database:
+    type: string
+    description: Access database file path. Not required if connection_string is supplied.
+  connection_string:
+    type: string
+    description: Full ODBC connection string. If provided, database, driver, and password are ignored.
+  driver:
+    type: string
+    description: ODBC driver name. Defaults to Microsoft Access Driver (*.mdb, *.accdb).
+  password:
+    type: string
+    description: Optional database password.
+  command:
+    type:
+      - string
+      - array
+    description: SQL command or a list of SQL commands to execute
+  params:
+    type: array
+    description: Variables to pass to a parameterized query.
+"""

--- a/wrangles/connectors/duckdb.py
+++ b/wrangles/connectors/duckdb.py
@@ -1,0 +1,205 @@
+"""
+Connector to read/write from DuckDB database files.
+"""
+import logging as _logging
+from typing import Union as _Union
+
+import pandas as _pd
+
+from ..utils import (
+    LazyLoader as _LazyLoader,
+    wildcard_expansion as _wildcard_expansion,
+)
+
+
+_duckdb = _LazyLoader('duckdb')
+
+_schema = {}
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '.'.join(
+        f'"{part.replace(chr(34), chr(34) * 2)}"'
+        for part in str(identifier).split('.')
+    )
+
+
+def read(
+    database: str,
+    command: str,
+    columns: _Union[str, list] = None,
+    params: _Union[list, tuple, dict] = None,
+    **kwargs
+) -> _pd.DataFrame:
+    """
+    Read data from a DuckDB database.
+
+    >>> from wrangles.connectors import duckdb
+    >>> df = duckdb.read(database='database.duckdb', command='SELECT * FROM table')
+
+    :param database: The database to connect to including the file path. Use ':memory:' for an in-memory database.
+    :param command: SQL command to select data.
+    :param columns: (Optional) Subset of columns to be returned. This is less efficient than specifying in the SQL command.
+    :param params: (Optional) Variables to pass to a parameterized query.
+    """
+    _logging.info(f": Reading data from DuckDB :: {database}")
+
+    with _duckdb.connect(database=database, **kwargs) as conn:
+        df = conn.execute(command, params or ()).fetchdf()
+
+    if columns is not None:
+        columns = _wildcard_expansion(df.columns, columns)
+        df = df[columns]
+
+    return df
+
+
+_schema['read'] = r"""
+type: object
+description: Import data from a DuckDB Database
+required:
+  - database
+  - command
+properties:
+  database:
+    type: string
+    description: The database to connect to including the file path. Use ':memory:' for an in-memory database.
+  command:
+    type: string
+    description: |-
+      SQL command to select data.
+      Note - using variables here can make your recipe vulnerable
+      to sql injection. Use params if using variables from
+      untrusted sources.
+  columns:
+    type:
+      - string
+      - array
+    description: A list with a subset of the columns to import. This is less efficient than specifying in the command.
+  params:
+    type:
+      - array
+      - object
+    description: Variables to pass to a parameterized query.
+"""
+
+
+def write(
+    df: _pd.DataFrame,
+    database: str,
+    table: str,
+    action: str = 'INSERT',
+    columns: _Union[str, list] = None,
+    **kwargs
+) -> None:
+    """
+    Write data to a DuckDB database.
+
+    >>> from wrangles.connectors import duckdb
+    >>> duckdb.write(df, database='database.duckdb', table='table')
+
+    :param df: Pandas Dataframe to be written.
+    :param database: The database to connect to including the file path. Use ':memory:' for an in-memory database.
+    :param table: Table to be exported to.
+    :param action: INSERT appends, REPLACE recreates the table, FAIL errors if the table exists. Defaults to INSERT.
+    :param columns: (Optional) Subset of the columns to be written. If not provided, all columns will be output.
+    """
+    _logging.info(f": Writing data to DuckDB :: {database} / {table}")
+
+    action = action.upper()
+    if columns is not None:
+        columns = _wildcard_expansion(df.columns, columns)
+        df = df[columns]
+
+    table_name = _quote_identifier(table)
+    with _duckdb.connect(database=database, **kwargs) as conn:
+        conn.register('_wrangles_df', df)
+
+        if action == 'FAIL':
+            conn.execute(f'CREATE TABLE {table_name} AS SELECT * FROM _wrangles_df')
+        elif action == 'REPLACE':
+            conn.execute(f'CREATE OR REPLACE TABLE {table_name} AS SELECT * FROM _wrangles_df')
+        elif action == 'INSERT':
+            conn.execute(f'CREATE TABLE IF NOT EXISTS {table_name} AS SELECT * FROM _wrangles_df WHERE false')
+            conn.execute(f'INSERT INTO {table_name} SELECT * FROM _wrangles_df')
+        else:
+            raise ValueError('Invalid action. Expected INSERT, REPLACE, or FAIL.')
+
+
+_schema['write'] = """
+type: object
+description: Export data to a DuckDB Database
+required:
+  - database
+  - table
+properties:
+  database:
+    type: string
+    description: The database to connect to including the file path. Use ':memory:' for an in-memory database.
+  table:
+    type: string
+    description: The table to write to
+  action:
+    type: string
+    description: INSERT appends, REPLACE recreates the table, FAIL errors if the table exists. Defaults to INSERT.
+    enum:
+      - INSERT
+      - REPLACE
+      - FAIL
+  columns:
+    type:
+      - string
+      - array
+    description: A list of the columns to write to the table. If omitted, all columns will be written.
+"""
+
+
+def run(
+    database: str,
+    command: _Union[str, list],
+    params: _Union[list, tuple, dict] = None,
+    **kwargs
+) -> None:
+    """
+    Run a command on a DuckDB database.
+
+    >>> wrangles.connectors.duckdb.run(
+    >>>    database='database.duckdb',
+    >>>    command='<SQL COMMAND>'
+    >>> )
+
+    :param database: The database to connect to including the file path. Use ':memory:' for an in-memory database.
+    :param command: SQL command or a list of SQL commands to execute.
+    :param params: Variables to pass to a parameterized query.
+    """
+    _logging.info(f": Executing DuckDB Command :: {database}")
+
+    if isinstance(command, str):
+        command = [command]
+
+    with _duckdb.connect(database=database, **kwargs) as conn:
+        for sql in command:
+            conn.execute(sql, params or ())
+
+
+_schema['run'] = r"""
+type: object
+description: Run a command against a DuckDB Database
+required:
+  - database
+  - command
+properties:
+  database:
+    type: string
+    description: The database to connect to including the file path. Use ':memory:' for an in-memory database.
+  command:
+    type:
+      - string
+      - array
+    description: SQL command or a list of SQL commands to execute
+  params:
+    type:
+      - array
+      - object
+    description: Variables to pass to a parameterized query.
+"""

--- a/wrangles/recipe_wrangles/convert.py
+++ b/wrangles/recipe_wrangles/convert.py
@@ -351,43 +351,46 @@ def from_json(
         description: Name of the output column. If omitted, the input column will be overwritten
       default:
         type: ["string","array","object","number","boolean","null"]
-        description: Value to return if the row is empty or fails to be parsed as JSON
+        description: >-
+            Value to return if the row is empty or fails to be parsed as JSON.
+            If input is a list, default may also be a list of values (one per column).
     """
-    def _load_with_fallback(value):
-        """
-        Attempt to load JSON.
-        If fails and user has provided a default, return that.
-        If no default, raise an error.
-        """
-        try:
-            return _json.loads(value, **kwargs)
-        except:
-            if default != None:
-                return default
-            else:
-                raise ValueError(
-                    "Unable to load all rows as JSON. " +
-                    "Set a default to set a value if the row is empty or fails to parse."
-                )
-
     # Set output column as input if not provided
     if output is None: output = input
-    
+
     # Ensure input and outputs are lists
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
-    
+
     # Ensure input and output are equal lengths
     if len(input) != len(output):
         raise ValueError('The lists for input and output must be the same length.')
-        
+
+    # Normalize default to a per-column list
+    if isinstance(default, list) and len(default) == len(input):
+        defaults = default
+    else:
+        defaults = [default] * len(input)
+
     # Loop through and apply for all columns
-    for input_column, output_column in zip(input, output):
+    for input_column, output_column, col_default in zip(input, output, defaults):
+        def _load_with_fallback(value, _col_default=col_default):
+            try:
+                return _json.loads(value, **kwargs)
+            except:
+                if _col_default is not None:
+                    return _col_default
+                else:
+                    raise ValueError(
+                        "Unable to load all rows as JSON. " +
+                        "Set a default to set a value if the row is empty or fails to parse."
+                    )
+
         df[output_column] = [
             _load_with_fallback(x)
             for x in df[input_column]
         ]
-    
+
     return df
 
 
@@ -507,43 +510,46 @@ def from_yaml(
           If omitted, the input column will be overwritten
       default:
         type: ["string","array","object","number","boolean","null"]
-        description: Value to return if the row is empty or fails to be parsed as JSON
+        description: >-
+          Value to return if the row is empty or fails to be parsed as YAML.
+          If input is a list, default may also be a list of values (one per column).
     """
-    def _load_with_fallback(value):
-        """
-        Attempt to load JSON.
-        If fails and user has provided a default, return that.
-        If no default, raise an error.
-        """
-        try:
-            return _yaml.load(value, Loader=_YAMLLoader, **kwargs) or default
-        except:
-            if default != None:
-                return default
-            else:
-                raise ValueError(
-                    "Unable to load all rows as YAML. " +
-                    "Set a default to set a value if the row is empty or fails to parse."
-                )
-
     # Set output column as input if not provided
     if output is None: output = input
-    
+
     # Ensure input and outputs are lists
     if not isinstance(input, list): input = [input]
     if not isinstance(output, list): output = [output]
-    
+
     # Ensure input and output are equal lengths
     if len(input) != len(output):
         raise ValueError('The lists for input and output must be the same length.')
-        
+
+    # Normalize default to a per-column list
+    if isinstance(default, list) and len(default) == len(input):
+        defaults = default
+    else:
+        defaults = [default] * len(input)
+
     # Loop through and apply for all columns
-    for input_column, output_column in zip(input, output):
+    for input_column, output_column, col_default in zip(input, output, defaults):
+        def _load_with_fallback(value, _col_default=col_default):
+            try:
+                return _yaml.load(value, Loader=_YAMLLoader, **kwargs) or _col_default
+            except:
+                if _col_default is not None:
+                    return _col_default
+                else:
+                    raise ValueError(
+                        "Unable to load all rows as YAML. " +
+                        "Set a default to set a value if the row is empty or fails to parse."
+                    )
+
         df[output_column] = [
             _load_with_fallback(x)
             for x in df[input_column]
         ]
-    
+
     return df
 
 

--- a/wrangles/recipe_wrangles/convert.py
+++ b/wrangles/recipe_wrangles/convert.py
@@ -325,9 +325,30 @@ def fraction_to_decimal(
     return df
 
 
+def _normalize_default_list(default, input: list, func_name: str) -> list:
+    """
+    Normalize a default value/list into a per-column list of defaults.
+
+    A scalar (or a single-element list) is broadcast to all columns.
+    A list with the same length as input is used as-is, one default per column.
+    An empty list (`[]`) is treated as the default value itself, not a per-column list.
+    """
+    if isinstance(default, list) and len(default) > 0:
+        if len(default) == 1:
+            return [default[0]] * len(input)
+        elif len(default) != len(input):
+            raise ValueError(
+                f'The list of default values must be a single value or the same length as input/output for {func_name}'
+            )
+        else:
+            return default
+    else:
+        return [default] * len(input)
+
+
 def from_json(
-    df: _pd.DataFrame, 
-    input: _Union[str, int, list], 
+    df: _pd.DataFrame,
+    input: _Union[str, int, list],
     output: _Union[str, list] = None,
     default = None,
     **kwargs
@@ -353,7 +374,8 @@ def from_json(
         type: ["string","array","object","number","boolean","null"]
         description: >-
             Value to return if the row is empty or fails to be parsed as JSON.
-            If input is a list, default may also be a list of values (one per column).
+            If input is a list, default may also be a list - either a single
+            value to apply to all columns, or one value per input column.
     """
     # Set output column as input if not provided
     if output is None: output = input
@@ -366,18 +388,7 @@ def from_json(
     if len(input) != len(output):
         raise ValueError('The lists for input and output must be the same length.')
 
-    # Normalize default to a per-column list.
-    # Only treat default as a per-column list when it is a non-empty list
-    # (an empty list like `default: []` is always the default value itself).
-    if isinstance(default, list) and len(default) > 0:
-        if len(default) == 1:
-            defaults = [default[0]] * len(input)
-        elif len(default) != len(input):
-            raise ValueError('The list of default values must be the same length as input/output for convert.from_json')
-        else:
-            defaults = default
-    else:
-        defaults = [default] * len(input)
+    defaults = _normalize_default_list(default, input, 'convert.from_json')
 
     # Loop through and apply for all columns
     for input_column, output_column, col_default in zip(input, output, defaults):
@@ -519,7 +530,8 @@ def from_yaml(
         type: ["string","array","object","number","boolean","null"]
         description: >-
           Value to return if the row is empty or fails to be parsed as YAML.
-          If input is a list, default may also be a list of values (one per column).
+          If input is a list, default may also be a list - either a single
+          value to apply to all columns, or one value per input column.
     """
     # Set output column as input if not provided
     if output is None: output = input
@@ -532,18 +544,7 @@ def from_yaml(
     if len(input) != len(output):
         raise ValueError('The lists for input and output must be the same length.')
 
-    # Normalize default to a per-column list.
-    # Only treat default as a per-column list when it is a non-empty list
-    # (an empty list like `default: []` is always the default value itself).
-    if isinstance(default, list) and len(default) > 0:
-        if len(default) == 1:
-            defaults = [default[0]] * len(input)
-        elif len(default) != len(input):
-            raise ValueError('The list of default values must be the same length as input/output for convert.from_yaml')
-        else:
-            defaults = default
-    else:
-        defaults = [default] * len(input)
+    defaults = _normalize_default_list(default, input, 'convert.from_yaml')
 
     # Loop through and apply for all columns
     for input_column, output_column, col_default in zip(input, output, defaults):

--- a/wrangles/recipe_wrangles/convert.py
+++ b/wrangles/recipe_wrangles/convert.py
@@ -366,9 +366,16 @@ def from_json(
     if len(input) != len(output):
         raise ValueError('The lists for input and output must be the same length.')
 
-    # Normalize default to a per-column list
-    if isinstance(default, list) and len(default) == len(input):
-        defaults = default
+    # Normalize default to a per-column list.
+    # Only treat default as a per-column list when it is a non-empty list
+    # (an empty list like `default: []` is always the default value itself).
+    if isinstance(default, list) and len(default) > 0:
+        if len(default) == 1:
+            defaults = [default[0]] * len(input)
+        elif len(default) != len(input):
+            raise ValueError('The list of default values must be the same length as input/output for convert.from_json')
+        else:
+            defaults = default
     else:
         defaults = [default] * len(input)
 
@@ -525,9 +532,16 @@ def from_yaml(
     if len(input) != len(output):
         raise ValueError('The lists for input and output must be the same length.')
 
-    # Normalize default to a per-column list
-    if isinstance(default, list) and len(default) == len(input):
-        defaults = default
+    # Normalize default to a per-column list.
+    # Only treat default as a per-column list when it is a non-empty list
+    # (an empty list like `default: []` is always the default value itself).
+    if isinstance(default, list) and len(default) > 0:
+        if len(default) == 1:
+            defaults = [default[0]] * len(input)
+        elif len(default) != len(input):
+            raise ValueError('The list of default values must be the same length as input/output for convert.from_yaml')
+        else:
+            defaults = default
     else:
         defaults = [default] * len(input)
 

--- a/wrangles/recipe_wrangles/convert.py
+++ b/wrangles/recipe_wrangles/convert.py
@@ -550,7 +550,11 @@ def from_yaml(
     for input_column, output_column, col_default in zip(input, output, defaults):
         def _load_with_fallback(value, _col_default=col_default):
             try:
-                return _yaml.load(value, Loader=_YAMLLoader, **kwargs) or _col_default
+                result = _yaml.load(value, Loader=_YAMLLoader, **kwargs)
+                # Only fall back to the default if the row was empty (parses to None).
+                # A falsy-but-valid result (e.g. [], {}, '', False, 0) must be preserved
+                # as-is rather than being overwritten by the default.
+                return _col_default if result is None else result
             except:
                 if _col_default is not None:
                     return _col_default


### PR DESCRIPTION
Check CI on dev after widening the `test_multiprocess` timing tolerance to fix Windows CI flakiness (process-spawn overhead was pushing wall-clock time past the old 10s upper bound).