### PR TITLE
Add train.delete with confirm gate and cross-section protection

### DIFF
--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -2235,3 +2235,36 @@ class TestTrainMetaData:
                 """,
                 dataframe=pd.DataFrame([{"settings": "not-a-dict"}])
             )
+
+
+#
+# Delete
+#
+class TestTrainDelete:
+    """
+    Tests for wrangles.train.delete
+    """
+
+    def test_create_and_delete_model(self):
+        """
+        Train a new classify model then delete it by the returned model_id.
+        Verifies the model is gone by attempting to read it after deletion.
+        """
+        training_data = [
+            ['apple', 'fruit', ''],
+            ['banana', 'fruit', ''],
+            ['carrot', 'vegetable', ''],
+        ]
+        response = wrangles.train.classify(training_data, name="Test Delete Integration Model")
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        body = response.json()
+        model_id = body.get('model_id') or body.get('id') or body.get('modelId') or body.get('model')
+        assert model_id, f"No model_id in creation response: {body}"
+
+        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+
+        wrangles.train.delete(model_id)
+
+        with pytest.raises(RuntimeError):
+            wrangles.data.model(model_id)

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -2273,7 +2273,7 @@ class TestTrainDelete:
         model_id = self._get_model_id(response)
         mock_delete = self._mock_delete_ok(mocker)
 
-        wrangles.train.delete(model_id)
+        wrangles.train.delete(model_id, confirm='delete')
 
         mock_delete.assert_called_once()
         assert model_id in str(mock_delete.call_args)
@@ -2294,7 +2294,7 @@ class TestTrainDelete:
         model_id = self._get_model_id(response)
         mock_delete = self._mock_delete_ok(mocker)
 
-        wrangles.train.delete(model_id)
+        wrangles.train.delete(model_id, confirm='delete')
 
         mock_delete.assert_called_once()
         assert model_id in str(mock_delete.call_args)
@@ -2315,7 +2315,7 @@ class TestTrainDelete:
         model_id = self._get_model_id(response)
         mock_delete = self._mock_delete_ok(mocker)
 
-        wrangles.train.delete(model_id)
+        wrangles.train.delete(model_id, confirm='delete')
 
         mock_delete.assert_called_once()
         assert model_id in str(mock_delete.call_args)
@@ -2336,7 +2336,7 @@ class TestTrainDelete:
         model_id = self._get_model_id(response)
         mock_delete = self._mock_delete_ok(mocker)
 
-        wrangles.train.delete(model_id)
+        wrangles.train.delete(model_id, confirm='delete')
 
         mock_delete.assert_called_once()
         assert model_id in str(mock_delete.call_args)
@@ -2351,4 +2351,156 @@ class TestTrainDelete:
         mock.return_value.text = '{"message":"Not Found"}'
 
         with pytest.raises(RuntimeError, match="Delete model failed"):
+            wrangles.train.delete("00000000-0000-0000", confirm='delete')
+
+    def test_delete_without_confirm_raises_value_error(self, mocker):
+        """
+        Calling delete without confirm='delete' raises a ValueError and
+        never reaches the API.
+        """
+        mock_delete = self._mock_delete_ok(mocker)
+
+        with pytest.raises(ValueError, match="confirm='delete'"):
             wrangles.train.delete("00000000-0000-0000")
+
+        mock_delete.assert_not_called()
+
+    def test_delete_with_wrong_confirm_value_raises_value_error(self, mocker):
+        """
+        Calling delete with an incorrect confirm value raises a ValueError
+        and never reaches the API.
+        """
+        mock_delete = self._mock_delete_ok(mocker)
+
+        with pytest.raises(ValueError, match="confirm='delete'"):
+            wrangles.train.delete("00000000-0000-0000", confirm='yes')
+
+        mock_delete.assert_not_called()
+
+    def test_create_then_delete_in_recipe(self, mocker):
+        """
+        Create a new classify model (real API), then delete it as part of a
+        recipe's run.on_success section (delete call itself is mocked).
+        """
+        training_data = [
+            ['apple', 'fruit', ''],
+            ['banana', 'fruit', ''],
+            ['carrot', 'vegetable', ''],
+        ]
+        response = wrangles.train.classify(training_data, name="Test Recipe Create Then Delete Model")
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        model_id = self._get_model_id(response)
+        mock_delete = self._mock_delete_ok(mocker)
+
+        df = wrangles.recipe.run(
+            f"""
+            run:
+              on_success:
+                - train.delete:
+                    model_id: {model_id}
+                    confirm: delete
+            """,
+            dataframe=pd.DataFrame({'a': [1, 2]})
+        )
+
+        assert len(df) == 2
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
+
+    def test_delete_in_recipe_without_confirm_raises(self, mocker):
+        """
+        Omitting confirm in a recipe's train.delete step fails schema
+        validation before the delete call is ever made.
+        """
+        mock_delete = self._mock_delete_ok(mocker)
+
+        with pytest.raises(Exception, match="confirm"):
+            wrangles.recipe.run(
+                """
+                run:
+                  on_success:
+                    - train.delete:
+                        model_id: 00000000-0000-0000
+                """,
+                dataframe=pd.DataFrame({'a': [1, 2]})
+            )
+
+        mock_delete.assert_not_called()
+
+    def test_delete_in_recipe_blocks_model_used_in_read(self, mocker):
+        """
+        A recipe cannot delete a model_id that its own read section
+        depends on - this guards against a recipe destroying the
+        model it is currently reading from.
+        """
+        mock_delete = self._mock_delete_ok(mocker)
+
+        with pytest.raises(Exception, match="because it is used in this recipe's read or write section"):
+            wrangles.recipe.run(
+                """
+                read:
+                  - train.classify:
+                      model_id: 94674750-f9e1-44af
+                run:
+                  on_success:
+                    - train.delete:
+                        model_id: 94674750-f9e1-44af
+                        confirm: delete
+                """
+            )
+
+        mock_delete.assert_not_called()
+
+    def test_delete_in_recipe_blocks_model_used_in_write(self, mocker):
+        """
+        A recipe cannot delete a model_id that its own write section
+        depends on - this guards against a recipe destroying the
+        model it just trained.
+        """
+        mock_delete = self._mock_delete_ok(mocker)
+
+        with pytest.raises(Exception, match="because it is used in this recipe's read or write section"):
+            wrangles.recipe.run(
+                """
+                write:
+                  - train.classify:
+                      model_id: 94674750-f9e1-44af
+                run:
+                  on_success:
+                    - train.delete:
+                        model_id: 94674750-f9e1-44af
+                        confirm: delete
+                """,
+                dataframe=pd.DataFrame({
+                    'Example': ['rice'],
+                    'Category': ['Grains'],
+                    'Notes': ['']
+                })
+            )
+
+        mock_delete.assert_not_called()
+
+    def test_delete_in_recipe_allows_unrelated_model(self, mocker):
+        """
+        A recipe can still delete a model_id that is unrelated to
+        its own read/write sections.
+        """
+        mock_delete = self._mock_delete_ok(mocker)
+
+        df = wrangles.recipe.run(
+            """
+            read:
+              - train.classify:
+                  model_id: 94674750-f9e1-44af
+            run:
+              on_success:
+                - train.delete:
+                    model_id: some-unrelated-model-id
+                    confirm: delete
+            """
+        )
+
+        assert len(df) > 0
+        mock_delete.assert_called_once()
+        assert 'some-unrelated-model-id' in str(mock_delete.call_args)

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -2245,9 +2245,15 @@ class TestTrainDelete:
     Tests for wrangles.train.delete
     """
 
