### PR TITLE
delete model after creating

### DIFF
--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -1,7 +1,5 @@
 import uuid
 
-from pytest_mock import mocker
-
 import wrangles
 import pandas as pd
 import pytest
@@ -16,6 +14,21 @@ class LogCapture(logging.Handler):
         self.records.append(record)
     def get_messages(self):
         return [self.format(r) for r in self.records]
+
+def _delete_model_from_log(caplog, log_marker):
+    """
+    Find a model id logged as "<log_marker> :: <id>" and delete it, so tests
+    that create a real model clean up after themselves. Tolerates failure
+    while the real delete endpoint is unavailable.
+    """
+    for record in caplog.records:
+        if record.levelname == "INFO" and log_marker in record.message:
+            model_id = record.message.split("::")[-1].strip()
+            try:
+                wrangles.train.delete(model_id)
+            except RuntimeError:
+                pass
+            return
 
 #
 # Classify
@@ -130,23 +143,26 @@ def test_classify_read_four_cols_error(mocker):
             """
         )
 
-def test_classify_write_logs_new_model_id_integration(caplog):  
-    df = pd.DataFrame({  
-        'Example': ['apple', 'banana'],  
-        'Category': ['fruit', 'fruit'],  
-        'Notes': ['', '']  
-    })  
-  
-    wrangles.recipe.run(  
-        """  
-        write:  
-          - train.classify:  
-              name: Test Classify Model  
-        """,  
-        dataframe=df  
-    )  
-  
-    assert any(record.message for record in caplog.records if record.levelname == "INFO" and "New classify model created" in record.message)
+def test_classify_write_logs_new_model_id_integration(caplog):
+    df = pd.DataFrame({
+        'Example': ['apple', 'banana'],
+        'Category': ['fruit', 'fruit'],
+        'Notes': ['', '']
+    })
+
+    try:
+        wrangles.recipe.run(
+            """
+            write:
+              - train.classify:
+                  name: Test Classify Model
+            """,
+            dataframe=df
+        )
+
+        assert any(record.message for record in caplog.records if record.levelname == "INFO" and "New classify model created" in record.message)
+    finally:
+        _delete_model_from_log(caplog, "New classify model created")
 
 class TestTrainExtract:
     """
@@ -739,7 +755,6 @@ class TestTrainLookup:
             'Value': ['Updated Rachel', 'New Movie']  
         })  
         model_name = f"model {{ {uuid.uuid4().hex[:8]} }}"
-        
         recipe = f"""  
         write:  
         - train.lookup:  
@@ -747,13 +762,23 @@ class TestTrainLookup:
             action: UPSERT  
             variant: key  
         """  
-        
-        result = wrangles.recipe.run(recipe, dataframe=df)  
-        assert len(result) == 2  
-        assert 'NewCharacter' in result['Key'].tolist()  
-        assert result['Value'].tolist() == ['Updated Rachel', 'New Movie']
-        models = wrangles.data.user.models('lookup')
-        assert any(m['name'] == model_name for m in models)
+
+        model_id = None  
+        try:
+            result = wrangles.recipe.run(recipe, dataframe=df)
+            assert len(result) == 2
+            assert 'NewCharacter' in result['Key'].tolist()
+            assert result['Value'].tolist() == ['Updated Rachel', 'New Movie']
+            models = wrangles.data.user.models('lookup')
+            match = next((m for m in models if m['name'] == model_name), None)
+            assert match is not None
+            model_id = match['id']
+        finally:
+            if model_id:
+                try:
+                    wrangles.train.delete(model_id)
+                except RuntimeError:
+                    pass
   
     def test_action_parameter_upsert(self):  
         """  
@@ -1396,22 +1421,25 @@ def test_lookup_write_logs_new_model_id(caplog):
         'Key': ['apple', 'banana'],  
         'Value': ['fruit', 'fruit']  
     })  
-  
-    wrangles.recipe.run(  
-        """  
-        write:  
-          - train.lookup:  
-              name: Test Lookup Model Integration  
-              variant: key  
-        """,  
-        dataframe=df  
-    )  
-  
-    # Check that model_id was logged  
-    assert any(  
-        record.message for record in caplog.records   
-        if record.levelname == "INFO" and "New lookup model created" in record.message  
-    )
+
+    try:
+        wrangles.recipe.run(  
+            """    
+            write:  
+              - train.lookup:  
+                  name: Test Lookup Model Integration  
+                  variant: key  
+            """,  
+            dataframe=df  
+        )  
+
+        # Check that model_id was logged  
+        assert any(  
+            record.message for record in caplog.records   
+            if record.levelname == "INFO" and "New lookup model created" in record.message  
+        )
+    finally:
+        _delete_model_from_log(caplog, "New lookup model created")
 
 
 #
@@ -1504,21 +1532,24 @@ def test_standardize_write_logs_new_model_id(caplog):
         'Replace': ['As Soon As Possible', 'Estimated Time of Arrival'],  
         'Notes': ['', '']  
     })  
-  
-    wrangles.recipe.run(  
-        """  
-        write:  
-          - train.standardize:  
-              name: Test Standardize Model Integration  
-        """,  
-        dataframe=df  
-    )  
-  
-    # Check that model creation was logged  
-    assert any(  
-        record.message for record in caplog.records   
-        if record.levelname == "INFO" and "Creating new standardize model" in record.message  
-    )
+
+    try:
+        wrangles.recipe.run(  
+            """  
+            write:  
+              - train.standardize:  
+                  name: Test Standardize Model Integration  
+            """,  
+            dataframe=df  
+        )  
+
+        # Check that model creation was logged  
+        assert any(  
+            record.message for record in caplog.records   
+            if record.levelname == "INFO" and "Creating new standardize model" in record.message  
+        )
+    finally:
+        _delete_model_from_log(caplog, "New standardize model created")
 
 
 class TestTrainMetaData:
@@ -1671,3 +1702,120 @@ class TestTrainMetaData:
                 """,
                 dataframe=pd.DataFrame([{"settings": "not-a-dict"}])
             )
