### PR TITLE
Improve recipe error messages with suggestions

### DIFF
--- a/tests/recipes/test_custom_functions.py
+++ b/tests/recipes/test_custom_functions.py
@@ -1756,7 +1756,7 @@ def test_complete_error_reporting_flow():
             raise RuntimeError("Batch too large")  
         return df  
       
-    with pytest.raises(RuntimeError, match=r"batch \(line 12\) - Batch #1 - custom\.batch_error \(line 15\) - Batch too large"):
+    with pytest.raises(RuntimeError) as exc:
         wrangles.recipe.run(
             """
             read:
@@ -1783,3 +1783,9 @@ def test_complete_error_reporting_flow():
             """,
             functions=batch_error
         )
+    msg = exc.value.args[0]
+    assert "Runtime Error: custom.batch_error (line 15)" in msg
+    assert "Details: Batch too large" in msg
+    assert "Suggestions:" in msg
+    assert "Batch: #1" in msg
+    assert "batch (line" not in msg

--- a/tests/recipes/test_custom_functions.py
+++ b/tests/recipes/test_custom_functions.py
@@ -1467,7 +1467,7 @@ def test_clear_errors_df():
     def raise_error(df):
         raise RuntimeError("This is an error")
 
-    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 8\) - This is an error"):
+    with pytest.raises(RuntimeError) as exc:
         wrangles.recipe.run(
             """
             read:
@@ -1480,6 +1480,10 @@ def test_clear_errors_df():
             """,
             functions=raise_error
         )
+    msg = exc.value.args[0]
+    assert "Runtime Error: custom.raise_error (line 8)" in msg
+    assert "Details: This is an error" in msg
+    assert "Suggestions:" in msg
 
 def test_clear_errors_row_output_missing():
     """
@@ -1531,7 +1535,7 @@ def test_clear_errors_read():
     def raise_error():
         raise RuntimeError("This is an error")
 
-    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 3\) - This is an error"):
+    with pytest.raises(RuntimeError) as exc:
         wrangles.recipe.run(
             """
             read:
@@ -1539,6 +1543,10 @@ def test_clear_errors_read():
             """,
             functions=raise_error
         )
+    msg = exc.value.args[0]
+    assert "Runtime Error: custom.raise_error (line 3)" in msg
+    assert "Details: This is an error" in msg
+    assert "Suggestions:" in msg
 
 def test_clear_errors_write():
     """
@@ -1547,7 +1555,7 @@ def test_clear_errors_write():
     def raise_error(df):
         raise RuntimeError("This is an error")
 
-    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 3\) - This is an error"):
+    with pytest.raises(RuntimeError) as exc:
         wrangles.recipe.run(
             """
             write:
@@ -1555,6 +1563,10 @@ def test_clear_errors_write():
             """,
             functions=raise_error
         )
+    msg = exc.value.args[0]
+    assert "Runtime Error: custom.raise_error (line 3)" in msg
+    assert "Details: This is an error" in msg
+    assert "Suggestions:" in msg
 
 class nested:
     def read():
@@ -1673,7 +1685,7 @@ def test_wrangle_position_error():
     def raise_error(df):  
         raise RuntimeError("This is an error")  
       
-    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 8\) - This is an error"):  
+    with pytest.raises(RuntimeError) as exc:
         wrangles.recipe.run(  
             """  
             read:  
@@ -1691,6 +1703,10 @@ def test_wrangle_position_error():
             """,  
             functions=raise_error  
         )  
+    msg = exc.value.args[0]
+    assert "Runtime Error: custom.raise_error (line 8)" in msg
+    assert "Details: This is an error" in msg
+    assert "Suggestions:" in msg
 
 def test_wrangle_position_error_2():  
     """  
@@ -1700,7 +1716,7 @@ def test_wrangle_position_error_2():
     def raise_error(df):  
         raise RuntimeError("This is an error")  
       
-    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 17\) - This is an error"):  
+    with pytest.raises(RuntimeError) as exc:
         wrangles.recipe.run(  
             """  
             read:  
@@ -1722,12 +1738,16 @@ def test_wrangle_position_error_2():
             """,  
             functions=raise_error  
         )  
+    msg = exc.value.args[0]
+    assert "Runtime Error: custom.raise_error (line 17)" in msg
+    assert "Details: This is an error" in msg
+    assert "Suggestions:" in msg
   
 def test_wrangle_position_multiple_same_type():  
     """  
     Test error reporting with multiple wrangles of same type  
     """  
-    with pytest.raises(TypeError, match=r"convert\.data_type \(line 12\) - data_type invalid_type is not supported\."):  
+    with pytest.raises(TypeError) as exc:
         wrangles.recipe.run(  
             """  
             read:  
