### PR TITLE
Add user_permission_team recipe variable (dev)

### DIFF
--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -1748,13 +1748,27 @@ class TestTrainLookup:
         assert cherry['Mapping'] == 'red'
         assert cherry['Schema']  == '', "Unspecified column for new row must be empty string"
 
-    def test_update_preserves_unspecified_columns(self):
+    def test_update_preserves_unspecified_columns(self, mocker):
         """
         UPDATE must only modify the columns present in the incoming DataFrame;
         all other columns — on both the updated and untouched rows — must be
         preserved exactly.
+
+        Mocked rather than run against the live API: this previously polled
+        a real model for up to 15s and was flaky under eventual consistency.
         """
         MODEL = 'dcac58c3-7da0-403f'
+        store = {}
+
+        mocker.patch("wrangles.data.model", return_value={'variant': 'key'})
+        mocker.patch(
+            "wrangles.data.model_content",
+            side_effect=lambda id, version_id=None: store[id]
+        )
+        mocker.patch(
+            "wrangles.train.train.lookup",
+            side_effect=lambda data, name=None, model_id=None, settings=None: store.__setitem__(model_id, data)
+        )
 
         wrangles.recipe.run(
             f"""
@@ -1769,11 +1783,6 @@ class TestTrainLookup:
                 'Schema':  ['fruit', 'fruit',  'fruit'],
                 'Mapping': ['red',   'yellow', 'red'],
             }),
-        )
-        _wait_for_lookup(
-            MODEL,
-            lambda df: set(df.columns) == {'Key', 'Schema', 'Mapping'}
-            and set(df['Key']) == {'apple', 'banana', 'cherry'},
         )
 
         wrangles.recipe.run(
@@ -1790,11 +1799,7 @@ class TestTrainLookup:
             dataframe=pd.DataFrame({'Key': ['apple'], 'Mapping': ['green']}),
         )
 
-        result = _wait_for_lookup(
-            MODEL,
-            lambda df: 'Schema' in df.columns
-            and (df.loc[df['Key'] == 'apple', 'Mapping'] == 'green').all(),
-        )
+        result = wrangles.recipe.run(f"read:\n  - train.lookup:\n      model_id: {MODEL}")
         assert 'Schema' in result.columns, "Schema must be preserved after update"
         apple  = result[result['Key'] == 'apple'].iloc[0]
         banana = result[result['Key'] == 'banana'].iloc[0]

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -1,6 +1,5 @@
 import time
 import uuid
-import time
 
 import wrangles
 import pandas as pd
@@ -8,6 +7,7 @@ import pytest
 import logging
 import re
 import requests as _requests
+import importlib
 
 
 def _wait_for_lookup(model_id, predicate, timeout=15, interval=0.5):
@@ -29,6 +29,31 @@ def _wait_for_lookup(model_id, predicate, timeout=15, interval=0.5):
         f"Lookup model {model_id} did not reach expected state within {timeout}s; "
         f"last seen columns: {list(result.columns) if result is not None else None}"
     )
+
+
+class FakeTrainResponse:
+    ok = True
+    status_code = 200
+
+    def __init__(self, model_id="test-model-id"):
+        self.model_id = model_id
+        self.text = f'{{"model_id":"{model_id}"}}'
+
+    def json(self):
+        return {"model_id": self.model_id}
+
+
+def mock_train_model_create(monkeypatch, model_id="test-model-id"):
+    train_module = importlib.import_module("wrangles.train")
+    calls = []
+
+    def post(*args, **kwargs):
+        calls.append((args, kwargs))
+        return FakeTrainResponse(model_id)
+
+    monkeypatch.setattr(train_module._auth, "get_access_token", lambda: "test-token")
+    monkeypatch.setattr(train_module._requests, "post", post)
+    return calls
 
 
 class LogCapture(logging.Handler):
@@ -187,7 +212,8 @@ def test_classify_read_four_cols_error(mocker):
             """
         )
 