+
+
+#
+# Delete
+#
+class TestTrainDelete:
+    """
+    Tests for wrangles.train.delete
+    """
+
+    def _get_model_id(self, response):
+        body = response.json()
+        model_id = body.get('model_id') or body.get('id') or body.get('modelId') or body.get('model')
+        assert model_id, f"No model_id in creation response: {body}"
+        return model_id
+
+    def _mock_delete_ok(self, mocker):
+        mock = mocker.patch('wrangles.train._requests.delete')
+        mock.return_value.ok = True
+        mock.return_value.status_code = 200
+        return mock
+
+    def test_create_and_delete_classify(self, mocker):
+        """
+        Train a new classify model (real API) then delete it (mocked).
+        Verifies creation succeeds and delete is called with the correct model_id.
+        """
+        training_data = [
+            ['apple', 'fruit', ''],
+            ['banana', 'fruit', ''],
+            ['carrot', 'vegetable', ''],
+        ]
+        response = wrangles.train.classify(training_data, name="Test Delete Classify Model")
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        model_id = self._get_model_id(response)
+        mock_delete = self._mock_delete_ok(mocker)
+
+        wrangles.train.delete(model_id)
+
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
+
+    def test_create_and_delete_extract(self, mocker):
+        """
+        Train a new extract model (real API) then delete it (mocked).
+        Verifies creation succeeds and delete is called with the correct model_id.
+        """
+        training_data = [
+            ['Television', 'TV', ''],
+            ['Refrigerator', 'Fridge', ''],
+            ['Automobile', 'Car', ''],
+        ]
+        response = wrangles.train.extract(training_data, name="Test Delete Extract Model")
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        model_id = self._get_model_id(response)
+        mock_delete = self._mock_delete_ok(mocker)
+
+        wrangles.train.delete(model_id)
+
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
+
+    def test_create_and_delete_lookup(self, mocker):
+        """
+        Train a new lookup model (real API) then delete it (mocked).
+        Verifies creation succeeds and delete is called with the correct model_id.
+        """
+        data = [
+            ['Key', 'Value'],
+            ['apple', 'fruit'],
+            ['carrot', 'vegetable'],
+        ]
+        response = wrangles.train.lookup(data, name="Test Delete Lookup Model", settings={'variant': 'key'})
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        model_id = self._get_model_id(response)
+        mock_delete = self._mock_delete_ok(mocker)
+
+        wrangles.train.delete(model_id)
+
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
+
+    def test_create_and_delete_standardize(self, mocker):
+        """
+        Train a new standardize model (real API) then delete it (mocked).
+        Verifies creation succeeds and delete is called with the correct model_id.
+        """
+        training_data = [
+            ['ASAP', 'As Soon As Possible', ''],
+            ['ETA', 'Estimated Time of Arrival', ''],
+            ['USA', 'United States of America', ''],
+        ]
+        response = wrangles.train.standardize(training_data, name="Test Delete Standardize Model")
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        model_id = self._get_model_id(response)
+        mock_delete = self._mock_delete_ok(mocker)
+
+        wrangles.train.delete(model_id)
+
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
+
+    def test_delete_error_raises_runtime_error(self, mocker):
+        """
+        A non-OK response from the delete endpoint raises RuntimeError.
+        """
+        mock = mocker.patch('wrangles.train._requests.delete')
+        mock.return_value.ok = False
+        mock.return_value.status_code = 404
+        mock.return_value.text = '{"message":"Not Found"}'
+
+        with pytest.raises(RuntimeError, match="Delete model failed"):
+            wrangles.train.delete("00000000-0000-0000")

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -1,4 +1,6 @@
 import uuid
