### PR TITLE
1010 consistent response orientation for extracts dev

### DIFF
--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -685,7 +685,7 @@ class TestExtractCodes:
         df = wrangles.recipe.run(recipe, dataframe=data)
         assert df.iloc[0]['code'] == 'Z1ON0101'
 
-    def test_extract_codes_output_format_string_with_delimiter(self):
+    def test_extract_codes_output_format_concatenate_with_char(self):
         data = pd.DataFrame({
             'col1': ['codes here']
         })
@@ -694,8 +694,8 @@ class TestExtractCodes:
         - extract.codes:
             input: col1
             output: code
-            output_format: String
-            delimiter: " | "
+            output_format: Concatenate
+            char: " | "
         """
         with patch("wrangles.extract.codes", return_value=[["ABC123", "XYZ789"]]):
             df = wrangles.recipe.run(recipe, dataframe=data)
@@ -2595,7 +2595,7 @@ class TestExtractProperties:
         assert df.iloc[0]['Colours'] == ['green']
         assert df.iloc[0]['Materials'] == ['cotton']
 
-    def test_extract_properties_output_format_string_with_delimiter(self):
+    def test_extract_properties_output_format_concatenate_with_char(self):
         data = pd.DataFrame({
             'col': ['green blue']
         })
@@ -2605,8 +2605,8 @@ class TestExtractProperties:
             input: col
             output: colours
             property_type: Colours
-            output_format: String
-            delimiter: "; "
+            output_format: Concatenate
+            char: "; "
         """
         with patch(
             "wrangles.extract.properties",
@@ -3507,7 +3507,7 @@ class TestExtractAI:
             result = wrangles.recipe.run(recipe, dataframe=df)
         assert result.iloc[0]["output"] == {"length": "25mm", "type": "wrench"}
 
-    def test_ai_output_format_string_with_delimiter(self):
+    def test_ai_output_format_concatenate_with_char(self):
         df = pd.DataFrame({
             "data": ["wrench 25mm"]
         })
@@ -3519,8 +3519,8 @@ class TestExtractAI:
               tags:
                 type: array
                 description: Tags found in the data
-            output_format: String
-            delimiter: " | "
+            output_format: Concatenate
+            char: " | "
         """
         with patch(
             "wrangles.extract.ai",

--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -2857,7 +2857,7 @@ class TestExtractBrackets:
             output: no_brackets
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['no_brackets'] == '1234'
+        assert df.iloc[0]['no_brackets'] == ['1234']
 
     def test_extract_brackets_output_format_columns_caps_matches(self):
         """
@@ -2945,7 +2945,7 @@ class TestExtractBrackets:
                 - no_brackets2
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['no_brackets2'] == '1234'
+        assert df.iloc[0]['no_brackets2'] == ['1234']
 
     def test_extract_brackets_3(self):
         """
@@ -2964,7 +2964,7 @@ class TestExtractBrackets:
             output: output
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == '12345, 1234'
+        assert df.iloc[0]['output'] == ['12345', '1234']
 
     def test_extract_brackets_multi_input(self):
         """
@@ -2983,7 +2983,7 @@ class TestExtractBrackets:
             output: output
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == '12345, 6789'
+        assert df.iloc[0]['output'] == ['12345', '6789']
 
     def test_extract_brackets_multi_input_where(self):
         """
@@ -3004,7 +3004,7 @@ class TestExtractBrackets:
             where: numbers > 4
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == "" and df.iloc[1]['output'] == 'this is in brackets' and df.iloc[2]['output'] == 'more stuff in brackets, But this is'
+        assert df.iloc[0]['output'] == "" and df.iloc[1]['output'] == ['this is in brackets'] and df.iloc[2]['output'] == ['more stuff in brackets', 'But this is']
 
     def test_brackets_round(self):
         data = pd.DataFrame({
@@ -3018,8 +3018,8 @@ class TestExtractBrackets:
                 find: round
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == 'some'
-        assert df.iloc[1]['output'] == ''
+        assert df.iloc[0]['output'] == ['some']
+        assert df.iloc[1]['output'] == []
 
     def test_brackets_square(self):
         data = pd.DataFrame({
@@ -3033,8 +3033,8 @@ class TestExtractBrackets:
                 find: square
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == 'example'
-        assert df.iloc[1]['output'] == ''
+        assert df.iloc[0]['output'] == ['example']
+        assert df.iloc[1]['output'] == []
 
     def test_brackets_round_square(self):
         data = pd.DataFrame({
@@ -3050,8 +3050,8 @@ class TestExtractBrackets:
                     - square
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == 'some'
-        assert df.iloc[1]['output'] == 'example'
+        assert df.iloc[0]['output'] == ['some']
+        assert df.iloc[1]['output'] == ['example']
 
     def test_all_brackets(self):
         data = pd.DataFrame({
@@ -3069,7 +3069,7 @@ class TestExtractBrackets:
                     - angled
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['some', 'example', 'example', 'example']
+        assert df['output'].tolist() == [['some'], ['example'], ['example'], ['example']]
 
     def test_all_brackets_no_find(self):
         data = pd.DataFrame({
@@ -3082,7 +3082,7 @@ class TestExtractBrackets:
                 output: output
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['some, some2', 'example', 'example', 'example']
+        assert df['output'].tolist() == [['some', 'some2'], ['example'], ['example'], ['example']]
 
     def test_all_brackets_with_all_specified(self):
         data = pd.DataFrame({
@@ -3096,7 +3096,7 @@ class TestExtractBrackets:
                 find: all
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['some', 'example', 'example', 'example']
+        assert df['output'].tolist() == [['some'], ['example'], ['example'], ['example']]
 
     def test_multi_bracket_all_included(self):
         data = pd.DataFrame({
@@ -3113,7 +3113,7 @@ class TestExtractBrackets:
                     - all
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['some', 'example', '', '']
+        assert df['output'].tolist() == [['some'], ['example'], [], []]
 
     def test_all_brackets_no_find_raw(self):
         data = pd.DataFrame({
@@ -3127,7 +3127,7 @@ class TestExtractBrackets:
                 include_brackets: true
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['(some), (some2)', '[example]', '{example}', '<example>']
+        assert df['output'].tolist() == [['(some)', '(some2)'], ['[example]'], ['{example}'], ['<example>']]
 
     def test_all_brackets_raw(self):
         data = pd.DataFrame({
@@ -3146,7 +3146,7 @@ class TestExtractBrackets:
                 include_brackets: true
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['(some)', '[example]', '{example}', '<example>']
+        assert df['output'].tolist() == [['(some)'], ['[example]'], ['{example}'], ['<example>']]
 
     def test_two_bracket_types(self):
         data = pd.DataFrame({
@@ -3162,7 +3162,7 @@ class TestExtractBrackets:
                     - square
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df['output'].tolist() == ['some', 'example', '', '']
+        assert df['output'].tolist() == [['some'], ['example'], [], []]
 
     def test_brackets_curly(self):
         data = pd.DataFrame({
@@ -3176,8 +3176,8 @@ class TestExtractBrackets:
                 find: curly
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == 'example'
-        assert df.iloc[1]['output'] == ''
+        assert df.iloc[0]['output'] == ['example']
+        assert df.iloc[1]['output'] == []
 
     def test_brackets_angled(self):
         data = pd.DataFrame({
@@ -3191,8 +3191,8 @@ class TestExtractBrackets:
                 find: angled
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == 'example'
-        assert df.iloc[1]['output'] == ''
+        assert df.iloc[0]['output'] == ['example']
+        assert df.iloc[1]['output'] == []
 
     def test_brackets_extract_raw(self):
         data = pd.DataFrame({
@@ -3206,9 +3206,9 @@ class TestExtractBrackets:
                 include_brackets: true
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == '(some)'
-        assert df.iloc[1]['output'] == '[example]'
-    
+        assert df.iloc[0]['output'] == ['(some)']
+        assert df.iloc[1]['output'] == ['[example]']
+
     def test_where(self):
         """
         Test using a where clause
@@ -3226,7 +3226,7 @@ class TestExtractBrackets:
                 'column': ['[x]', '[y]']
             })
         )