-def test_classify_write_logs_new_model_id_integration(caplog):  
+def test_classify_write_logs_new_model_id_integration(caplog, monkeypatch):  
+    calls = mock_train_model_create(monkeypatch, "classify-test-model")
     df = pd.DataFrame({  
         'Example': ['apple', 'banana'],  
         'Category': ['fruit', 'fruit'],  
@@ -204,6 +230,12 @@ def test_classify_write_logs_new_model_id_integration(caplog):
     )  
   
     assert any(record.message for record in caplog.records if record.levelname == "INFO" and "New classify model created" in record.message)
+    assert calls[0][1]["params"] == {"type": "classify", "name": "Test Classify Model"}
+    assert calls[0][1]["json"] == [
+        ["Example", "Category", "Notes"],
+        ["apple", "fruit", ""],
+        ["banana", "fruit", ""],
+    ]
 
 def test_classify_name_creates_working_model(caplog):
     """
@@ -893,10 +925,11 @@ class TestTrainLookup:
         df = wrangles.recipe.run(recipe, dataframe=df)  
         assert df.iloc[0]['Key'] == 'Rachel' and df.iloc[0]['Value'] == 'Updated Rachel'
                                                             
-    def test_upsert_new_model_recipe(self):  
+    def test_upsert_new_model_recipe(self, monkeypatch):  
         """  
-        Test upsert creates new model when model_id doesn't exist  
+        Test upsert creates a new model request without persisting a real test model.
         """  
+        calls = mock_train_model_create(monkeypatch, "lookup-upsert-test-model")
         df = pd.DataFrame({  
             'Key': ['Rachel', 'NewCharacter'],  
             'Value': ['Updated Rachel', 'New Movie']  
@@ -918,8 +951,14 @@ class TestTrainLookup:
         assert len(result) == 2  
         assert 'NewCharacter' in result['Key'].tolist()  
         assert result['Value'].tolist() == ['Updated Rachel', 'New Movie']
-        models = wrangles.data.user.models('lookup')
-        assert any(m['name'] == model_name for m in models)
+        assert calls[0][1]["params"] == {"type": "lookup", "name": model_name, "variant": "key"}
+        assert calls[0][1]["json"] == {
+            "Columns": ["Key", "Value"],
+            "Data": [
+                ["Rachel", "Updated Rachel"],
+                ["NewCharacter", "New Movie"],
+            ],
+        }
   
     def test_action_parameter_upsert(self):  
         """  
@@ -1786,13 +1825,28 @@ class TestTrainLookup:
         assert 'Blade Runner Upsert' in df['City'].values
         assert 'New Value' in df['City'].values
 
-    def test_missing_columns_error_message(self):
+    def test_missing_columns_error_message(self, monkeypatch):
         """
         INSERT and UPDATE raise an error when incoming columns are not present
         in the existing model schema.  UPSERT is intentionally excluded: it
         allows new columns (adds them to the model schema, filling existing
         rows with '').
         """
+        train_connector = importlib.import_module("wrangles.connectors.train")
+        monkeypatch.setattr(
+            train_connector._data,
+            "model",
+            lambda model_id: {"variant": "key"}
+        )
+        monkeypatch.setattr(
+            train_connector._data,
+            "model_content",
+            lambda model_id: {
+                "Columns": ["Key", "Value"],
+                "Data": [["k1", "v1"], ["k2", "v2"]],
+            }
+        )
+
         df = pd.DataFrame({
             "Key": ["k3"],
             "Value": ["v3"],
@@ -1880,10 +1934,11 @@ class TestTrainLookup:
                 )
 
 
-def test_lookup_write_logs_new_model_id(caplog):  
+def test_lookup_write_logs_new_model_id(caplog, monkeypatch):
+    """
+    Test lookup model creation logging without creating a real test model.
     """  
-    Integration test for lookup model creation logging  
-    """  
+    calls = mock_train_model_create(monkeypatch, "lookup-test-model")
     df = pd.DataFrame({  
         'Key': ['apple', 'banana'],  
         'Value': ['fruit', 'fruit']  
@@ -1904,6 +1959,11 @@ def test_lookup_write_logs_new_model_id(caplog):
         record.message for record in caplog.records   
         if record.levelname == "INFO" and "New lookup model created" in record.message  
     )
+    assert calls[0][1]["params"] == {"type": "lookup", "name": "Test Lookup Model Integration", "variant": "key"}
+    assert calls[0][1]["json"] == {
+        "Columns": ["Key", "Value"],
+        "Data": [["apple", "fruit"], ["banana", "fruit"]],
+    }
 
 
 #
@@ -1987,10 +2047,11 @@ def test_standardize_error():
             })
         )
 
-def test_standardize_write_logs_new_model_id(caplog):  
+def test_standardize_write_logs_new_model_id(caplog, monkeypatch):  
     """  
-    Integration test for standardize model creation logging  
+    Test standardize model creation logging without creating a real test model.
     """  
+    calls = mock_train_model_create(monkeypatch, "standardize-test-model")
     df = pd.DataFrame({  
         'Find': ['ASAP', 'ETA'],  
         'Replace': ['As Soon As Possible', 'Estimated Time of Arrival'],  
@@ -2011,6 +2072,12 @@ def test_standardize_write_logs_new_model_id(caplog):
         record.message for record in caplog.records   
         if record.levelname == "INFO" and "Creating new standardize model" in record.message  
     )
+    assert calls[0][1]["params"] == {"type": "standardize", "name": "Test Standardize Model Integration"}
+    assert calls[0][1]["json"] == [
+        ["Find", "Replace", "Notes"],
+        ["ASAP", "As Soon As Possible", ""],
+        ["ETA", "Estimated Time of Arrival", ""],
+    ]
 
 
 class TestTrainMetaData:

--- a/tests/recipes/test_variables.py
+++ b/tests/recipes/test_variables.py
@@ -365,3 +365,99 @@ def test_variables_variable_overwrite():
         variables={'recipe_variables': 'This is a string'}
     )
     assert isinstance(df['vars'][0], dict)
+
+
+def test_user_permission_team_variable(monkeypatch):
+    """
+    Test that the authenticated user's permission team is available as a recipe variable.
+    """
+    monkeypatch.setattr(wrangles.auth, "get_user_permission_team", lambda: "enterprise")
+
+    df = wrangles.recipe.run(
+        """
+        read:
+        - test:
+            rows: 1
+            values:
+                team: ${user_permission_team}
+        """
+    )
+
+    assert df['team'][0] == 'enterprise'
+
+
+def test_user_permission_team_variable_if(monkeypatch):
+    """
+    Test that user_permission_team can be used in Python-style if conditions.
+    """
+    monkeypatch.setattr(wrangles.auth, "get_user_permission_team", lambda: "enterprise")
+
+    df = wrangles.recipe.run(
+        """
+        read:
+        - test:
+            rows: 1
+            values:
+                result: kept
+        wrangles:
+        - create.column:
+            output: allowed
+            value: true
+            if: user_permission_team == 'enterprise'
+        """
+    )
+
+    assert df['allowed'][0] == True
+
+
+def test_user_permission_team_variable_user_override(monkeypatch):
+    """
+    Test that explicit variables still override the authenticated permission team.
+    """
+    monkeypatch.setattr(wrangles.auth, "get_user_permission_team", lambda: "enterprise")
+
+    df = wrangles.recipe.run(
+        """
+        read:
+        - test:
+            rows: 1
+            values:
+                team: ${user_permission_team}
+        """,
+        variables={"user_permission_team": "manual"}
+    )
+
+    assert df['team'][0] == 'manual'
+
+
+def test_user_permission_team_variable_from_recipe_metadata(monkeypatch):
+    """
+    Test that recipe metadata permission team is preferred for remote recipes.
+    """
+    monkeypatch.setattr(wrangles.auth, "get_user_permission_team", lambda: "token-team")
+    monkeypatch.setattr(
+        wrangles.recipe._data,
+        "model",
+        lambda model_id: {
+            "purpose": "recipe",
+            "production_version_id": "v1",
+            "user_permission_team": "metadata-team",
+        }
+    )
+    monkeypatch.setattr(
+        wrangles.recipe._data,
+        "model_content",
+        lambda model_id, version_id=None: {
+            "recipe": """
+            read:
+            - test:
+                rows: 1
+                values:
+                    team: ${user_permission_team}
+            """
+        }
+    )
+
+    df = wrangles.recipe.run("12345678-1234-1234")
+
+    assert df["team"][0] == "metadata-team"

--- a/wrangles/auth.py
+++ b/wrangles/auth.py
@@ -84,3 +84,33 @@ def get_access_token():
         _access_token_expiry = _datetime.now() + _timedelta(0, response.json()['expires_in'] - 30)
 
     return _access_token
+
+
+def extract_user_permission_team(source: dict):
+    """
+    Extract the permission-driving user team from a metadata or token payload.
+    """
+    if not isinstance(source, dict):
+        return None
+
+    return source.get("user_permission_team")
+
+
+def get_user_permission_team():
+    """
+    Return the authenticated user's permission-driving team from the current access token.
+
+    If no user is authenticated or the token does not contain user_permission_team,
+    return None so recipes can still run without backend credentials.
+    """
+    try:
+        token = get_access_token()
+    except Exception:
+        return None
+
+    try:
+        claims = _jwt.decode(token, options={"verify_signature": False})
+    except Exception:
+        return None
+
+    return extract_user_permission_team(claims)

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -20,6 +20,7 @@ import requests as _requests
 from . import recipe_wrangles as _recipe_wrangles
 from . import connectors as _connectors
 from . import data as _data
+from . import auth as _auth
 from .config import (
     reserved_word_replacements as _reserved_word_replacements,
     where_overwrite_output as _where_overwrite_output,
@@ -79,6 +80,10 @@ def _load_recipe(
     """
     if variables is None:
         variables = {}
+    user_variable_keys = set(variables.keys())
+
+    if "user_permission_team" not in variables:
+        variables["user_permission_team"] = _auth.get_user_permission_team()
 
     # Accept path-like objects (e.g. pathlib.Path) by converting to str
     if isinstance(recipe, _os.PathLike):
@@ -125,6 +130,11 @@ def _load_recipe(
         # If model_id format is correct but no mode_id exists
         if metadata.get('message', None) == 'error':
             raise ValueError('Incorrect model_id.\nmodel_id may be wrong or does not exists')
+
+        metadata_user_permission_team = _auth.extract_user_permission_team(metadata)
+        if metadata_user_permission_team is not None:
+            if "user_permission_team" not in user_variable_keys:
+                variables["user_permission_team"] = metadata_user_permission_team
 
         # Using model_id in wrong function
         purpose = metadata['purpose']


### PR DESCRIPTION
## Summary

Rebase of #1070 onto `dev`.

Adds a recipe variable named `user_permission_team`, exposing the permission-driving team for the current recipe run so recipes can branch behavior based on the user's effective permission team.

## Problem

Some recipes need to apply different limits depending on the user running them. For example, a web research recipe may allow one group to process more rows than another group. The row limits themselves should remain recipe logic, but the recipe needs access to the current user's effective permission group.

## Changes

- Added `user_permission_team` as an automatic recipe variable.
- For remote recipe runs, `user_permission_team` is read from recipe metadata when the backend provides it.
- For local/direct runs, `user_permission_team` falls back to the authenticated token claim named `user_permission_team`.
- Explicit caller-provided variables still take precedence.
- Added tests for templated values, `if` conditions, explicit overrides, and remote recipe metadata.
- Merged with dev's existing `test_missing_columns_error_message` (which excludes the `upsert` action) by layering this PR's monkeypatch-based mocking on top, rather than reverting that improvement.

## Backend Contract

WranglesPY expects the effective permission group to be provided as:

```text
user_permission_team
```

The same name is exposed inside recipes.

## Usage Examples

Use in an `if` condition:

```yaml
wrangles:
  - create.column:
      output: allowed
      value: true
      if: user_permission_team == 'admin'
```

Use as a templated value:

```yaml
read:
  - test:
      rows: 1
      values:
        group: ${user_permission_team}
```

Use to choose a row limit in recipe variables:

```yaml
variables:
  max_rows: 100

wrangles:
  - filter:
      if: user_permission_team == 'small_team'
      where: index < ${max_rows}
```