### PR TITLE
Simplify error line-number format and drop suggestion text

### DIFF
--- a/tests/connectors/test_recipe.py
+++ b/tests/connectors/test_recipe.py
@@ -1,8 +1,5 @@
 import wrangles
 import pandas as pd
-import pytest
-import yaml
-import requests
 from wrangles.connectors import memory
 
 
@@ -276,56 +273,3 @@ def test_model_with_custom_functions():
         df['header2'][0] == "value2" and
         df['header3'][0] == "VALUE2"
     )
-
-
-def test_recipe_error_suggestion():
-        """
-        Ensure that recipe errors include a Suggestion in the enhanced message
-        """
-        data = pd.DataFrame({'col': ['a'], 'col2': ['b']})
-        recipe = """
-        wrangles:
-        - copy:
-                input:
-                    - col
-                    - col2
-                output:
-                    - col-copy
-        """
-        with pytest.raises(ValueError) as info:
-                wrangles.recipe.run(recipe=recipe, dataframe=data)
-
-        assert info.typename == 'ValueError'
-        msg = str(info.value)
-        assert 'Suggestion:' in msg
-        assert 'Validate parameter formats' in msg or 'types match expectations' in msg
-
-
-def test_wrap_and_raise_suggestions_various():
-    """
-    Directly call the internal _wrap_and_raise helper with different
-    exception types to ensure suggestions are included and relevant.
-    """
-    import wrangles.recipe as recipe_module
-
-    # Provide a simple recipe string so line lookups can succeed
-    recipe_module._CURRENT_RECIPE_STRING = "\n- extract.attributes:\n- copy:\n- explode:\n"
-
-    cases = [
-        (FileNotFoundError("missing"), 'Check the file path'),
-        (KeyError('k'), 'missing keys'),
-        (ValueError('v'), 'Validate parameter formats'),
-        (TypeError('t'), 'Verify function argument types'),
-        (NotImplementedError('n'), 'not implemented'),
-        (RuntimeError('r'), 'expected types'),
-        (yaml.YAMLError('y'), 'Check YAML syntax'),
-        (requests.exceptions.RequestException('req'), 'Verify the recipe URL')
-    ]
-
-    for exc, expected in cases:
-        with pytest.raises(type(exc)) as ei:
-            recipe_module._wrap_and_raise('wrangle', 'extract.attributes', 1, exc)
-
-        em = str(ei.value)
-        assert 'Suggestion:' in em
-        assert expected in em

--- a/tests/recipes/test_custom_functions.py
+++ b/tests/recipes/test_custom_functions.py
@@ -1467,7 +1467,7 @@ def test_clear_errors_df():
     def raise_error(df):
         raise RuntimeError("This is an error")
 