@@ -1746,6 +1766,10 @@ def test_wrangle_position_multiple_same_type():
                     data_type: invalid_type  
             """  
         )
+    msg = exc.value.args[0]
+    assert "Type Error: convert.data_type (line 12)" in msg
+    assert "Details: data_type invalid_type is not supported." in msg
+    assert "Suggestions:" in msg
 
 def test_complete_error_reporting_flow():  
     """  

--- a/tests/recipes/test_recipes.py
+++ b/tests/recipes/test_recipes.py
@@ -935,7 +935,9 @@ class TestColumnWildcards:
             )
         assert (
             info.typename == 'KeyError' and
-            "format.trim (line 3) - 'Column nothing does not exist'" in info.value.args[0]
+            "Key Error: format.trim (line 3)" in info.value.args[0] and
+            "Details: Column nothing does not exist" in info.value.args[0] and
+            "Suggestions:" in info.value.args[0]
         )
 
 
@@ -1058,15 +1060,19 @@ def test_enhanced_error_message_long_recipe():
           case: lower  
     """  
       
-    with pytest.raises(RuntimeError, match=r"custom\.failing_function \(line 18\) - This is the actual error from wrangle #5"):
+    with pytest.raises(RuntimeError) as exc:
         wrangles.recipe.run(recipe, functions=[working_function, failing_function])
+    msg = exc.value.args[0]
+    assert "Runtime Error: custom.failing_function (line 18)" in msg
+    assert "Details: This is the actual error from wrangle #5" in msg
+    assert "Suggestions:" in msg
 
 def test_enhanced_error_message_read_phase():  
     """Test error message prominence in read phase"""  
     def failing_read():  
         raise RuntimeError("Read operation failed")  
       
-    with pytest.raises(RuntimeError, match=r"custom\.failing_read \(line 3\) - Read operation failed"):  
+    with pytest.raises(RuntimeError) as exc:
         wrangles.recipe.run(  
             """  
             read:  
@@ -1074,13 +1080,17 @@ def test_enhanced_error_message_read_phase():
             """,  
             functions=[failing_read]  
         )  
+    msg = exc.value.args[0]
+    assert "Runtime Error: custom.failing_read (line 3)" in msg
+    assert "Details: Read operation failed" in msg
+    assert "Suggestions:" in msg
     
 def test_enhanced_error_message_write_phase():  
     """Test error message prominence in write phase"""  
     def failing_write(df):  
         raise RuntimeError("Write operation failed")  
       
-    with pytest.raises(RuntimeError, match=r"custom\.failing_write \(line 8\) - Write operation failed"):  
+    with pytest.raises(RuntimeError) as exc:
         wrangles.recipe.run(  
             """  
             read:  
@@ -1093,6 +1103,10 @@ def test_enhanced_error_message_write_phase():
             """,  
             functions=[failing_write]  
         )
+    msg = exc.value.args[0]
+    assert "Runtime Error: custom.failing_write (line 8)" in msg
+    assert "Details: Write operation failed" in msg
+    assert "Suggestions:" in msg
 
 def test_enhanced_error_message_nested_recipe():  
     """Test error messages work correctly with nested meta-wrangles"""  
@@ -1106,10 +1120,8 @@ def test_enhanced_error_message_nested_recipe():
         """A function that always fails"""  
         raise RuntimeError("Error in nested recipe")  
     
-    # Test the batch wrangle with a failing function  
-    with pytest.raises(RuntimeError, match=r"Error in nested recipe"):  
-        wrangles.recipe.run(  
-            """  
+    # Test the batch wrangle with a failing function
+    r = """
             read:  
             - test:  
                 rows: 5  
@@ -1122,12 +1134,25 @@ def test_enhanced_error_message_nested_recipe():
                 - custom.working_function: {}  
                 - custom.failing_function: {}  
                 - custom.working_function: {}  
-            """,  
+            """
+    expected_line = next(
+        i for i, line in enumerate(r.splitlines(), start=1)
+        if "custom.failing_function:" in line
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        wrangles.recipe.run(
+            r,
             functions={  
                 "working_function": working_function,  
                 "failing_function": failing_function  
             }  
         )
+    msg = exc.value.args[0]
+    assert f"Runtime Error: custom.failing_function (line {expected_line})" in msg
+    assert "Details: Error in nested recipe" in msg
+    assert "Suggestions:" in msg
+    assert "batch (line" not in msg
 
 def test_action_position_error():  
     """  