-    def test_create_and_delete_model(self):
+    def _get_model_id(self, response):
+        body = response.json()
+        model_id = body.get('model_id') or body.get('id') or body.get('modelId') or body.get('model')
+        assert model_id, f"No model_id in creation response: {body}"
+        return model_id
+
+    def test_create_and_delete_classify(self):
         """
-        Train a new classify model then delete it by the returned model_id.
+        Train a new classify model then delete it.
         Verifies the model is gone by attempting to read it after deletion.
         """
         training_data = [
@@ -2255,16 +2261,83 @@ class TestTrainDelete:
             ['banana', 'fruit', ''],
             ['carrot', 'vegetable', ''],
         ]
-        response = wrangles.train.classify(training_data, name="Test Delete Integration Model")
+        response = wrangles.train.classify(training_data, name="Test Delete Classify Model")
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
-        body = response.json()
-        model_id = body.get('model_id') or body.get('id') or body.get('modelId') or body.get('model')
-        assert model_id, f"No model_id in creation response: {body}"
-
+        model_id = self._get_model_id(response)
         assert wrangles.data.model(model_id), "Model should be readable before deletion"
 
         wrangles.train.delete(model_id)
 
         with pytest.raises(RuntimeError):
             wrangles.data.model(model_id)
+
+    def test_create_and_delete_extract(self):
+        """
+        Train a new extract model then delete it.
+        Verifies the model is gone by attempting to read it after deletion.
+        """
+        training_data = [
+            ['Television', 'TV', ''],
+            ['Refrigerator', 'Fridge', ''],
+            ['Automobile', 'Car', ''],
+        ]
+        response = wrangles.train.extract(training_data, name="Test Delete Extract Model")
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        model_id = self._get_model_id(response)
+        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+
+        wrangles.train.delete(model_id)
+
+        with pytest.raises(RuntimeError):
+            wrangles.data.model(model_id)
+
+    def test_create_and_delete_lookup(self):
+        """
+        Train a new lookup model then delete it.
+        Verifies the model is gone by attempting to read it after deletion.
+        """
+        data = [
+            ['Key', 'Value'],
+            ['apple', 'fruit'],
+            ['carrot', 'vegetable'],
+        ]
+        response = wrangles.train.lookup(data, name="Test Delete Lookup Model", settings={'variant': 'key'})
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        model_id = self._get_model_id(response)
+        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+
+        wrangles.train.delete(model_id)
+
+        with pytest.raises(RuntimeError):
+            wrangles.data.model(model_id)
+
+    def test_create_and_delete_standardize(self):
+        """
+        Train a new standardize model then delete it.
+        Verifies the model is gone by attempting to read it after deletion.
+        """
+        training_data = [
+            ['ASAP', 'As Soon As Possible', ''],
+            ['ETA', 'Estimated Time of Arrival', ''],
+            ['USA', 'United States of America', ''],
+        ]
+        response = wrangles.train.standardize(training_data, name="Test Delete Standardize Model")
+        assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
+
+        model_id = self._get_model_id(response)
+        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+
+        wrangles.train.delete(model_id)
+
+        with pytest.raises(RuntimeError):
+            wrangles.data.model(model_id)
+
+    def test_delete_invalid_model_id(self):
+        """
+        Deleting a non-existent model_id should raise RuntimeError.
+        """
+        with pytest.raises(RuntimeError):
+            wrangles.train.delete("00000000-0000-0000")