-    with pytest.raises(RuntimeError, match="custom.raise_error - at line 8 - This is an error"):
+    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 8\) - This is an error"):
         wrangles.recipe.run(
             """
             read:
@@ -1531,7 +1531,7 @@ def test_clear_errors_read():
     def raise_error():
         raise RuntimeError("This is an error")
 
-    with pytest.raises(RuntimeError, match="custom.raise_error - at line 3 - This is an error"):
+    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 3\) - This is an error"):
         wrangles.recipe.run(
             """
             read:
@@ -1547,7 +1547,7 @@ def test_clear_errors_write():
     def raise_error(df):
         raise RuntimeError("This is an error")
 
-    with pytest.raises(RuntimeError, match="custom.raise_error - at line 3 - This is an error"):
+    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 3\) - This is an error"):
         wrangles.recipe.run(
             """
             write:
@@ -1673,7 +1673,7 @@ def test_wrangle_position_error():
     def raise_error(df):  
         raise RuntimeError("This is an error")  
       
-    with pytest.raises(RuntimeError, match="ERROR IN WRANGLE custom.raise_error - at line 8 - This is an error"):  
+    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 8\) - This is an error"):  
         wrangles.recipe.run(  
             """  
             read:  
@@ -1700,7 +1700,7 @@ def test_wrangle_position_error_2():
     def raise_error(df):  
         raise RuntimeError("This is an error")  
       
-    with pytest.raises(RuntimeError, match="ERROR IN WRANGLE custom.raise_error - at line 17 - This is an error"):  
+    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 17\) - This is an error"):  
         wrangles.recipe.run(  
             """  
             read:  
@@ -1727,7 +1727,7 @@ def test_wrangle_position_multiple_same_type():
     """  
     Test error reporting with multiple wrangles of same type  
     """  
-    with pytest.raises(TypeError, match="ERROR IN WRANGLE convert.data_type - at line 12 - data_type invalid_type is not supported."):  
+    with pytest.raises(TypeError, match=r"convert\.data_type \(line 12\) - data_type invalid_type is not supported\."):  
         wrangles.recipe.run(  
             """  
             read:  
@@ -1756,7 +1756,7 @@ def test_complete_error_reporting_flow():
             raise RuntimeError("Batch too large")  
         return df  
       
-    with pytest.raises(RuntimeError, match="ERROR IN WRANGLE batch - at line 12 - Batch #1 - ERROR IN WRANGLE custom.batch_error - at line 15 - Batch too large") as err:
+    with pytest.raises(RuntimeError, match=r"batch \(line 12\) - Batch #1 - custom\.batch_error \(line 15\) - Batch too large"):
         wrangles.recipe.run(
             """
             read:
@@ -1783,6 +1783,3 @@ def test_complete_error_reporting_flow():
             """,
             functions=batch_error
         )
-    # The nested batch error is already enhanced with a suggestion by the
-    # inner recipe.run() call - the outer wrap must not append a second one
-    assert str(err.value).count("Suggestion:") == 1

--- a/tests/recipes/test_recipes.py
+++ b/tests/recipes/test_recipes.py
@@ -197,7 +197,7 @@ def test_recipe_model_id_wrong_type_shows_line():
         wrangles.recipe.run(recipe)
 
     msg = info.value.args[0]
-    assert f"at line {expected_line}" in msg
+    assert f"(line {expected_line})" in msg
     assert "Using extract model_id fce592c9-26f5-4fd7 in a classify function" in msg
 
 def test_recipe_model_id_not_found_shows_line():
@@ -235,7 +235,7 @@ def test_recipe_model_id_not_found_shows_line():
         wrangles.recipe.run(recipe)
 
     msg = info.value.args[0]
-    assert f"at line {expected_line}" in msg
+    assert f"(line {expected_line})" in msg
     assert "00000000-0000-0000" in msg
 
 def test_timeout():
@@ -935,7 +935,7 @@ class TestColumnWildcards:
             )
         assert (
             info.typename == 'KeyError' and
-            "format.trim - at line 3 - 'Column nothing does not exist'" in info.value.args[0]
+            "format.trim (line 3) - 'Column nothing does not exist'" in info.value.args[0]
         )
 
 
@@ -1058,7 +1058,7 @@ def test_enhanced_error_message_long_recipe():
           case: lower  
     """  
       
-    with pytest.raises(RuntimeError, match=r"ERROR IN WRANGLE custom.failing_function - at line 18 - This is the actual error from wrangle #5"):
+    with pytest.raises(RuntimeError, match=r"custom\.failing_function \(line 18\) - This is the actual error from wrangle #5"):
         wrangles.recipe.run(recipe, functions=[working_function, failing_function])
 
 def test_enhanced_error_message_read_phase():  
@@ -1066,7 +1066,7 @@ def test_enhanced_error_message_read_phase():
     def failing_read():  
         raise RuntimeError("Read operation failed")  
       
-    with pytest.raises(RuntimeError, match=r"ERROR IN READ custom.failing_read - at line 3 - Read operation failed"):  
+    with pytest.raises(RuntimeError, match=r"custom\.failing_read \(line 3\) - Read operation failed"):  
         wrangles.recipe.run(  
             """  
             read:  
@@ -1080,7 +1080,7 @@ def test_enhanced_error_message_write_phase():
     def failing_write(df):  
         raise RuntimeError("Write operation failed")  
       