@@ -1136,7 +1161,7 @@ def test_action_position_error():
     def fail_func():  
         raise RuntimeError("Action failed")  
       
-    with pytest.raises(RuntimeError, match=r"custom\.fail_func \(line 4\) - Action failed"):  
+    with pytest.raises(RuntimeError) as exc:
         wrangles.recipe.run(  
             """  
             run:  
@@ -1144,10 +1169,13 @@ def test_action_position_error():
                 - custom.fail_func: {}  
                 - custom.fail_func: {}  
                 - custom.fail_func: {}  
-            """,  
-            functions=fail_func  
-        )  
-  
+            """,
+            functions=fail_func
+        )
+    msg = exc.value.args[0]
+    assert "Runtime Error: custom.fail_func (line 4)" in msg
+    assert "Details: Action failed" in msg
+    assert "Suggestions:" in msg
 
 def test_wrangle_error_includes_index_and_name_and_line():
     # Wrangle that does not exist should raise the original exception (ValueError)
@@ -1162,6 +1190,33 @@ def test_wrangle_error_includes_index_and_name_and_line():
     msg = str(exc.value)
     assert '(line' in msg
     assert 'nonexistent_wrangle' in msg
+
+
+def test_wrangle_error_has_details_and_suggestion_format():
+    r = """
+        read:
+        - test:
+            rows: 1
+            values:
+                header1: value1
+        wrangles:
+        - convert.case:
+            input: missing_column
+            output: output
+            case: upper
+        """
+    expected_line = next(
+        i for i, line in enumerate(r.splitlines(), start=1)
+        if "convert.case:" in line
+    )
+
+    with pytest.raises(KeyError) as exc:
+        recipe.run(r)
+
+    msg = exc.value.args[0]
+    assert f"Key Error: convert.case (line {expected_line})" in msg
+    assert "Details: Column missing_column does not exist" in msg
+    assert "Suggestions:" in msg
 
 
 def test_read_error_shows_line():

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -772,7 +772,9 @@ class TestConvertDataType:
             wrangles.recipe.run(recipe, dataframe=df)
         assert (
             info.typename == 'TypeError' and
-            'convert.data_type (line 3) - data_type squirrel is not supported.' in info.value.args[0]
+            'Type Error: convert.data_type (line 3)' in info.value.args[0] and
+            'Details: data_type squirrel is not supported.' in info.value.args[0] and
+            'Suggestions:' in info.value.args[0]
         )
 
 

--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -988,7 +988,9 @@ class TestExtractCodes:
         )
         assert (
             info.typename == 'ValueError' and
-            'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "min_length must be non-negative integer"} \n' in info.value.args[0]
+            'Value Error: extract.codes (line 3)' in info.value.args[0] and
+            'Details: Status Code: 400 - Bad Request. {"message": "min_length must be non-negative integer"} \n' in info.value.args[0] and
+            'Suggestions:' in info.value.args[0]
         )
 
 
@@ -1012,7 +1014,9 @@ class TestExtractCodes:
         )
         assert (
             info.typename == 'ValueError' and
-            'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "max length must be an integer greater than zero"} \n' in info.value.args[0]
+            'Value Error: extract.codes (line 3)' in info.value.args[0] and
+            'Details: Status Code: 400 - Bad Request. {"message": "max length must be an integer greater than zero"} \n' in info.value.args[0] and
+            'Suggestions:' in info.value.args[0]
         )
 
     def test_extract_codes_wrong_params_strategy(self):
@@ -1035,7 +1039,9 @@ class TestExtractCodes:
         )
         assert (
             info.typename == 'ValueError' and
-            'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "Invalid parameter strategy. Expected lenient, balanced, or strict."} \n' in info.value.args[0]
+            'Value Error: extract.codes (line 3)' in info.value.args[0] and
+            'Details: Status Code: 400 - Bad Request. {"message": "Invalid parameter strategy. Expected lenient, balanced, or strict."} \n' in info.value.args[0] and
+            'Suggestions:' in info.value.args[0]
         )
 
     def test_extract_codes_wrong_params_sort(self):
@@ -1058,9 +1064,11 @@ class TestExtractCodes:
         )
         assert (
             info.typename == 'ValueError' and
+            'Value Error: extract.codes (line 3)' in info.value.args[0] and
+            'Suggestions:' in info.value.args[0] and
             (
-                'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected input, longest, or shortest."} \n' in info.value.args[0]
-                or 'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected longest or shortest."} \n' in info.value.args[0]
+                'Details: Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected input, longest, or shortest."} \n' in info.value.args[0]
+                or 'Details: Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected longest or shortest."} \n' in info.value.args[0]
             )
         )
 

--- a/tests/recipes/wrangles/test_extract_unit_conversion.py
+++ b/tests/recipes/wrangles/test_extract_unit_conversion.py
@@ -68,7 +68,12 @@ def test_non_existing_unit():
             """,
             dataframe=data
         )