--- a/tests/connectors/test_train.py
+++ b/tests/connectors/test_train.py
@@ -2251,10 +2251,16 @@ class TestTrainDelete:
         assert model_id, f"No model_id in creation response: {body}"
         return model_id
 
-    def test_create_and_delete_classify(self):
+    def _mock_delete_ok(self, mocker):
+        mock = mocker.patch('wrangles.train._requests.delete')
+        mock.return_value.ok = True
+        mock.return_value.status_code = 200
+        return mock
+
+    def test_create_and_delete_classify(self, mocker):
         """
-        Train a new classify model then delete it.
-        Verifies the model is gone by attempting to read it after deletion.
+        Train a new classify model (real API) then delete it (mocked).
+        Verifies creation succeeds and delete is called with the correct model_id.
         """
         training_data = [
             ['apple', 'fruit', ''],
@@ -2265,17 +2271,17 @@ class TestTrainDelete:
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
         model_id = self._get_model_id(response)
-        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+        mock_delete = self._mock_delete_ok(mocker)
 
         wrangles.train.delete(model_id)
 
-        with pytest.raises(RuntimeError):
-            wrangles.data.model(model_id)
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
 
-    def test_create_and_delete_extract(self):
+    def test_create_and_delete_extract(self, mocker):
         """
-        Train a new extract model then delete it.
-        Verifies the model is gone by attempting to read it after deletion.
+        Train a new extract model (real API) then delete it (mocked).
+        Verifies creation succeeds and delete is called with the correct model_id.
         """
         training_data = [
             ['Television', 'TV', ''],
@@ -2286,17 +2292,17 @@ class TestTrainDelete:
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
         model_id = self._get_model_id(response)
-        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+        mock_delete = self._mock_delete_ok(mocker)
 
         wrangles.train.delete(model_id)
 
-        with pytest.raises(RuntimeError):
-            wrangles.data.model(model_id)
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
 
-    def test_create_and_delete_lookup(self):
+    def test_create_and_delete_lookup(self, mocker):
         """
-        Train a new lookup model then delete it.
-        Verifies the model is gone by attempting to read it after deletion.
+        Train a new lookup model (real API) then delete it (mocked).
+        Verifies creation succeeds and delete is called with the correct model_id.
         """
         data = [
             ['Key', 'Value'],
@@ -2307,17 +2313,17 @@ class TestTrainDelete:
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
         model_id = self._get_model_id(response)
-        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+        mock_delete = self._mock_delete_ok(mocker)
 
         wrangles.train.delete(model_id)
 
-        with pytest.raises(RuntimeError):
-            wrangles.data.model(model_id)
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
 
-    def test_create_and_delete_standardize(self):
+    def test_create_and_delete_standardize(self, mocker):
         """
-        Train a new standardize model then delete it.
-        Verifies the model is gone by attempting to read it after deletion.
+        Train a new standardize model (real API) then delete it (mocked).
+        Verifies creation succeeds and delete is called with the correct model_id.
         """
         training_data = [
             ['ASAP', 'As Soon As Possible', ''],
@@ -2328,16 +2334,21 @@ class TestTrainDelete:
         assert response.ok, f"Model creation failed: {response.status_code} {response.text}"
 
         model_id = self._get_model_id(response)
-        assert wrangles.data.model(model_id), "Model should be readable before deletion"
+        mock_delete = self._mock_delete_ok(mocker)
 
         wrangles.train.delete(model_id)
 
-        with pytest.raises(RuntimeError):
-            wrangles.data.model(model_id)
+        mock_delete.assert_called_once()
+        assert model_id in str(mock_delete.call_args)
 
-    def test_delete_invalid_model_id(self):
+    def test_delete_error_raises_runtime_error(self, mocker):
         """
-        Deleting a non-existent model_id should raise RuntimeError.
+        A non-OK response from the delete endpoint raises RuntimeError.
         """
-        with pytest.raises(RuntimeError):
+        mock = mocker.patch('wrangles.train._requests.delete')
+        mock.return_value.ok = False
+        mock.return_value.status_code = 404
+        mock.return_value.text = '{"message":"Not Found"}'
+
+        with pytest.raises(RuntimeError, match="Delete model failed"):
             wrangles.train.delete("00000000-0000-0000")

--- a/wrangles/connectors/train.py
+++ b/wrangles/connectors/train.py
@@ -656,6 +656,38 @@ class lookup():
         """
 
 
+class delete():
+    _schema = {}
+
+    def run(model_id: str, confirm: str = None) -> None:
+        """
+        Delete a trained Wrangle model.
+
+        :param model_id: The ID of the model to delete.
+        :param confirm: Must be set to 'delete' to confirm this destructive action.
+        """
+        _logging.info(f": Deleting Wrangle :: {model_id}")
+        _train.delete(model_id, confirm)
+
+    _schema["run"] = """
+        type: object
+        description: Delete a trained Wrangle model
+        additionalProperties: false
+        required:
+          - model_id
+          - confirm
+        properties:
+          model_id:
+            type: string
+            description: The ID of the model to delete
+          confirm:
+            type: string
+            description: Must be set to 'delete' to confirm this destructive action
+            enum:
+              - delete
+        """
+
+
 class meta_data():
     _schema = {}
 

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -417,11 +417,39 @@ def _wrap_and_raise(section: str, name: str, index: int, original_exception: Exc
     raise original_exception.__class__(enhanced).with_traceback(original_exception.__traceback__) from None
 
 
+def _get_train_model_ids(section: _Union[dict, list, None]) -> set:
+    """
+    Extract all model_id values referenced by train.* actions
+    within a read or write section of a recipe.
+
+    :param section: read or write section of a recipe
+    :return: Set of model_ids referenced by train.* actions
+    """
+    model_ids = set()
+    if not section:
+        return model_ids
+    if not isinstance(section, list):
+        section = [section]
+    for step in section:
+        if not isinstance(step, dict):
+            continue
+        for action_type, params in step.items():
+            if (
+                isinstance(action_type, str) and
+                action_type.startswith('train.') and
+                isinstance(params, dict) and
+                params.get('model_id')
+            ):
+                model_ids.add(params['model_id'])
+    return model_ids
+
+
 def _run_actions(
     recipe: _Union[dict, list],
     functions: dict = None,
     variables: dict = None,
-    error: Exception = None
+    error: Exception = None,
+    full_recipe: dict = None
 ) -> None:
     """
     Run any actions defined in the recipe
@@ -430,6 +458,8 @@ def _run_actions(
     :param functions: (Optional) A dictionary of named custom functions passed in by the user
     :param variables: (Optional) A dictionary of variables to pass to the recipe
     :param error: (Optional) If the action is triggered by an exception, this contains the error object
+    :param full_recipe: (Optional) The full parsed recipe, used to check that train.delete \
+        does not target a model_id that this recipe's read or write sections depend on
     """
     if functions is None:
         functions = {}
@@ -438,6 +468,11 @@ def _run_actions(
     # Ensure recipe object is a list
     if not isinstance(recipe, list):
         recipe = [recipe]
+
+    protected_model_ids = (
+        _get_train_model_ids((full_recipe or {}).get('read')) |
+        _get_train_model_ids((full_recipe or {}).get('write'))
+    )
 
     for action in recipe:
         if not isinstance(action, dict):
@@ -449,13 +484,23 @@ def _run_actions(
 
         for action_type, params in action.items():
             try:
+                if (
+                    action_type == 'train.delete' and
+                    isinstance(params, dict) and
+                    params.get('model_id') in protected_model_ids
+                ):
+                    raise ValueError(
+                        f"Cannot delete model {params.get('model_id')} because it is "
+                        "used in this recipe's read or write section."
+                    )
+
                 # If the action is conditional, check if it should be run
                 if (
                     "if" in params and
                     not _evaluate_conditional(params["if"], variables)
                 ):
                     continue
-                
+
                 common_params = {}
                 # Add to common_params dict and remove from params
                 for key in ['if']:
@@ -1227,7 +1272,7 @@ def _run_thread(
     # supported sources such as files, url, model id
     # Run any actions required before the main recipe runs
     if 'on_start' in recipe.get('run', {}).keys():
-        _run_actions(recipe['run']['on_start'], functions, variables)
+        _run_actions(recipe['run']['on_start'], functions, variables, full_recipe=recipe)
 
     # Get requested data
     if 'read' in recipe.keys():
@@ -1264,7 +1309,7 @@ def _run_thread(
 
     # Run any actions required after the main recipe finishes
     if 'on_success' in recipe.get('run', {}).keys():
-        _run_actions(recipe['run']['on_success'], functions, variables)
+        _run_actions(recipe['run']['on_success'], functions, variables, full_recipe=recipe)
 
     return df
 
@@ -1322,7 +1367,7 @@ def run(
                     executor._threads.clear()
                     # Run any actions requested if the recipe fails
                     if 'on_failure' in recipe.get('run', {}).keys():
-                        _run_actions(recipe['run']['on_failure'], functions, variables, e)
+                        _run_actions(recipe['run']['on_failure'], functions, variables, e, full_recipe=recipe)
                 except:
                     pass
                 raise TimeoutError(f"Recipe timed out. Limit: {timeout}s")
@@ -1331,7 +1376,7 @@ def run(
                 try:
                     # Run any actions requested if the recipe fails
                     if 'on_failure' in recipe.get('run', {}).keys():
-                        _run_actions(recipe['run']['on_failure'], functions, variables, e)
+                        _run_actions(recipe['run']['on_failure'], functions, variables, e, full_recipe=recipe)
                 except:
                     pass
                 raise

--- a/wrangles/train.py
+++ b/wrangles/train.py
@@ -251,7 +251,7 @@ class train():
         """
         _logging.info(f": Deleting model :: {model_id}")
         response = _requests.delete(
-            f'{_config.api_host}/model/content',
+            f'{_config.api_host}/model/delete',
             params={'model_id': model_id},
             headers={'Authorization': f'Bearer {_auth.get_access_token()}'}
         )

--- a/wrangles/train.py
+++ b/wrangles/train.py
@@ -242,6 +242,23 @@ class train():
         
         return response
 
+    def delete(model_id: str):
+        """
+        Delete a trained model by its model ID.
+        Requires WrangleWorks Account and Subscription.
+
+        :param model_id: The ID of the model to delete.
+        """
+        _logging.info(f": Deleting model :: {model_id}")
+        response = _requests.delete(
+            f'{_config.api_host}/model/delete',
+            params={'model_id': model_id},
+            headers={'Authorization': f'Bearer {_auth.get_access_token()}'}
+        )
+        if not response.ok:
+            raise RuntimeError(f"Delete model failed. {response.status_code} : {response.text}")
+        return response
+
     def standardize(training_data: list, name: str = None, model_id: str = None):
         """
         Train a standardize model. This can standardize text to a desired format.

--- a/wrangles/train.py
+++ b/wrangles/train.py
@@ -251,7 +251,7 @@ class train():
         """
         _logging.info(f": Deleting model :: {model_id}")
         response = _requests.delete(
-            f'{_config.api_host}/model/delete',
+            f'{_config.api_host}/model/content',
             params={'model_id': model_id},
             headers={'Authorization': f'Bearer {_auth.get_access_token()}'}
         )

--- a/wrangles/train.py
+++ b/wrangles/train.py
@@ -242,13 +242,19 @@ class train():
         
         return response
 
-    def delete(model_id: str):
+    def delete(model_id: str, confirm: str = None):
         """
         Delete a trained model by its model ID.
         Requires WrangleWorks Account and Subscription.
 
         :param model_id: The ID of the model to delete.
+        :param confirm: Must be set to 'delete' to confirm this destructive action.
         """
+        if confirm != 'delete':
+            raise ValueError(
+                "Deleting a model is a destructive action. "
+                "To confirm, pass confirm='delete'."
+            )
         _logging.info(f": Deleting model :: {model_id}")
         response = _requests.delete(
             f'{_config.api_host}/model/delete',


### PR DESCRIPTION
## Summary
- Add `wrangles.train.delete(model_id, confirm)` to permanently delete a trained model, requiring `confirm='delete'` as an explicit safeguard.
- Wire `train.delete` into the recipe engine's `run:` section (`on_start`/`on_success`/`on_failure`) so it can be triggered as part of a recipe.
- Block a recipe from deleting a `model_id` that its own `read:`/`write:` sections depend on, to prevent a recipe destroying the model it just used or trained.
- Dev-branch counterpart of #997 (targets `main`), rebased onto `dev`'s current train.py/connectors/train.py (which already diverged with the lookup `columns`-required refactor).

## Test plan
- [x] `pytest tests/connectors/test_train.py` (98 passed)
- [x] `pytest tests/recipes/test_run.py` (9 passed)