-    with pytest.raises(RuntimeError, match=r"ERROR IN WRITE custom.failing_write - at line 8 - Write operation failed"):  
+    with pytest.raises(RuntimeError, match=r"custom\.failing_write \(line 8\) - Write operation failed"):  
         wrangles.recipe.run(  
             """  
             read:  
@@ -1136,7 +1136,7 @@ def test_action_position_error():
     def fail_func():  
         raise RuntimeError("Action failed")  
       
-    with pytest.raises(RuntimeError, match="ERROR IN ACTION custom.fail_func - at line 4 - Action failed"):  
+    with pytest.raises(RuntimeError, match=r"custom\.fail_func \(line 4\) - Action failed"):  
         wrangles.recipe.run(  
             """  
             run:  
@@ -1160,7 +1160,7 @@ def test_wrangle_error_includes_index_and_name_and_line():
         recipe.run(r)
 
     msg = str(exc.value)
-    assert 'ERROR IN WRANGLE' in msg
+    assert '(line' in msg
     assert 'nonexistent_wrangle' in msg
 
 
@@ -1172,7 +1172,7 @@ def test_read_error_shows_line():
     with pytest.raises(ValueError) as exc:
         recipe.run(r)
     msg = str(exc.value)
-    assert 'ERROR IN READ' in msg
+    assert '(line' in msg
     assert 'nonexistent_read' in msg
 
 
@@ -1185,5 +1185,5 @@ def test_write_error_shows_line():
         # run will execute write even with no read; run will process wrangles then write
         recipe.run(r)
     msg = str(exc.value)
-    assert 'ERROR IN WRITE' in msg
+    assert '(line' in msg
     assert 'nonexistent_write' in msg

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -772,7 +772,7 @@ class TestConvertDataType:
             wrangles.recipe.run(recipe, dataframe=df)
         assert (
             info.typename == 'TypeError' and
-            'convert.data_type - at line 3 - data_type squirrel is not supported.' in info.value.args[0]
+            'convert.data_type (line 3) - data_type squirrel is not supported.' in info.value.args[0]
         )
 
 

--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -988,7 +988,7 @@ class TestExtractCodes:
         )
         assert (
             info.typename == 'ValueError' and
-            'ERROR IN WRANGLE extract.codes - at line 3 - Status Code: 400 - Bad Request. {"message": "min_length must be non-negative integer"} \n' in info.value.args[0]
+            'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "min_length must be non-negative integer"} \n' in info.value.args[0]
         )
 
 
@@ -1012,7 +1012,7 @@ class TestExtractCodes:
         )
         assert (
             info.typename == 'ValueError' and
-            'ERROR IN WRANGLE extract.codes - at line 3 - Status Code: 400 - Bad Request. {"message": "max length must be an integer greater than zero"} \n' in info.value.args[0]
+            'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "max length must be an integer greater than zero"} \n' in info.value.args[0]
         )
 
     def test_extract_codes_wrong_params_strategy(self):
@@ -1035,7 +1035,7 @@ class TestExtractCodes:
         )
         assert (
             info.typename == 'ValueError' and
-            'ERROR IN WRANGLE extract.codes - at line 3 - Status Code: 400 - Bad Request. {"message": "Invalid parameter strategy. Expected lenient, balanced, or strict."} \n' in info.value.args[0]
+            'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "Invalid parameter strategy. Expected lenient, balanced, or strict."} \n' in info.value.args[0]
         )
 
     def test_extract_codes_wrong_params_sort(self):
@@ -1059,8 +1059,8 @@ class TestExtractCodes:
         assert (
             info.typename == 'ValueError' and
             (
-                'ERROR IN WRANGLE extract.codes - at line 3 - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected input, longest, or shortest."} \n' in info.value.args[0]
-                or 'ERROR IN WRANGLE extract.codes - at line 3 - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected longest or shortest."} \n' in info.value.args[0]
+                'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected input, longest, or shortest."} \n' in info.value.args[0]
+                or 'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected longest or shortest."} \n' in info.value.args[0]
             )
         )
 