+from importlib import import_module
+from unittest.mock import Mock
 
 import wrangles
 import pandas as pd
@@ -25,7 +27,7 @@ def _delete_model_from_log(caplog, log_marker):
         if record.levelname == "INFO" and log_marker in record.message:
             model_id = record.message.split("::")[-1].strip()
             try:
-                wrangles.train.delete(model_id)
+                wrangles.train.delete(model_id, confirm='delete')
             except RuntimeError:
                 pass
             return
@@ -776,7 +778,7 @@ class TestTrainLookup:
         finally:
             if model_id:
                 try:
-                    wrangles.train.delete(model_id)
+                    wrangles.train.delete(model_id, confirm='delete')
                 except RuntimeError:
                     pass
   
@@ -1718,13 +1720,15 @@ class TestTrainDelete:
         assert model_id, f"No model_id in creation response: {body}"
         return model_id
 
-    def _mock_delete_ok(self, mocker):
-        mock = mocker.patch('wrangles.train._requests.delete')
+    def _mock_delete_ok(self, monkeypatch):
+        mock = Mock()
         mock.return_value.ok = True
         mock.return_value.status_code = 200
+        monkeypatch.setattr(import_module("wrangles.auth"), "get_access_token", lambda: "token")
+        monkeypatch.setattr(import_module("wrangles.train")._requests, "delete", mock)
         return mock
 
-    def test_create_and_delete_classify(self, mocker):
+    def test_create_and_delete_classify(self, monkeypatch):
         """
         Train a new classify model (real API) then delete it (mocked).
         Verifies creation succeeds and delete is called with the correct model_id.
@@ -1738,14 +1742,14 @@ class TestTrainDelete:
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
         model_id = self._get_model_id(response)
-        mock_delete = self._mock_delete_ok(mocker)
+        mock_delete = self._mock_delete_ok(monkeypatch)
 
-        wrangles.train.delete(model_id)
+        wrangles.train.delete(model_id, confirm='delete')
 
         mock_delete.assert_called_once()
         assert model_id in str(mock_delete.call_args)
 
-    def test_create_and_delete_extract(self, mocker):
+    def test_create_and_delete_extract(self, monkeypatch):
         """
         Train a new extract model (real API) then delete it (mocked).
         Verifies creation succeeds and delete is called with the correct model_id.
@@ -1759,14 +1763,14 @@ class TestTrainDelete:
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
         model_id = self._get_model_id(response)
-        mock_delete = self._mock_delete_ok(mocker)
+        mock_delete = self._mock_delete_ok(monkeypatch)
 
-        wrangles.train.delete(model_id)
+        wrangles.train.delete(model_id, confirm='delete')
 
         mock_delete.assert_called_once()
         assert model_id in str(mock_delete.call_args)
 
-    def test_create_and_delete_lookup(self, mocker):
+    def test_create_and_delete_lookup(self, monkeypatch):
         """
         Train a new lookup model (real API) then delete it (mocked).
         Verifies creation succeeds and delete is called with the correct model_id.
@@ -1780,14 +1784,14 @@ class TestTrainDelete:
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
         model_id = self._get_model_id(response)
-        mock_delete = self._mock_delete_ok(mocker)
+        mock_delete = self._mock_delete_ok(monkeypatch)
 
-        wrangles.train.delete(model_id)
+        wrangles.train.delete(model_id, confirm='delete')
 
         mock_delete.assert_called_once()
         assert model_id in str(mock_delete.call_args)
 
-    def test_create_and_delete_standardize(self, mocker):
+    def test_create_and_delete_standardize(self, monkeypatch):
         """
         Train a new standardize model (real API) then delete it (mocked).
         Verifies creation succeeds and delete is called with the correct model_id.
@@ -1801,21 +1805,163 @@ class TestTrainDelete:
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
         model_id = self._get_model_id(response)
-        mock_delete = self._mock_delete_ok(mocker)
+        mock_delete = self._mock_delete_ok(monkeypatch)
 
-        wrangles.train.delete(model_id)
+        wrangles.train.delete(model_id, confirm='delete')
 
         mock_delete.assert_called_once()
         assert model_id in str(mock_delete.call_args)
 
