### PR TITLE
942 new variable user permission team

### DIFF
--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -1400,11 +1400,25 @@ class TestTrainLookup:
         assert 'Blade Runner Upsert' in df['City'].values
         assert 'New Value' in df['City'].values
     
-    def test_missing_columns_error_message(self):  
+    def test_missing_columns_error_message(self, monkeypatch):  
         """  
         Verify that INSERT/UPSERT/UPDATE raise the expected error  
         when incoming columns are not present in the existing model.  
         """  
+        train_connector = importlib.import_module("wrangles.connectors.train")
+        monkeypatch.setattr(
+            train_connector._data,
+            "model",
+            lambda model_id: {"variant": "key"}
+        )
+        monkeypatch.setattr(
+            train_connector._data,
+            "model_content",
+            lambda model_id: {
+                "Columns": ["Key", "Value"],
+                "Data": [["k1", "v1"], ["k2", "v2"]],
+            }
+        )
 
         df = pd.DataFrame({  
             "Key": ["k3"],  

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -1,12 +1,37 @@
 import uuid
 
-from pytest_mock import mocker
-
 import wrangles
 import pandas as pd
 import pytest
 import logging
 import re
+import importlib
+
+
+class FakeTrainResponse:
+    ok = True
+    status_code = 200
+
+    def __init__(self, model_id="test-model-id"):
+        self.model_id = model_id
+        self.text = f'{{"model_id":"{model_id}"}}'
+
+    def json(self):
+        return {"model_id": self.model_id}
+
+
+def mock_train_model_create(monkeypatch, model_id="test-model-id"):
+    train_module = importlib.import_module("wrangles.train")
+    calls = []
+
+    def post(*args, **kwargs):
+        calls.append((args, kwargs))
+        return FakeTrainResponse(model_id)
+
+    monkeypatch.setattr(train_module._auth, "get_access_token", lambda: "test-token")
+    monkeypatch.setattr(train_module._requests, "post", post)
+    return calls
+
 
 class LogCapture(logging.Handler):
     def __init__(self, *args, **kwargs):
@@ -130,7 +155,8 @@ def test_classify_read_four_cols_error(mocker):
             """
         )
 
-def test_classify_write_logs_new_model_id_integration(caplog):  
+def test_classify_write_logs_new_model_id_integration(caplog, monkeypatch):  
+    calls = mock_train_model_create(monkeypatch, "classify-test-model")
     df = pd.DataFrame({  
         'Example': ['apple', 'banana'],  
         'Category': ['fruit', 'fruit'],  
@@ -147,6 +173,12 @@ def test_classify_write_logs_new_model_id_integration(caplog):
     )  
   
     assert any(record.message for record in caplog.records if record.levelname == "INFO" and "New classify model created" in record.message)
+    assert calls[0][1]["params"] == {"type": "classify", "name": "Test Classify Model"}
+    assert calls[0][1]["json"] == [
+        ["Example", "Category", "Notes"],
+        ["apple", "fruit", ""],
+        ["banana", "fruit", ""],
+    ]
 
 class TestTrainExtract:
     """
@@ -730,10 +762,11 @@ class TestTrainLookup:
         df = wrangles.recipe.run(recipe, dataframe=df)  
         assert df.iloc[0]['Key'] == 'Rachel' and df.iloc[0]['Value'] == 'Updated Rachel'
                                                             
-    def test_upsert_new_model_recipe(self):  
+    def test_upsert_new_model_recipe(self, monkeypatch):  
         """  
-        Test upsert creates new model when model_id doesn't exist  
+        Test upsert creates a new model request without persisting a real test model.
         """  
+        calls = mock_train_model_create(monkeypatch, "lookup-upsert-test-model")
         df = pd.DataFrame({  
             'Key': ['Rachel', 'NewCharacter'],  
             'Value': ['Updated Rachel', 'New Movie']  
@@ -752,8 +785,14 @@ class TestTrainLookup:
         assert len(result) == 2  
         assert 'NewCharacter' in result['Key'].tolist()  
         assert result['Value'].tolist() == ['Updated Rachel', 'New Movie']
-        models = wrangles.data.user.models('lookup')
-        assert any(m['name'] == model_name for m in models)
+        assert calls[0][1]["params"] == {"type": "lookup", "name": model_name, "variant": "key"}
+        assert calls[0][1]["json"] == {
+            "Columns": ["Key", "Value"],
+            "Data": [
+                ["Rachel", "Updated Rachel"],
+                ["NewCharacter", "New Movie"],
+            ],
+        }
   
     def test_action_parameter_upsert(self):  
         """  
@@ -1388,10 +1427,11 @@ class TestTrainLookup:
                 wrangles.recipe.run(recipe, dataframe=df)
     
             
-def test_lookup_write_logs_new_model_id(caplog):  
+def test_lookup_write_logs_new_model_id(caplog, monkeypatch):  
     """  
-    Integration test for lookup model creation logging  
+    Test lookup model creation logging without creating a real test model.
     """  
+    calls = mock_train_model_create(monkeypatch, "lookup-test-model")
     df = pd.DataFrame({  
         'Key': ['apple', 'banana'],  
         'Value': ['fruit', 'fruit']  
@@ -1412,6 +1452,11 @@ def test_lookup_write_logs_new_model_id(caplog):
         record.message for record in caplog.records   
         if record.levelname == "INFO" and "New lookup model created" in record.message  
     )
+    assert calls[0][1]["params"] == {"type": "lookup", "name": "Test Lookup Model Integration", "variant": "key"}
+    assert calls[0][1]["json"] == {
+        "Columns": ["Key", "Value"],
+        "Data": [["apple", "fruit"], ["banana", "fruit"]],
+    }
 
 
 #
@@ -1495,10 +1540,11 @@ def test_standardize_error():
             })
         )
 
-def test_standardize_write_logs_new_model_id(caplog):  
+def test_standardize_write_logs_new_model_id(caplog, monkeypatch):  
     """  
-    Integration test for standardize model creation logging  
+    Test standardize model creation logging without creating a real test model.
     """  
+    calls = mock_train_model_create(monkeypatch, "standardize-test-model")
     df = pd.DataFrame({  
         'Find': ['ASAP', 'ETA'],  
         'Replace': ['As Soon As Possible', 'Estimated Time of Arrival'],  
@@ -1519,6 +1565,12 @@ def test_standardize_write_logs_new_model_id(caplog):
         record.message for record in caplog.records   
         if record.levelname == "INFO" and "Creating new standardize model" in record.message  
     )
+    assert calls[0][1]["params"] == {"type": "standardize", "name": "Test Standardize Model Integration"}
+    assert calls[0][1]["json"] == [
+        ["Find", "Replace", "Notes"],
+        ["ASAP", "As Soon As Possible", ""],
+        ["ETA", "Estimated Time of Arrival", ""],
+    ]
 
 
 class TestTrainMetaData:

--- a/tests/recipes/test_variables.py
+++ b/tests/recipes/test_variables.py
@@ -367,11 +367,11 @@ def test_variables_variable_overwrite():
     assert isinstance(df['vars'][0], dict)
 
 
-def test_user_group_variable(monkeypatch):
+def test_user_permission_team_variable(monkeypatch):
     """
-    Test that the authenticated user's group is available as a recipe variable.
+    Test that the authenticated user's permission team is available as a recipe variable.
     """
-    monkeypatch.setattr(wrangles.auth, "get_user_group", lambda: "enterprise")
+    monkeypatch.setattr(wrangles.auth, "get_user_permission_team", lambda: "enterprise")
 
     df = wrangles.recipe.run(
         """
@@ -379,18 +379,18 @@ def test_user_group_variable(monkeypatch):
         - test:
             rows: 1
             values:
-                group: ${user_group}
+                team: ${user_permission_team}
         """
     )
 
-    assert df['group'][0] == 'enterprise'
+    assert df['team'][0] == 'enterprise'
 
 
-def test_user_group_variable_if(monkeypatch):
+def test_user_permission_team_variable_if(monkeypatch):
     """
-    Test that user_group can be used in Python-style if conditions.
+    Test that user_permission_team can be used in Python-style if conditions.
     """
-    monkeypatch.setattr(wrangles.auth, "get_user_group", lambda: "enterprise")
+    monkeypatch.setattr(wrangles.auth, "get_user_permission_team", lambda: "enterprise")
 
     df = wrangles.recipe.run(
         """
@@ -403,18 +403,18 @@ def test_user_group_variable_if(monkeypatch):
         - create.column:
             output: allowed
             value: true
-            if: user_group == 'enterprise'
+            if: user_permission_team == 'enterprise'
         """
     )
 
     assert df['allowed'][0] == True
 
 
-def test_user_group_variable_user_override(monkeypatch):
+def test_user_permission_team_variable_user_override(monkeypatch):
     """
-    Test that explicit variables still override the authenticated user group.
+    Test that explicit variables still override the authenticated permission team.
     """
-    monkeypatch.setattr(wrangles.auth, "get_user_group", lambda: "enterprise")
+    monkeypatch.setattr(wrangles.auth, "get_user_permission_team", lambda: "enterprise")
 
     df = wrangles.recipe.run(
         """
@@ -422,26 +422,26 @@ def test_user_group_variable_user_override(monkeypatch):
         - test:
             rows: 1
             values:
-                group: ${user_group}
+                team: ${user_permission_team}
         """,
-        variables={"user_group": "manual"}
+        variables={"user_permission_team": "manual"}
     )
 
-    assert df['group'][0] == 'manual'
+    assert df['team'][0] == 'manual'
 
 
-def test_user_group_variable_from_recipe_metadata(monkeypatch):
+def test_user_permission_team_variable_from_recipe_metadata(monkeypatch):
     """
-    Test that recipe metadata permission group is preferred for remote recipes.
+    Test that recipe metadata permission team is preferred for remote recipes.
     """
-    monkeypatch.setattr(wrangles.auth, "get_user_group", lambda: "token-group")
+    monkeypatch.setattr(wrangles.auth, "get_user_permission_team", lambda: "token-team")
     monkeypatch.setattr(
         wrangles.recipe._data,
         "model",
         lambda model_id: {
             "purpose": "recipe",
             "production_version_id": "v1",
-            "user_group": "metadata-group",
+            "user_permission_team": "metadata-team",
         }
     )
     monkeypatch.setattr(
@@ -453,11 +453,11 @@ def test_user_group_variable_from_recipe_metadata(monkeypatch):
             - test:
                 rows: 1
                 values:
-                    group: ${user_group}
+                    team: ${user_permission_team}
             """
         }
     )
 
     df = wrangles.recipe.run("12345678-1234-1234")
 
-    assert df["group"][0] == "metadata-group"
+    assert df["team"][0] == "metadata-team"

--- a/tests/recipes/test_variables.py
+++ b/tests/recipes/test_variables.py
@@ -365,3 +365,99 @@ def test_variables_variable_overwrite():
         variables={'recipe_variables': 'This is a string'}
     )
     assert isinstance(df['vars'][0], dict)
+
+
+def test_user_group_variable(monkeypatch):
+    """
+    Test that the authenticated user's group is available as a recipe variable.
+    """
+    monkeypatch.setattr(wrangles.auth, "get_user_group", lambda: "enterprise")
+
+    df = wrangles.recipe.run(
+        """
+        read:
+        - test:
+            rows: 1
+            values:
+                group: ${user_group}
+        """
+    )
+
+    assert df['group'][0] == 'enterprise'
+
+
+def test_user_group_variable_if(monkeypatch):
+    """
+    Test that user_group can be used in Python-style if conditions.
+    """
+    monkeypatch.setattr(wrangles.auth, "get_user_group", lambda: "enterprise")
+
+    df = wrangles.recipe.run(
+        """
+        read:
+        - test:
+            rows: 1
+            values:
+                result: kept
+        wrangles:
+        - create.column:
+            output: allowed
+            value: true
+            if: user_group == 'enterprise'
+        """
+    )
+
+    assert df['allowed'][0] == True
+
+
+def test_user_group_variable_user_override(monkeypatch):
+    """
+    Test that explicit variables still override the authenticated user group.
+    """
+    monkeypatch.setattr(wrangles.auth, "get_user_group", lambda: "enterprise")
+
+    df = wrangles.recipe.run(
+        """
+        read:
+        - test:
+            rows: 1
+            values:
+                group: ${user_group}
+        """,
+        variables={"user_group": "manual"}
+    )
+
+    assert df['group'][0] == 'manual'
+
+
+def test_user_group_variable_from_recipe_metadata(monkeypatch):
+    """
+    Test that recipe metadata permission group is preferred for remote recipes.
+    """
+    monkeypatch.setattr(wrangles.auth, "get_user_group", lambda: "token-group")
+    monkeypatch.setattr(
+        wrangles.recipe._data,
+        "model",
+        lambda model_id: {
+            "purpose": "recipe",
+            "production_version_id": "v1",
+            "user_group": "metadata-group",
+        }
+    )
+    monkeypatch.setattr(
+        wrangles.recipe._data,
+        "model_content",
+        lambda model_id, version_id=None: {
+            "recipe": """
+            read:
+            - test:
+                rows: 1
+                values:
+                    group: ${user_group}
+            """
+        }
+    )
+
+    df = wrangles.recipe.run("12345678-1234-1234")
+
+    assert df["group"][0] == "metadata-group"

--- a/tests/recipes/test_variables.py
+++ b/tests/recipes/test_variables.py
@@ -371,7 +371,12 @@ def test_user_permission_team_variable(monkeypatch):
     """
     Test that the authenticated user's permission team is available as a recipe variable.
     """
-    monkeypatch.setattr(wrangles.auth, "get_user_permission_team", lambda: "enterprise")
+    token = wrangles.auth._jwt.encode(
+        {"user_permission_team": "enterprise"},
+        "test-secret",
+        algorithm="HS256"
+    )
+    monkeypatch.setattr(wrangles.auth, "get_access_token", lambda: token)
 
     df = wrangles.recipe.run(
         """

--- a/wrangles/auth.py
+++ b/wrangles/auth.py
@@ -86,21 +86,21 @@ def get_access_token():
     return _access_token
 
 
-def extract_user_group(source: dict):
+def extract_user_permission_team(source: dict):
     """
-    Extract the permission-driving user group from a metadata or token payload.
+    Extract the permission-driving user team from a metadata or token payload.
     """
     if not isinstance(source, dict):
         return None
 
-    return source.get("user_group")
+    return source.get("user_permission_team")
 
 
-def get_user_group():
+def get_user_permission_team():
     """
-    Return the authenticated user's permission-driving group from the current access token.
+    Return the authenticated user's permission-driving team from the current access token.
 
-    If no user is authenticated or the token does not contain user_group,
+    If no user is authenticated or the token does not contain user_permission_team,
     return None so recipes can still run without backend credentials.
     """
     try:
@@ -113,4 +113,4 @@ def get_user_group():
     except Exception:
         return None
 
-    return extract_user_group(claims)
+    return extract_user_permission_team(claims)

--- a/wrangles/auth.py
+++ b/wrangles/auth.py
@@ -84,3 +84,33 @@ def get_access_token():
         _access_token_expiry = _datetime.now() + _timedelta(0, response.json()['expires_in'] - 30)
 
     return _access_token
+
+
+def extract_user_group(source: dict):
+    """
+    Extract the permission-driving user group from a metadata or token payload.
+    """
+    if not isinstance(source, dict):
+        return None
+
+    return source.get("user_group")
+
+
+def get_user_group():
+    """
+    Return the authenticated user's permission-driving group from the current access token.
+
+    If no user is authenticated or the token does not contain user_group,
+    return None so recipes can still run without backend credentials.
+    """
+    try:
+        token = get_access_token()
+    except Exception:
+        return None
+
+    try:
+        claims = _jwt.decode(token, options={"verify_signature": False})
+    except Exception:
+        return None
+
+    return extract_user_group(claims)

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -19,6 +19,7 @@ import requests as _requests
 from . import recipe_wrangles as _recipe_wrangles
 from . import connectors as _connectors
 from . import data as _data
+from . import auth as _auth
 from .config import (
     reserved_word_replacements as _reserved_word_replacements,
     where_overwrite_output as _where_overwrite_output,
@@ -64,6 +65,10 @@ def _load_recipe(
     """
     if variables is None:
         variables = {}
+    user_variable_keys = set(variables.keys())
+
+    if "user_group" not in variables:
+        variables["user_group"] = _auth.get_user_group()
 
     # Accept path-like objects (e.g. pathlib.Path) by converting to str
     if isinstance(recipe, _os.PathLike):
@@ -99,6 +104,11 @@ def _load_recipe(
         # If model_id format is correct but no mode_id exists
         if metadata.get('message', None) == 'error':
             raise ValueError('Incorrect model_id.\nmodel_id may be wrong or does not exists')
+
+        metadata_user_group = _auth.extract_user_group(metadata)
+        if metadata_user_group is not None:
+            if "user_group" not in user_variable_keys:
+                variables["user_group"] = metadata_user_group
 
         # Using model_id in wrong function
         purpose = metadata['purpose']

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -67,8 +67,8 @@ def _load_recipe(
         variables = {}
     user_variable_keys = set(variables.keys())
 
-    if "user_group" not in variables:
-        variables["user_group"] = _auth.get_user_group()
+    if "user_permission_team" not in variables:
+        variables["user_permission_team"] = _auth.get_user_permission_team()
 
     # Accept path-like objects (e.g. pathlib.Path) by converting to str
     if isinstance(recipe, _os.PathLike):
@@ -105,10 +105,10 @@ def _load_recipe(
         if metadata.get('message', None) == 'error':
             raise ValueError('Incorrect model_id.\nmodel_id may be wrong or does not exists')
 
-        metadata_user_group = _auth.extract_user_group(metadata)
-        if metadata_user_group is not None:
-            if "user_group" not in user_variable_keys:
-                variables["user_group"] = metadata_user_group
+        metadata_user_permission_team = _auth.extract_user_permission_team(metadata)
+        if metadata_user_permission_team is not None:
+            if "user_permission_team" not in user_variable_keys:
+                variables["user_permission_team"] = metadata_user_permission_team
 
         # Using model_id in wrong function
         purpose = metadata['purpose']

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -1108,6 +1108,7 @@ def run(
     """
     if variables is None:
         variables = {}
+    variables = variables.copy()
 
     # Parse recipe
     recipe, functions = _load_recipe(


### PR DESCRIPTION

## Summary

Adds a recipe variable named `user_permission_team`.

This variable is intended to expose the permission-driving team for the current recipe run, so recipes can branch behavior based on the user's effective permission team.

## Problem

Some recipes need to apply different limits depending on the user running them.

For example, a web research recipe may allow one group to process more rows than another group. The row limits themselves should remain recipe logic, but the recipe needs access to the current user's effective permission group.

## Changes

- Added `user_permission_team` as an automatic recipe variable.
- For remote recipe runs, `user_permission_team` is read from recipe metadata when the backend provides it.
- For local/direct runs, `user_permission_team` falls back to the authenticated token claim named `user_permission_team`.
- Explicit caller-provided variables still take precedence.
- Added tests for templated values, `if` conditions, explicit overrides, and remote recipe metadata.

## Backend Contract

WranglesPY expects the effective permission group to be provided as:

```text
user_permission_team
```

The same name is exposed inside recipes.

## Usage Examples

Use in an `if` condition:

```yaml
wrangles:
  - create.column:
      output: allowed
      value: true
      if: user_permission_team == 'admin'
```

Use as a templated value:

```yaml
read:
  - test:
      rows: 1
      values:
        group: ${user_permission_team}
```

Use to choose a row limit in recipe variables:

```yaml
variables:
  max_rows: 100

wrangles:
  - filter:
      if: user_permission_team == 'small_team'
      where: index < ${max_rows}
```