--- a/tests/recipes/wrangles/test_extract_unit_conversion.py
+++ b/tests/recipes/wrangles/test_extract_unit_conversion.py
@@ -68,7 +68,7 @@ def test_non_existing_unit():
             """,
             dataframe=data
         )
-    assert info.typename == 'ValueError' and ('ERROR IN WRANGLE extract.attributes - at line 3 - Status Code: 400 - Bad Request. {"ValueError":"Invalid desiredUnit provided"}\n \n') in info.value.args[0]
+    assert info.typename == 'ValueError' and ('extract.attributes (line 3) - Status Code: 400 - Bad Request. {"ValueError":"Invalid desiredUnit provided"}\n \n') in info.value.args[0]
 
 def test_wrong_match_1():
     """

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -2075,7 +2075,7 @@ class TestRename:
             wrangles.recipe.run(recipe, functions=add_suffix)
 
         msg = str(info.value)
-        assert f"at line {expected_line}" in msg
+        assert f"(line {expected_line})" in msg
         assert "Failed running" not in msg
 
     def test_rename_empty(self):
@@ -2613,7 +2613,7 @@ class TestSimilarity:
             wrangles.recipe.run(recipe, dataframe=data)
         assert (
             info.typename == 'ValueError' and
-            'similarity - at line 3 - shapes (4,) and (5,) not aligned: 4 (dim 0) != 5 (dim 0)' in info.value.args[0]
+            'similarity (line 3) - shapes (4,) and (5,) not aligned: 4 (dim 0) != 5 (dim 0)' in info.value.args[0]
         )
 
     def test_similarity_cosine_string(self):
@@ -2807,7 +2807,7 @@ class TestSimilarity:
             wrangles.recipe.run(recipe, dataframe=data)
         assert (
             info.typename == 'ValueError' and
-            'similarity - at line 3 - shapes (4,) and (5,) not aligned: 4 (dim 0) != 5 (dim 0)' in info.value.args[0]
+            'similarity (line 3) - shapes (4,) and (5,) not aligned: 4 (dim 0) != 5 (dim 0)' in info.value.args[0]
         )
 
     def test_similarity_adjusted_cosine_string(self):
@@ -4052,7 +4052,7 @@ wrangles:
                 wrangles.recipe.run(outer_recipe)
 
         msg = str(info.value)
-        assert f"at line {expected_line}" in msg
+        assert f"(line {expected_line})" in msg
 
     def test_recipe_input(self):
         """
@@ -5427,7 +5427,7 @@ class TestAccordion:
             )
         assert (
             err.typename == 'KeyError' and
-            'ERROR IN WRANGLE accordion' in err.value.args[0] and
+            'accordion (line' in err.value.args[0] and
             'Did you forget' in err.value.args[0]
         )
 
@@ -5462,7 +5462,7 @@ class TestAccordion:
             )
         assert (
             err.typename == 'KeyError' and
-            'ERROR IN WRANGLE accordion' in err.value.args[0] and
+            'accordion (line' in err.value.args[0] and
             'Did you forget' in err.value.args[0]
         )
 
@@ -5537,7 +5537,7 @@ class TestAccordion:
             )
         assert (
             err.typename == 'KeyError' and
-            'ERROR IN WRANGLE accordion' in err.value.args[0] and
+            'accordion (line' in err.value.args[0] and
             'Did you forget' in err.value.args[0]
         )
 
@@ -6162,7 +6162,7 @@ class TestBatch:
                 raise KeyError("column1 does not exist")  
             return df  
         
-        with pytest.raises(KeyError, match=r'Batch #2 - "ERROR IN WRANGLE custom\.fail_on_2nd_batch.*"'):  
+        with pytest.raises(KeyError, match=r'Batch #2 - "custom\.fail_on_2nd_batch.*"'):  
             wrangles.recipe.run(  
                 """  
                 read:  