-    assert info.typename == 'ValueError' and ('extract.attributes (line 3) - Status Code: 400 - Bad Request. {"ValueError":"Invalid desiredUnit provided"}\n \n') in info.value.args[0]
+    assert (
+        info.typename == 'ValueError' and
+        'Value Error: extract.attributes (line 3)' in info.value.args[0] and
+        'Details: Status Code: 400 - Bad Request. {"ValueError":"Invalid desiredUnit provided"}\n \n' in info.value.args[0] and
+        'Suggestions:' in info.value.args[0]
+    )
 
 def test_wrong_match_1():
     """

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -2613,7 +2613,9 @@ class TestSimilarity:
             wrangles.recipe.run(recipe, dataframe=data)
         assert (
             info.typename == 'ValueError' and
-            'similarity (line 3) - shapes (4,) and (5,) not aligned: 4 (dim 0) != 5 (dim 0)' in info.value.args[0]
+            'Value Error: similarity (line 3)' in info.value.args[0] and
+            'Details: shapes (4,) and (5,) not aligned: 4 (dim 0) != 5 (dim 0)' in info.value.args[0] and
+            'Suggestions:' in info.value.args[0]
         )
 
     def test_similarity_cosine_string(self):
@@ -2807,7 +2809,9 @@ class TestSimilarity:
             wrangles.recipe.run(recipe, dataframe=data)
         assert (
             info.typename == 'ValueError' and
-            'similarity (line 3) - shapes (4,) and (5,) not aligned: 4 (dim 0) != 5 (dim 0)' in info.value.args[0]
+            'Value Error: similarity (line 3)' in info.value.args[0] and
+            'Details: shapes (4,) and (5,) not aligned: 4 (dim 0) != 5 (dim 0)' in info.value.args[0] and
+            'Suggestions:' in info.value.args[0]
         )
 
     def test_similarity_adjusted_cosine_string(self):

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -6162,7 +6162,7 @@ class TestBatch:
                 raise KeyError("column1 does not exist")  
             return df  
         
-        with pytest.raises(KeyError, match=r'Batch #2 - "custom\.fail_on_2nd_batch.*"'):  
+        with pytest.raises(KeyError) as exc:
             wrangles.recipe.run(  
                 """  
                 read:  