-        assert df['output'].values.tolist() == ['x', '']
+        assert df['output'].values.tolist() == [['x'], '']
 
     def test_brackets_empty(self):
         """

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -754,18 +754,12 @@ def brackets(
     if not all(element in bracket_types for element in find):
         raise ValueError("find must only contain the elements: round, square, curly, angled")
 
-    # If only only one output and multiple inputs, concatenate the inputs
-    # Also need list results (not a joined string) whenever a single input
-    # is being fanned out across multiple explicit output columns
-    implicit_columns = len(input) == 1 and (len(output) > 1 or output_is_list)
-    return_data_type = "string" if output_format is None and not implicit_columns else "list"
-
     if len(input) == 1 and _is_columns_target(output, output_format, output_is_list):
         results = _extract.brackets(
             df[input[0]].astype(str).tolist(),
             find,
             include_brackets,
-            return_data_type=return_data_type
+            return_data_type="list"
         )
         _write_list_output(
             df,
@@ -773,7 +767,6 @@ def brackets(
             results,
             output_format,
             char,
-            default_format="concatenate",
             output_is_list=output_is_list
         )
     elif len(output) == 1 and len(input) > 1:
@@ -781,7 +774,7 @@ def brackets(
             df[input].astype(str).aggregate(' '.join, axis=1).tolist(),
             find,
             include_brackets,
-            return_data_type=return_data_type
+            return_data_type="list"
         )
         _write_list_output(
             df,
@@ -789,7 +782,6 @@ def brackets(
             results,
             output_format,
             char,
-            default_format="concatenate",
             output_is_list=output_is_list
         )
     else:
@@ -799,15 +791,14 @@ def brackets(
                 df[input_column].astype(str).tolist(),
                 find,
                 include_brackets,
-                return_data_type=return_data_type
+                return_data_type="list"
             )
             _write_list_output(
                 df,
                 [output_column],
                 results,
                 output_format,
-                char,
-                default_format="concatenate"
+                char
             )
 
     return df

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -23,8 +23,8 @@ _OUTPUT_FORMAT_ALIASES = {
     "dictionary": "json_dictionary",
     "columns": "columns",
     "column": "columns",
-    "string": "string",
-    "text": "string",
+    "concatenate": "concatenate",
+    "concat": "concatenate",
 }
 
 
@@ -40,9 +40,9 @@ def _normalize_output_format(output_format, default):
     if output_format == "json":
         return default
 
-    if output_format not in ("json_list", "json_dictionary", "columns", "string"):
+    if output_format not in ("json_list", "json_dictionary", "columns", "concatenate"):
         raise ValueError(
-            "output_format must be one of List, Dictionary, Columns, or String"
+            "output_format must be one of list, dictionary, columns, or concatenate"
         )
 
     return output_format
@@ -70,11 +70,11 @@ def _resolve_output_format(output, output_format, default_format, output_is_list
     return _normalize_output_format(output_format, default_format)
 
 
-def _stringify_list(value, delimiter):
+def _stringify_list(value, char):
     if value in (None, ""):
         return ""
     if isinstance(value, list):
-        return delimiter.join([str(item) for item in value])
+        return char.join([str(item) for item in value])
     return str(value)
 
 
@@ -83,17 +83,17 @@ def _write_list_output(
     output,
     results,
     output_format,
-    delimiter=", ",
+    char=", ",
     default_format="json_list",
     output_is_list=False
 ):
     output_format = _resolve_output_format(output, output_format, default_format, output_is_list)
 
     if output_format == "json_dictionary":
-        raise ValueError("output_format Dictionary is only valid for dictionary-producing extracts")
+        raise ValueError("output_format dictionary is only valid for dictionary-producing extracts")
 
-    if output_format == "string":
-        df[output[0]] = [_stringify_list(row, delimiter) for row in results]
+    if output_format == "concatenate":
+        df[output[0]] = [_stringify_list(row, char) for row in results]
         return
 
     if output_format == "columns":
@@ -137,8 +137,8 @@ def _dict_keys(results):
 def _write_dict_output(df, output, results, output_format, default_format="json_dictionary", output_is_list=False):
     output_format = _resolve_output_format(output, output_format, default_format, output_is_list)
 
-    if output_format in ("json_list", "string"):
-        raise ValueError("output_format List or String is only valid for list-producing extracts")
+    if output_format in ("json_list", "concatenate"):
+        raise ValueError("output_format list or concatenate is only valid for list-producing extracts")
 
     if output_format == "columns":
         output_columns = (
@@ -161,7 +161,7 @@ def _write_results(
     output,
     results,
     output_format,
-    delimiter=", ",
+    char=", ",
     default_format="json_list",
     output_is_list=False
 ):
@@ -173,7 +173,7 @@ def _write_results(
             output,
             results,
             output_format,
-            delimiter,
+            char,
             default_format,
             output_is_list
         )
@@ -206,7 +206,7 @@ def address(
     output: _Union[str, list],
     dataType: str,
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -239,12 +239,12 @@ def address(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Columns
-          - String
-      delimiter:
+          - list
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -266,14 +266,14 @@ def address(
             dataType,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
+        _write_list_output(df, output, results, output_format, char, output_is_list=output_is_list)
     elif len(output) == 1 and len(input) > 1:
         results = _extract.address(
             df[input].astype(str).aggregate(' '.join, axis=1).tolist(),
             dataType,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
+        _write_list_output(df, output, results, output_format, char, output_is_list=output_is_list)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -282,7 +282,7 @@ def address(
                 dataType,
                 **kwargs
             )
-            _write_list_output(df, [output_column], results, output_format, delimiter)
+            _write_list_output(df, [output_column], results, output_format, char)
 
     return df
 
@@ -294,7 +294,7 @@ def ai(
     output: _Union[dict, str, list] = None,
     model_id: str = None,
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ):
     """