--- a/tests/recipes/wrangles/test_pandas.py
+++ b/tests/recipes/wrangles/test_pandas.py
@@ -381,7 +381,7 @@ class TestCopy:
             wrangles.recipe.run(recipe=recipe, dataframe=data)
         assert (
             info.typename == "ValueError" and 
-            ("ERROR IN WRANGLE copy - at line 3 - Input and output must be the same length") in str(info.value)
+            ("copy (line 3) - Input and output must be the same length") in str(info.value)
         )
 
     def test_copy_shorthand(self):
@@ -902,7 +902,7 @@ class TestExplode:
             )
         assert (
             info.typename == "ValueError" and 
-            ("ERROR IN WRANGLE explode - at line 3 - columns must have matching element counts") in str(info.value)
+            ("explode (line 3) - columns must have matching element counts") in str(info.value)
         )
 
     def test_explode_reset_index_default(self):

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -312,70 +312,16 @@ def _find_item_line(item_name: str, occurrence_index: int = 1) -> int:
         return None
 
 
-def _get_error_suggestion(original_exception: Exception) -> str:
-    """
-    Best-effort: return a concise suggestion to help the user resolve
-    the given exception, based on its type.
-    """
-    try:
-        if isinstance(original_exception, FileNotFoundError):
-            return (
-                "Check the file path and permissions; ensure the file exists "
-                "and the path is correct."
-            )
-        elif isinstance(original_exception, KeyError):
-            return (
-                "Check for missing keys in the recipe, variables, or function "
-                "parameters; verify spelling and casing."
-            )
-        elif isinstance(original_exception, ValueError):
-            return (
-                "Validate parameter formats and values in the recipe; ensure "
-                "types match expectations."
-            )
-        elif isinstance(original_exception, TypeError):
-            return (
-                "Verify function argument types and the number of parameters "
-                "in the recipe or custom functions."
-            )
-        elif isinstance(original_exception, NotImplementedError):
-            return (
-                "This feature is not implemented; remove or change the offending "
-                "parameter or use an alternative wrangle."
-            )
-        elif isinstance(original_exception, RuntimeError):
-            return (
-                "Check function return values and that connectors return the "
-                "expected types (e.g. DataFrame for reads)."
-            )
-        elif 'yaml' in original_exception.__class__.__name__.lower() or isinstance(original_exception, _yaml.YAMLError):
-            return (
-                "Check YAML syntax and encoding (use UTF-8); look for indentation "
-                "or quoting issues."
-            )
-        elif 'request' in original_exception.__class__.__name__.lower() or isinstance(original_exception, _requests.exceptions.RequestException):
-            return (
-                "Verify the recipe URL, network connectivity, authentication, "
-                "and response status."
-            )
-        else:
-            return (
-                "Inspect the recipe at the indicated line; check parameters, "
-                "variable names, and custom functions for issues."
-            )
-    except Exception:
-        return (
-            "Inspect the recipe at the indicated line; check parameters, "
-            "variable names, and custom functions for issues."
-        )
-
-
 def _wrap_and_raise(section: str, name: str, index: int, original_exception: Exception):
     # If this exception was already enhanced by a nested recipe.run() call
     # (e.g. an inner wrangle used by rename's `wrangles:`), propagate it as-is
     # instead of wrapping it again - otherwise the message and line number
     # would be duplicated and the real (inner) line number would be buried.
-    if f"{original_exception}".startswith("ERROR IN "):
+    # Tracked via an attribute (rather than sniffing the message text) since
+    # intermediate code sometimes reformats the message (e.g. rename always
+    # re-raises as RuntimeError) independently of whether it was already
+    # enhanced.
+    if getattr(original_exception, '_wrangles_error_wrapped', False):
         raise original_exception
 
     line = None