@@ -6178,6 +6178,11 @@ class TestBatch:
                 """,  
                 functions=fail_on_2nd_batch  
         )  
+        msg = exc.value.args[0]
+        assert "Key Error: custom.fail_on_2nd_batch (line 11)" in msg
+        assert "Details: column1 does not exist" in msg
+        assert "Suggestions:" in msg
+        assert "Batch: #2" in msg
   
 
 

--- a/tests/recipes/wrangles/test_pandas.py
+++ b/tests/recipes/wrangles/test_pandas.py
@@ -381,7 +381,9 @@ class TestCopy:
             wrangles.recipe.run(recipe=recipe, dataframe=data)
         assert (
             info.typename == "ValueError" and 
-            ("copy (line 3) - Input and output must be the same length") in str(info.value)
+            "Value Error: copy (line 3)" in str(info.value) and
+            "Details: Input and output must be the same length" in str(info.value) and
+            "Suggestions:" in str(info.value)
         )
 
     def test_copy_shorthand(self):
@@ -902,7 +904,9 @@ class TestExplode:
             )
         assert (
             info.typename == "ValueError" and 
-            ("explode (line 3) - columns must have matching element counts") in str(info.value)
+            "Value Error: explode (line 3)" in str(info.value) and
+            "Details: columns must have matching element counts" in str(info.value) and
+            "Suggestions:" in str(info.value)
         )
 
     def test_explode_reset_index_default(self):

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -312,6 +312,78 @@ def _find_item_line(item_name: str, occurrence_index: int = 1) -> int:
         return None
 
 
+def _format_exception_type(error: Exception) -> str:
+    """
+    Convert exception class names to a display label.
+    """
+    name = error.__class__.__name__
+    return _re.sub(r"(?<!^)(?=[A-Z])", " ", name)
+
+
+def _get_exception_detail(error: Exception) -> str:
+    """
+    Return the most useful detail string without KeyError's repr quotes.
+    """
+    if len(getattr(error, "args", [])) == 1:
+        return str(error.args[0])
+    return str(error)
+
+
+def _get_error_suggestion(original_exception: Exception) -> str:
+    """
+    Best-effort: return a concise suggestion to help the user resolve
+    the given exception, based on its type.
+    """
+    try:
+        if isinstance(original_exception, FileNotFoundError):
+            return (
+                "Check the file path and permissions; ensure the file exists "
+                "and the path is correct."
+            )
+        elif isinstance(original_exception, KeyError):
+            return (
+                "Check that referenced columns, recipe variables, and function "
+                "parameters exist; verify spelling and casing."
+            )
+        elif isinstance(original_exception, ValueError):
+            return (
+                "Validate parameter formats and values in the recipe; ensure "
+                "types match expectations."
+            )
+        elif isinstance(original_exception, TypeError):
+            return (
+                "Verify function argument types and the number of parameters "
+                "in the recipe or custom functions."
+            )
+        elif isinstance(original_exception, NotImplementedError):
+            return (
+                "This feature is not implemented; remove or change the offending "
+                "parameter or use an alternative wrangle."
+            )
+        elif isinstance(original_exception, RuntimeError):
+            return (
+                "Check function return values and that connectors return the "
+                "expected types, such as a DataFrame for reads."
+            )
+        elif 'yaml' in original_exception.__class__.__name__.lower() or isinstance(original_exception, _yaml.YAMLError):
+            return (
+                "Check YAML syntax and encoding; look for indentation, quoting, "
+                "or formatting issues."
+            )
+        elif 'request' in original_exception.__class__.__name__.lower() or isinstance(original_exception, _requests.exceptions.RequestException):
+            return (
+                "Verify the recipe URL, network connectivity, authentication, "
+                "and response status."
+            )
+    except Exception:
+        pass
+
+    return (
+        "Inspect the recipe at the indicated line; check parameters, variable "
+        "names, and custom functions for issues."
+    )
+
+
 def _wrap_and_raise(section: str, name: str, index: int, original_exception: Exception):
     # If this exception was already enhanced by a nested recipe.run() call
     # (e.g. an inner wrangle used by rename's `wrangles:`), propagate it as-is
@@ -336,15 +408,18 @@ def _wrap_and_raise(section: str, name: str, index: int, original_exception: Exc
         line = None
 
     # Build enhanced message but keep original exception class so tests expecting
-    # original exceptions continue to work. The exception type name isn't
-    # included here - Python already prefixes it automatically when the
-    # exception is displayed (e.g. "KeyError: convert.case (line 10) - ...").
-    orig_msg = f"{original_exception}"
+    # original exceptions continue to work.
     header = name or ""
     if line is not None:
         header += f" (line {line})"
 
-    enhanced = " - ".join([p for p in [header, orig_msg] if p])
+    detail = _get_exception_detail(original_exception)
+    suggestion = _get_error_suggestion(original_exception)
+    enhanced = (
+        f"{_format_exception_type(original_exception)}: {header}\n\n"
+        f"Details: {detail}\n"
+        f"Suggestions: {suggestion}"
+    )
 
     # Re-raise same exception type with enhanced message
     wrapped_exception = original_exception.__class__(enhanced)

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -207,6 +207,11 @@ def _batch_thread(
                 for k, v in on_error.items()
             })
         else:
+            if getattr(err, "_wrangles_error_wrapped", False):
+                message = err.args[0] if len(getattr(err, "args", [])) == 1 else str(err)
+                batched_error = err.__class__(f"{message}\nBatch: #{batch_num}")
+                batched_error._wrangles_error_wrapped = True
+                raise batched_error.with_traceback(err.__traceback__) from None
             raise err.__class__(f"Batch #{batch_num} - {err}").with_traceback(err.__traceback__) from None 
 
 


### PR DESCRIPTION
## Summary
- Add structured recipe error output with error type, recipe item name, line number, details, and suggestions.
- Preserve inner wrangle errors in nested batch recipes while keeping batch context.
- Update recipe and batch tests for the new message format.

## Tests
- Targeted recipe and batch error tests passed: 11 passed.