-    def test_delete_error_raises_runtime_error(self, mocker):
+    def test_delete_error_raises_runtime_error(self, monkeypatch):
         """
         A non-OK response from the delete endpoint raises RuntimeError.
         """
-        mock = mocker.patch('wrangles.train._requests.delete')
+        mock = Mock()
         mock.return_value.ok = False
         mock.return_value.status_code = 404
         mock.return_value.text = '{"message":"Not Found"}'
+        monkeypatch.setattr(import_module("wrangles.auth"), "get_access_token", lambda: "token")
+        monkeypatch.setattr(import_module("wrangles.train")._requests, "delete", mock)
 
         with pytest.raises(RuntimeError, match="Delete model failed"):
+            wrangles.train.delete("00000000-0000-0000", confirm='delete')
+
+    def test_delete_without_confirm_raises_value_error(self, monkeypatch):
+        """
+        Calling delete without confirm='delete' raises before the API is called.
+        """
+        mock_delete = self._mock_delete_ok(monkeypatch)
+
+        with pytest.raises(ValueError, match="confirm='delete'"):
             wrangles.train.delete("00000000-0000-0000")
+
+        mock_delete.assert_not_called()
+
+    def test_delete_with_wrong_confirm_value_raises_value_error(self, monkeypatch):
+        """
+        Calling delete with any confirm value except 'delete' raises before the API is called.
+        """
+        mock_delete = self._mock_delete_ok(monkeypatch)
+
+        with pytest.raises(ValueError, match="confirm='delete'"):
+            wrangles.train.delete("00000000-0000-0000", confirm='yes')
+
+        mock_delete.assert_not_called()
+
+    def test_delete_as_recipe_wrangle_section(self, monkeypatch):
+        """
+        train.delete can be used as a side-effect wrangle in the wrangles section.
+        """
+        model_id = "93d92b4c-9f49-4ff5"
+        mock_delete = self._mock_delete_ok(monkeypatch)
+
+        df = wrangles.recipe.run(
+            f"""
+            read:
+              - test:
+                  rows: 1
+                  values:
+                    value: keep
+            wrangles:
+              - train.delete:
+                  model_id: {model_id}
+                  confirm: delete
+            """
+        )
+
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
+        assert df["value"].iloc[0] == "keep"
+
+    def test_delete_as_recipe_wrangle_section_requires_confirm(self, monkeypatch):
+        """
+        train.delete in a recipe wrangles section still requires confirm='delete'.
+        """
+        mock_delete = self._mock_delete_ok(monkeypatch)
+
+        with pytest.raises(ValueError, match="confirm='delete'"):
+            wrangles.recipe.run(
+                """
+                read:
+                  - test:
+                      rows: 1
+                      values:
+                        value: keep
+                wrangles:
+                  - train.delete:
+                      model_id: 93d92b4c-9f49-4ff5
+                """
+            )
+
+        mock_delete.assert_not_called()
+
+    def test_delete_as_recipe_wrangle_section_rejects_wrong_confirm(self, monkeypatch):
+        """
+        train.delete in a recipe wrangles section rejects confirm values other than 'delete'.
+        """
+        mock_delete = self._mock_delete_ok(monkeypatch)
+
+        with pytest.raises(ValueError, match="confirm='delete'"):
+            wrangles.recipe.run(
+                """
+                read:
+                  - test:
+                      rows: 1
+                      values:
+                        value: keep
+                wrangles:
+                  - train.delete:
+                      model_id: 93d92b4c-9f49-4ff5
+                      confirm: yes
+                """
+            )
+
+        mock_delete.assert_not_called()
+
+    def test_delete_as_recipe_write(self, monkeypatch):
+        """
+        train.delete can be used as a side-effect connector in the write section.
+        """
+        model_id = "93d92b4c-9f49-4ff5"
+        mock_delete = self._mock_delete_ok(monkeypatch)
+
+        df = wrangles.recipe.run(
+            f"""
+            read:
+              - test:
+                  rows: 1
+                  values:
+                    value: keep
+            write:
+              - train.delete:
+                  model_id: {model_id}
+                  confirm: delete
+            """
+        )
+
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
+        assert df["value"].iloc[0] == "keep"
+
+    def test_delete_as_recipe_write_without_confirm_raises(self, monkeypatch):
+        """
+        train.delete in a recipe write section still requires confirm='delete'.
+        """
+        mock_delete = self._mock_delete_ok(monkeypatch)
+
+        with pytest.raises(ValueError, match="confirm='delete'"):
+            wrangles.recipe.run(
+                """
+                read:
+                  - test:
+                      rows: 1
+                      values:
+                        value: keep
+                write:
+                  - train.delete:
+                      model_id: 93d92b4c-9f49-4ff5
+                """
+            )
+
+        mock_delete.assert_not_called()
+