@@ -390,31 +336,20 @@ def _wrap_and_raise(section: str, name: str, index: int, original_exception: Exc
         line = None
 
     # Build enhanced message but keep original exception class so tests expecting
-    # original exceptions continue to work.
+    # original exceptions continue to work. The exception type name isn't
+    # included here - Python already prefixes it automatically when the
+    # exception is displayed (e.g. "KeyError: convert.case (line 10) - ...").
     orig_msg = f"{original_exception}"
-    header = f"ERROR IN {section.upper()}"
-    if name:
-        header += f" {name}"
-
-    parts = [header]
+    header = name or ""
     if line is not None:
-        parts.append(f"at line {line}")
-    parts.append(orig_msg)
+        header += f" (line {line})"
 
-    # Add a concise suggestion to help the user resolve the issue.
-    # Skip if orig_msg already carries one - this happens when an inner
-    # exception was already wrapped by _wrap_and_raise but then had its
-    # message reformatted by intermediate code (e.g. batch's "Batch #N - "
-    # prefix in recipe_wrangles/main.py), which defeats the "ERROR IN "
-    # startswith check above. Without this, the same suggestion gets
-    # appended twice.
-    if "Suggestion:" not in orig_msg:
-        parts.append(f"Suggestion: {_get_error_suggestion(original_exception)}")
-
-    enhanced = " - ".join([p for p in parts if p])
+    enhanced = " - ".join([p for p in [header, orig_msg] if p])
 
     # Re-raise same exception type with enhanced message
-    raise original_exception.__class__(enhanced).with_traceback(original_exception.__traceback__) from None
+    wrapped_exception = original_exception.__class__(enhanced)
+    wrapped_exception._wrangles_error_wrapped = True
+    raise wrapped_exception.with_traceback(original_exception.__traceback__) from None
 
 
 def _run_actions(

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -130,6 +130,9 @@ def accordion(
         )
     except KeyError as e:
         e.args = (f"Did you forget the column in the accordion input or propagate? - {e.args[0]}",)
+        # The message just changed, so it no longer reads as already-wrapped -
+        # let the outer accordion wrangle add its own line-number wrap on top.
+        e._wrangles_error_wrapped = False
         raise e
 
     try:
@@ -144,6 +147,9 @@ def accordion(
         )
     except KeyError as e:
         e.args = (f"Did you forget the column in the accordion output? - {e.args[0]}",)
+        # The message just changed, so it no longer reads as already-wrapped -
+        # let the outer accordion wrangle add its own line-number wrap on top.
+        e._wrangles_error_wrapped = False
         raise e
 
     df_temp = df_temp.set_index(f"index_asbjdbasjk_{random_str}")[output]
@@ -1607,7 +1613,11 @@ def rename(
                     # Preserve the inner wrangle's own message (which already
                     # includes the correct line number and a suggestion when
                     # available) rather than burying it behind extra text.
-                    raise RuntimeError(f"{e}") from e
+                    # Also carry over the "already wrapped" marker so the
+                    # outer rename wrangle doesn't wrap it a second time.
+                    wrapped = RuntimeError(f"{e}")
+                    wrapped._wrangles_error_wrapped = getattr(e, '_wrangles_error_wrapped', False)
+                    raise wrapped.with_traceback(e.__traceback__) from None
 
                 if len(target) != len(result):
                     raise RuntimeError(


### PR DESCRIPTION
## Summary
- Replaces the old `ERROR IN WRANGLE X - at line N - ... - Suggestion: ...` error format (merged previously via #1054/#1060) with a leaner `X (line N) - <original error>` message.
- Drops the embedded exception type name from the message text — Python already prefixes it automatically when an exception is raised/printed, so keeping it in the message caused it to show twice (e.g. `KeyError: KeyError convert.case (line 10) - ...`). Now a traceback reads `KeyError: convert.case (line 10) - ...`.
- Removes the per-exception-type "Suggestion:" text, which added noise without much practical value.
- All other dev-only functionality (lookup `Key` output handling, `user_permission_team`, `train.delete` guard rails, `convert.from_json` defaults, etc.) is untouched.

## Test plan
- [x] Full suite: `tests/recipes/wrangles/test_extract.py` (242 passed)
- [x] Full suite: `tests/recipes/wrangles/test_main.py` (400 passed)
- [x] `tests/recipes/test_recipes.py`, `tests/recipes/test_custom_functions.py`, `tests/connectors/test_recipe.py`, `tests/recipes/wrangles/test_pandas.py`, `tests/recipes/wrangles/test_convert.py`, `tests/recipes/wrangles/test_extract_unit_conversion.py` (all passed)