### PR TITLE
Allow rename to skip missing inputs when output exists

### DIFF
--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -2465,6 +2465,67 @@ class TestRename:
         # Should rename Col1 to COL1
         assert 'COL1' in df.columns
 
+    def test_rename_missing_input_skips_when_output_exists_dict(self):
+        """
+        Missing input should not error when the target output column already exists.
+        """
+        data = pd.DataFrame({
+            'Description': ['already normalized'],
+            'Part Number': ['PN-1'],
+        })
+        recipe = """
+        wrangles:
+            - rename:
+                desc: Description
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+
+        assert df.columns.tolist() == ['Description', 'Part Number']
+        assert df.iloc[0]['Description'] == 'already normalized'
+
+    def test_rename_multiple_possible_inputs_to_existing_output(self):
+        """
+        Alternate input names can map to one output, or skip if output already exists.
+        """
+        recipe = """
+        wrangles:
+            - rename:
+                input:
+                    - [input desc, desc]
+                output:
+                    - Description
+        """
+
+        input_desc_df = wrangles.recipe.run(
+            recipe,
+            dataframe=pd.DataFrame({
+                'input desc': ['from input desc'],
+                'Part Number': ['PN-1'],
+            })
+        )
+        assert input_desc_df.columns.tolist() == ['Description', 'Part Number']
+        assert input_desc_df.iloc[0]['Description'] == 'from input desc'
+
+        desc_df = wrangles.recipe.run(
+            recipe,
+            dataframe=pd.DataFrame({
+                'desc': ['from desc'],
+                'Part Number': ['PN-2'],
+            })
+        )
+        assert desc_df.columns.tolist() == ['Description', 'Part Number']
+        assert desc_df.iloc[0]['Description'] == 'from desc'
+
+        existing_output_df = wrangles.recipe.run(
+            recipe,
+            dataframe=pd.DataFrame({
+                'Description': ['already normalized'],
+                'Part Number': ['PN-3'],
+            })
+        )
+        assert existing_output_df.columns.tolist() == ['Description', 'Part Number']
+        assert existing_output_df.iloc[0]['Description'] == 'already normalized'
+
 class TestSimilarity:
     """
     Test similarity

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -1629,6 +1629,39 @@ def rename(
         ):
             del kwargs["functions"]
 
+    def output_exists(output_column):
+        return output_column in list(df.columns)
+
+    def resolve_rename_input(input_column, output_column):
+        candidates = input_column if isinstance(input_column, list) else [input_column]
+        optional_candidates = []
+        required_candidates = []
+
+        for candidate in candidates:
+            optional = False
+            actual_col = candidate
+            if isinstance(candidate, str) and candidate.endswith("?"):
+                optional = True
+                actual_col = candidate[:-1]
+
+            if actual_col in list(df.columns):
+                return actual_col
+
+            if optional:
+                optional_candidates.append(actual_col)
+                continue
+
+            required_candidates.append(actual_col)
+
+        if optional_candidates and not required_candidates:
+            return None
+
+        if output_exists(output_column):
+            return None
+
+        missing = required_candidates[0] if required_candidates else candidates[0]
+        raise ValueError(f'Rename column "{missing}" not found.')
+
 
     # If short form of paired names is provided, use that
     if input is None:
@@ -1686,7 +1719,7 @@ def rename(
 
         # Regular non-wildcard name
         if name not in cols:
-          if optional:
+          if optional or kwargs[x] in cols:
             continue
           else:
             raise ValueError(f'Rename column "{name}" not found.')
@@ -1712,19 +1745,12 @@ def rename(
             raise ValueError('The lists for input and output must be the same length.')
           
         for inp, out in zip(input, output):
-            if inp.endswith("?"):
-                actual_col = inp[:-1]
-                if actual_col not in list(df.columns):
-                    # Skip this column if it doesn't exist
-                    continue  # This skips both input and output
-                else:
-                    filtered_input.append(actual_col)
-                    filtered_output.append(out)
-            elif inp not in list(df.columns):
-                raise ValueError(f'Rename column "{inp}" not found.')
-            else:
-                filtered_input.append(inp)
-                filtered_output.append(out)
+            actual_col = resolve_rename_input(inp, out)
+            if actual_col is None:
+                continue
+
+            filtered_input.append(actual_col)
+            filtered_output.append(out)
           
         # Check that the output columns don't already exist if so drop them
         df = df.drop(columns=[x for x in filtered_output if x in df.columns and x not in filtered_input])


### PR DESCRIPTION
## Summary
- Allow `rename` wrangle to skip missing input columns without erroring when the output already exists

## Test plan
- [x] Existing and new unit tests in `tests/recipes/wrangles/test_main.py` cover this behavior