--- a/wrangles/connectors/train.py
+++ b/wrangles/connectors/train.py
@@ -638,6 +638,39 @@ class lookup():
         """
 
 
+class delete():
+    _schema = {}
+
+    def write(df: _pd.DataFrame, model_id: str, confirm: str = None) -> None:
+        """
+        Delete a trained model.
+
+        :param df: DataFrame passed through by recipe execution.
+        :param model_id: The ID of the model to delete.
+        :param confirm: Must be set to 'delete' to confirm this destructive action.
+        """
+        _logging.info(f": Deleting Train Wrangle model :: {model_id}")
+        _train.delete(model_id, confirm=confirm)
+
+    _schema["write"] = """
+        type: object
+        description: Delete a trained model
+        additionalProperties: false
+        required:
+          - model_id
+          - confirm
+        properties:
+          model_id:
+            type: string
+            description: The ID of the model to delete
+          confirm:
+            type: string
+            description: Must be set to 'delete' to confirm this destructive action
+            enum:
+              - delete
+        """
+
+
 class meta_data():
     _schema = {}
 

--- a/wrangles/recipe_wrangles/__init__.py
+++ b/wrangles/recipe_wrangles/__init__.py
@@ -28,3 +28,28 @@ from . import compare
 from . import generate
 from . import compute
 from . import search
+
+
+class train():
+    def delete(df, model_id: str, confirm: str = None):
+        """
+        type: object
+        description: Delete a trained model.
+        additionalProperties: false
+        required:
+          - model_id
+          - confirm
+        properties:
+          model_id:
+            type: string
+            description: The ID of the model to delete.
+          confirm:
+            type: string
+            description: Must be set to 'delete' to confirm this destructive action.
+            enum:
+              - delete
+        """
+        from ..train import train as _train
+
+        _train.delete(model_id, confirm=confirm)
+        return df

--- a/wrangles/train.py
+++ b/wrangles/train.py
@@ -258,7 +258,24 @@ class train():
 
         if not response.ok:
             raise RuntimeError(f"Training Lookup Failed. {response.status_code} : {response.text}")
-        
+
+        return response
+
+    def delete(model_id: str):
+        """
+        Delete a trained model by its model ID.
+        Requires WrangleWorks Account and Subscription.
+
+        :param model_id: The ID of the model to delete.
+        """
+        _logging.info(f": Deleting model :: {model_id}")
+        response = _requests.delete(
+            f'{_config.api_host}/model/delete',
+            params={'model_id': model_id},
+            headers={'Authorization': f'Bearer {_auth.get_access_token()}'}
+        )
+        if not response.ok:
+            raise RuntimeError(f"Delete model failed. {response.status_code} : {response.text}")
         return response
 
     def standardize(training_data: list, name: str = None, model_id: str = None):

--- a/wrangles/train.py
+++ b/wrangles/train.py
@@ -261,13 +261,20 @@ class train():
 
         return response
 
-    def delete(model_id: str):
+    def delete(model_id: str, confirm: str = None):
         """
         Delete a trained model by its model ID.
         Requires WrangleWorks Account and Subscription.
 
         :param model_id: The ID of the model to delete.
+        :param confirm: Must be set to 'delete' to confirm this destructive action.
         """
+        if confirm != 'delete':
+            raise ValueError(
+                "Deleting a model is destructive. "
+                "To confirm, pass confirm='delete'."
+            )
+
         _logging.info(f": Deleting model :: {model_id}")
         response = _requests.delete(
             f'{_config.api_host}/model/delete',


### PR DESCRIPTION
  ## Summary

  Integration tests for `train.classify`, `train.extract`, `train.lookup`, and `train.standardize` create real models on the WrangleWorks platform but never clean them up, leaving a growing number of orphaned test models in the account. This adds a `wrangles.train.delete()` method and updates the affected tests to delete the models they create.

  - Add `wrangles.train.delete(model_id)`, which calls the `DELETE /model/delete` API endpoint and raises `RuntimeError` on a non-OK response.
  - Wrap model-creation tests in `try/finally` so the created model is deleted after the test runs, regardless of pass/fail.
  - Add `_delete_model_from_log()` helper to `tests/connectors/test_train.py` to extract a model ID from a logged message (e.g. `"New classify model created :: <id>"`) and delete it, tolerating failure while cleaning up.
  - Add `TestTrainDelete` test class covering create-then-delete for classify, extract, lookup, and standardize models, plus a test that a non-OK delete response raises `RuntimeError`.
