### PR TITLE
Document extract.codes strategy, min/max_length, sort_order, disallowed_patterns, include_multi_part_tokens, and extract_raw params (dev)

### DIFF
--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -1058,7 +1058,10 @@ class TestExtractCodes:
         )
         assert (
             info.typename == 'ValueError' and
-            'ERROR IN WRANGLE extract.codes - at line 3 - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected longest or shortest."} \n' in info.value.args[0]
+            (
+                'ERROR IN WRANGLE extract.codes - at line 3 - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected input, longest, or shortest."} \n' in info.value.args[0]
+                or 'ERROR IN WRANGLE extract.codes - at line 3 - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected longest or shortest."} \n' in info.value.args[0]
+            )
         )
 
         

--- a/wrangles/extract.py
+++ b/wrangles/extract.py
@@ -433,10 +433,9 @@ def codes(
     :param max_length: Maximum length of allowed results.
     :param strategy: How aggressive to be at removing false positives such as
         measurements. One of 'lenient', 'balanced' or 'strict'. Default is
-        'balanced'. Note that 'balanced' and 'strict' currently apply the
-        same filtering on the backend; only 'lenient' differs by not
-        applying it.
-    :param sort_order: Default is as found in the input. Also allows 'longest' or 'shortest'.
+        'balanced'. Default minimum lengths are 3 for lenient, 4 for balanced,
+        and 5 for strict unless min_length is provided.
+    :param sort_order: Default is input order. Also allows 'longest' or 'shortest'.
     :param disallowed_patterns: A pattern or JSON array of regex patterns to not include in the found codes.
     :param include_multi_part_tokens: Whether to include multi-part tokens that have a space. Default True.
     :param extract_raw: Whether to return tokens with their adjacent non-whitespace characters

--- a/wrangles/extract.py
+++ b/wrangles/extract.py
@@ -427,6 +427,21 @@ def codes(
 
     e.g. 'Something ABC123ZZ something' -> 'ABC123ZZ'
 
+    :param input: A string or list of strings to search for codes.
+    :param first_element: Get the first element from results.
+    :param min_length: Minimum length of allowed results.
+    :param max_length: Maximum length of allowed results.
+    :param strategy: How aggressive to be at removing false positives such as
+        measurements. One of 'lenient', 'balanced' or 'strict'. Default is
+        'balanced'. Note that 'balanced' and 'strict' currently apply the
+        same filtering on the backend; only 'lenient' differs by not
+        applying it.
+    :param sort_order: Default is as found in the input. Also allows 'longest' or 'shortest'.
+    :param disallowed_patterns: A pattern or JSON array of regex patterns to not include in the found codes.
+    :param include_multi_part_tokens: Whether to include multi-part tokens that have a space. Default True.
+    :param extract_raw: Whether to return tokens with their adjacent non-whitespace characters
+        included, rather than the cleaned token. Default False.
+    :return: A list of codes found.
     """
     if isinstance(input, str): 
         json_data = [input]

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -856,7 +856,7 @@ def codes(
         description: Maximum length of allowed results
       strategy:
         type: string
-        description: How aggressive to be at removing false positives such as measurements.
+        description: How aggressive to be at removing false positives such as measurements. Default is balanced. Note that balanced and strict currently apply the same filtering on the backend; only lenient differs by not applying it.
         enum:
           - lenient
           - balanced
@@ -876,7 +876,7 @@ def codes(
         description: Whether to include multi-part tokens that have a space. Default True.
       extract_raw:
         type: boolean
-        description: Whether to return tokens with their adjacent non-whitespace characters. Default False.
+        description: Whether to return tokens with their adjacent non-whitespace characters included, rather than the cleaned token. Default False.
     """
     # If output is not specified, overwrite input columns in place
     if output is None: output = input

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -856,7 +856,7 @@ def codes(
         description: Maximum length of allowed results
       strategy:
         type: string
-        description: How aggressive to be at removing false positives such as measurements. Default is balanced. Note that balanced and strict currently apply the same filtering on the backend; only lenient differs by not applying it.
+        description: How aggressive to be at removing false positives such as measurements. Default is balanced. Default minimum lengths are 3 for lenient, 4 for balanced, and 5 for strict unless min_length is provided.
         enum:
           - lenient
           - balanced


### PR DESCRIPTION
## Summary
- Ports the documentation-only changes from #1023 (extract.codes docstrings for min/max_length, sort_order, disallowed_patterns, include_multi_part_tokens, extract_raw) onto `dev`.
- Aligns extract.codes docs with the current service strategy behavior.

## Test plan
- [x] Cherry-picked both content commits from #1023 onto a fresh branch off `origin/dev`, resolving conflicts against dev's newer translate tests and updated error-message format.
- [x] `pytest tests/recipes/wrangles/test_extract.py -k "sort"` passes (52 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)