@@ -391,12 +391,12 @@ def ai(
         type: string
         description: Format of the extract output
         enum:
-          - Dictionary
-          - Columns
-          - String
-      delimiter:
+          - dictionary
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     output_format_normalized = _normalize_output_format(output_format, "columns")
 
@@ -474,18 +474,18 @@ def ai(
         if output_format_normalized == "json_dictionary":
             output_column_name = target_columns[0] if target_columns and len(target_columns) == 1 else "output"
             df[output_column_name] = results
-        elif output_format_normalized == "string":
+        elif output_format_normalized == "concatenate":
             if target_columns and len(target_columns) != 1:
-                raise ValueError("output_format String can only be used with a single output column")
+                raise ValueError("output_format concatenate can only be used with a single output column")
             output_column = target_columns[0] if target_columns else "output"
             if len(exploded_df.columns) == 1:
                 df[output_column] = [
-                    _stringify_list(row, delimiter)
+                    _stringify_list(row, char)
                     for row in exploded_df[exploded_df.columns[0]].tolist()
                 ]
             else:
                 df[output_column] = [
-                    delimiter.join([_stringify_list(value, delimiter) for value in row.values()])
+                    char.join([_stringify_list(value, char) for value in row.values()])
                     for row in results
                 ]
         elif target_columns and len(target_columns) == 1:
@@ -524,7 +524,7 @@ def attributes(
     bound: str = 'mid',
     first_element: bool = False,
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -597,13 +597,13 @@ def attributes(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Dictionary
-          - Columns
-          - String
-      delimiter:
+          - list
+          - dictionary
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     $ref: "#/$defs/misc/unit_entity_map"
     """
     # If output is not specified, overwrite input columns in place
@@ -635,7 +635,7 @@ def attributes(
             output,
             results,
             output_format,
-            delimiter,
+            char,
             "json_list" if attribute_type else "json_dictionary",
             output_is_list
         )
@@ -655,7 +655,7 @@ def attributes(
             output,
             results,
             output_format,
-            delimiter,
+            char,
             "json_list" if attribute_type else "json_dictionary",
             output_is_list
         )
@@ -676,7 +676,7 @@ def attributes(
                 [output_column],
                 results,
                 output_format,
-                delimiter,
+                char,
                 "json_list" if attribute_type else "json_dictionary"
             )
 
@@ -690,7 +690,7 @@ def brackets(
     find: _Union[str, list] = 'all',
     include_brackets: bool = False,
     output_format: str = None,
-    delimiter: str = ", "
+    char: str = ", "
 ) -> _pd.DataFrame:
     """
     type: object
@@ -723,12 +723,12 @@ def brackets(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Columns
-          - String
-      delimiter:
+          - list
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -772,8 +772,8 @@ def brackets(
             output,
             results,
             output_format,
-            delimiter,
-            default_format="string",
+            char,
+            default_format="concatenate",
             output_is_list=output_is_list
         )
     elif len(output) == 1 and len(input) > 1:
@@ -788,8 +788,8 @@ def brackets(
             output,
             results,
             output_format,
-            delimiter,
-            default_format="string",
+            char,
+            default_format="concatenate",
             output_is_list=output_is_list
         )
     else:
@@ -806,8 +806,8 @@ def brackets(
                 [output_column],
                 results,
                 output_format,
-                delimiter,
-                default_format="string"
+                char,
+                default_format="concatenate"
             )
 
     return df
@@ -819,7 +819,7 @@ def codes(
     output: _Union[str, list],
     first_element: bool = False,
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -847,12 +847,12 @@ def codes(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Columns
-          - String
-      delimiter:
+          - list
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
       min_length:
         type:
           - integer
@@ -907,14 +907,14 @@ def codes(
             False,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
+        _write_list_output(df, output, results, output_format, char, output_is_list=output_is_list)
     elif len(output) == 1 and len(input) > 1:
         results = _extract.codes(
             df[input].astype(str).aggregate(' AAA '.join, axis=1).tolist(),
             first_element if output_format is None else False,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
+        _write_list_output(df, output, results, output_format, char, output_is_list=output_is_list)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -923,7 +923,7 @@ def codes(
                 first_element if output_format is None else False,
                 **kwargs
             )
-            _write_list_output(df, [output_column], results, output_format, delimiter)
+            _write_list_output(df, [output_column], results, output_format, char)
 
     return df
 
@@ -941,7 +941,7 @@ def custom(
     include_empty_labels: bool = True,
     sort: str = 'training_order',
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -1001,13 +1001,13 @@ def custom(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Dictionary
-          - Columns
-          - String
-      delimiter:
+          - list
+          - dictionary
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     if output is None: output = input
 
@@ -1037,7 +1037,7 @@ def custom(
             sort=sort,
             **kwargs
         )
-        _write_results(df, output, results, output_format, delimiter, default_format, output_is_list)
+        _write_results(df, output, results, output_format, char, default_format, output_is_list)
 
     elif len(input) == len(output) and len(model_id) == 1:
         # if one model_id, then use that model for all columns inputs and outputs
@@ -1055,7 +1055,7 @@ def custom(
                 sort=sort,
                 **kwargs
             )
-            _write_results(df, [out_col], results, output_format, delimiter, default_format)
+            _write_results(df, [out_col], results, output_format, char, default_format)
 
     elif len(input) > 1 and len(output) == 1 and len(model_id) == 1:
         model_id = [model_id[0] for _ in range(len(input))]
@@ -1080,7 +1080,7 @@ def custom(
             results = [_combine_dict_rows(row) for row in df_temp.values.tolist()]
         else:
             results = [_combine_list_rows(row) for row in df_temp.values.tolist()]
-        _write_results(df, [output], results, output_format, delimiter, default_format, output_is_list)
+        _write_results(df, [output], results, output_format, char, default_format, output_is_list)
 
     else:
         # Iterate through the inputs, outputs and model_ids
@@ -1097,7 +1097,7 @@ def custom(
                 sort=sort,
                 **kwargs
             )
-            _write_results(df, [out_col], results, output_format, delimiter, default_format)
+            _write_results(df, [out_col], results, output_format, char, default_format)
 
     return df
 
@@ -1292,7 +1292,7 @@ def html(
     data_type: str,
     output: _Union[str, list] = None,
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -1324,12 +1324,12 @@ def html(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Columns
-          - String
-      delimiter:
+          - list
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -1353,7 +1353,7 @@ def html(
             dataType=data_type,
             **kwargs
         )
-        _write_list_output(df, output, results, output_format, delimiter, output_is_list=output_is_list)
+        _write_list_output(df, output, results, output_format, char, output_is_list=output_is_list)
     else:
         # Loop through and apply for all columns
         for input_column, output_column in zip(input, output):
@@ -1362,7 +1362,7 @@ def html(
                 dataType=data_type,
                 **kwargs
             )
-            _write_list_output(df, [output_column], results, output_format, delimiter)
+            _write_list_output(df, [output_column], results, output_format, char)
 
     return df
 
@@ -1375,7 +1375,7 @@ def properties(
     return_data_type: str = 'list',
     first_element: bool = False,
     output_format: str = None,
-    delimiter: str = ", ",
+    char: str = ", ",
     **kwargs
 ) -> _pd.DataFrame:
     """
@@ -1417,13 +1417,13 @@ def properties(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Dictionary
-          - Columns
-          - String
-      delimiter:
+          - list
+          - dictionary
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input
@@ -1437,7 +1437,7 @@ def properties(
 
     # Ensure input and output lengths are compatible
     if output_format is None and return_data_type == "string":
-        output_format = "string"
+        output_format = "concatenate"
 
     if len(input) != len(output) and len(output) > 1 and not (len(input) == 1 and _is_columns_target(output, output_format, output_is_list)):
         raise ValueError('Extract must output to a single column or equal amount of columns as input.')
@@ -1455,7 +1455,7 @@ def properties(
             output,
             results,
             output_format,
-            delimiter,
+            char,
             "json_list" if property_type else "json_dictionary",
             output_is_list
         )
@@ -1472,7 +1472,7 @@ def properties(
             output,
             results,
             output_format,
-            delimiter,
+            char,
             "json_list" if property_type else "json_dictionary",
             output_is_list
         )
@@ -1491,7 +1491,7 @@ def properties(
                 [output_column],
                 results,
                 output_format,
-                delimiter,
+                char,
                 "json_list" if property_type else "json_dictionary"
             )
 
@@ -1505,7 +1505,7 @@ def regex(
   output_pattern: str = None,
   first_element: bool = False,
   output_format: str = None,
-  delimiter: str = ", "
+  char: str = ", "
   ) -> _pd.DataFrame:
     r"""
     type: object
@@ -1543,12 +1543,12 @@ def regex(
         type: string
         description: Format of the extract output
         enum:
-          - List
-          - Columns
-          - String
-      delimiter:
+          - list
+          - columns
+          - concatenate
+      char:
         type: string
-        description: Delimiter to use when output_format is String
+        description: Character to use when output_format is concatenate
     """
     # If output is not specified, overwrite input columns in place
     if output is None:
@@ -1582,7 +1582,7 @@ def regex(
         if output_format is None and first_element and len(output_columns) == 1 and not columns_is_list:
             df[output_columns[0]] = [row[0] if len(row) >= 1 else "" for row in results]
         else:
-            _write_list_output(df, output_columns, results, output_format, delimiter, output_is_list=columns_is_list)
+            _write_list_output(df, output_columns, results, output_format, char, output_is_list=columns_is_list)
 
     if len(input) == 1 and _is_columns_target(output, output_format, output_is_list):
         _write_regex(input[0], output, output_is_list)


### PR DESCRIPTION
## Summary
- Normalizes `output_format` enum values for `extract.*` wrangles to lowercase (`list`, `dictionary`, `columns`, `concatenate`) in the schema/docstrings.
- Renames the `string` output format to `concatenate` and the accompanying `delimiter` parameter to `char`.

Dev counterpart of #1032.

## Test plan
- [x] Ran `tests/recipes/wrangles/test_extract.py` against updated code
- [x] Regenerated `schema/schema.json` and spot-checked `output_format` enums are lowercase and `char` replaces `delimiter`