### PR TITLE
allow rename to skip missing inputs when output exists

### DIFF
--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -2424,6 +2424,67 @@ class TestRename:
         # Should rename Col1 to COL1
         assert 'COL1' in df.columns
 
+    def test_rename_missing_input_skips_when_output_exists_dict(self):
+        """
+        Missing input should not error when the target output column already exists.
+        """
+        data = pd.DataFrame({
+            'Description': ['already normalized'],
+            'Part Number': ['PN-1'],
+        })
+        recipe = """
+        wrangles:
+            - rename:
+                desc: Description
+        """
+        df = wrangles.recipe.run(recipe, dataframe=data)
+
+        assert df.columns.tolist() == ['Description', 'Part Number']
+        assert df.iloc[0]['Description'] == 'already normalized'
+
+    def test_rename_multiple_possible_inputs_to_existing_output(self):
+        """
+        Alternate input names can map to one output, or skip if output already exists.
+        """
+        recipe = """
+        wrangles:
+            - rename:
+                input:
+                    - [input desc, desc]
+                output:
+                    - Description
+        """
+
+        input_desc_df = wrangles.recipe.run(
+            recipe,
+            dataframe=pd.DataFrame({
+                'input desc': ['from input desc'],
+                'Part Number': ['PN-1'],
+            })
+        )
+        assert input_desc_df.columns.tolist() == ['Description', 'Part Number']
+        assert input_desc_df.iloc[0]['Description'] == 'from input desc'
+
+        desc_df = wrangles.recipe.run(
+            recipe,
+            dataframe=pd.DataFrame({
+                'desc': ['from desc'],
+                'Part Number': ['PN-2'],
+            })
+        )
+        assert desc_df.columns.tolist() == ['Description', 'Part Number']
+        assert desc_df.iloc[0]['Description'] == 'from desc'
+
+        existing_output_df = wrangles.recipe.run(
+            recipe,
+            dataframe=pd.DataFrame({
+                'Description': ['already normalized'],
+                'Part Number': ['PN-3'],
+            })
+        )
+        assert existing_output_df.columns.tolist() == ['Description', 'Part Number']
+        assert existing_output_df.iloc[0]['Description'] == 'already normalized'
+
 class TestSimilarity:
     """
     Test similarity

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -1641,7 +1641,7 @@ def rename(
             del kwargs["functions"]
 
     def output_exists(output_column):
-        return output_column in list(df.columns)
+        return output_column in df.columns
 
     def resolve_rename_input(input_column, output_column):
         candidates = input_column if isinstance(input_column, list) else [input_column]
@@ -1655,7 +1655,7 @@ def rename(
                 optional = True
                 actual_col = candidate[:-1]
 
-            if actual_col in list(df.columns):
+            if actual_col in df.columns:
                 return actual_col
 
             if optional:

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -1640,6 +1640,39 @@ def rename(
         ):
             del kwargs["functions"]
 
+    def output_exists(output_column):
+        return output_column in list(df.columns)
+
+    def resolve_rename_input(input_column, output_column):
+        candidates = input_column if isinstance(input_column, list) else [input_column]
+        optional_candidates = []
+        required_candidates = []
+
+        for candidate in candidates:
+            optional = False
+            actual_col = candidate
+            if isinstance(candidate, str) and candidate.endswith("?"):
+                optional = True
+                actual_col = candidate[:-1]
+
+            if actual_col in list(df.columns):
+                return actual_col
+
+            if optional:
+                optional_candidates.append(actual_col)
+                continue
+
+            required_candidates.append(actual_col)
+
+        if optional_candidates and not required_candidates:
+            return None
+
+        if output_exists(output_column):
+            return None
+
+        missing = required_candidates[0] if required_candidates else candidates[0]
+        raise ValueError(f'Rename column "{missing}" not found.')
+
 
     # If short form of paired names is provided, use that
     if input is None:
@@ -1697,7 +1730,7 @@ def rename(
 
         # Regular non-wildcard name
         if name not in cols:
-          if optional:
+          if optional or kwargs[x] in cols:
             continue
           else:
             raise ValueError(f'Rename column "{name}" not found.')
@@ -1723,19 +1756,12 @@ def rename(
             raise ValueError('The lists for input and output must be the same length.')
           
         for inp, out in zip(input, output):
-            if inp.endswith("?"):
-                actual_col = inp[:-1]
-                if actual_col not in list(df.columns):
-                    # Skip this column if it doesn't exist
-                    continue  # This skips both input and output
-                else:
-                    filtered_input.append(actual_col)
-                    filtered_output.append(out)
-            elif inp not in list(df.columns):
-                raise ValueError(f'Rename column "{inp}" not found.')
-            else:
-                filtered_input.append(inp)
-                filtered_output.append(out)
+            actual_col = resolve_rename_input(inp, out)
+            if actual_col is None:
+                continue
+
+            filtered_input.append(actual_col)
+            filtered_output.append(out)
           
         # Check that the output columns don't already exist if so drop them
         df = df.drop(columns=[x for x in filtered_output if x in df.columns and x not in filtered_input])


### PR DESCRIPTION
## Summary

Updates `rename` so recipes can safely handle inputs with different source column names.

If a requested input column is missing, `rename` now checks whether the target output column already exists. If it does, the rename is skipped instead of raising an error.

## Problem

Recipes may receive data from different sources where the same value has different column names.

For example, one source may already provide:

```text
Description
```

while another source may provide:

```text
desc
```

Previously, this could fail when a recipe tried to normalize one source name but the data was already normalized.

## Changes

- Added rename input resolution helpers in `wrangles/recipe_wrangles/main.py`.
- Updated dictionary-style rename so `missing: existing` is allowed when `existing` is already present.
- Updated `input` / `output` rename syntax to support multiple possible input columns for one output.
- Preserved existing optional input behavior with `?`.
- Preserved existing errors when required inputs are missing and the target output does not already exist.
- Added regression coverage for already-normalized output columns.
- Added regression coverage for multiple possible input columns mapping to the same output.

## Rename Behavior

Missing source column with existing output:

```yaml
wrangles:
  - rename:
      desc: Description
```

If `desc` is missing but `Description` already exists, the wrangle now carries on without error.

Multiple possible input columns:

```yaml
wrangles:
  - rename:
      input:
        - [input desc, desc]
      output:
        - Description
```

This maps the first existing source column to `Description`.

If neither source column exists but `Description` already exists, it is treated as already normalized and no error is raised.

## Usage Example

Source A:

```python
pd.DataFrame({
    "input desc": ["from input desc"],
    "Part Number": ["PN-1"],
})
```

Source B:

```python
pd.DataFrame({
    "desc": ["from desc"],
    "Part Number": ["PN-2"],
})
```

Source C:

```python
pd.DataFrame({
    "Description": ["already normalized"],
    "Part Number": ["PN-3"],
})
```

All three can use the same recipe:

```yaml
wrangles:
  - rename:
      input:
        - [input desc, desc]
      output:
        - Description
```

## Documentation And Demo

Added supporting material:

- `issue_1046_rename_no_error_if_exists_demo.ipynb`

## Validation

Focused rename tests pass:

```powershell
$env:PYTHONPATH='.'; pytest tests\recipes\wrangles\test_main.py::TestRename -q
```

Result:

```text
44 passed
```