### PR TITLE
Add dev RC schema publishing step

### DIFF
--- a/.github/workflows/publish-dev-rc.yml
+++ b/.github/workflows/publish-dev-rc.yml
@@ -129,11 +129,67 @@ jobs:
           pip install .
           wrangles.recipe tests/samples/generate-data.wrgl.yml
 
-  # ── 3. Publish Python package to CodeArtifact ────────────────────────────
+  # ── 3. Generate and test schema ──────────────────────────────────────────
+  test-generate-schema:
+    name: Generate and Test Schema
+    runs-on: ubuntu-latest
+    needs: [compute-version]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install Dependencies
+        run: |
+          pip install -r requirements-full.txt
+          pip install jsonschema
+
+      - name: Generate and Test Schema
+        run: cd schema && python generate_recipe_schema.py
+
+      - name: Save schema as schema_dev.json
+        run: cp schema/schema.json schema/schema_dev.json
+
+      - name: Checkout wrangleworks.github.io
+        uses: actions/checkout@v5
+        with:
+          repository: wrangleworks/wrangleworks.github.io
+          token: ${{ secrets.CROSS_REPO_PAT_V2 }}
+          path: wrangleworks.github.io
+
+      - name: Copy schema_dev.json to wrangleworks.github.io
+        run: cp schema/schema_dev.json wrangleworks.github.io/schema/recipes/schema_dev.json
+
+      - name: Commit and push schema_dev.json
+        working-directory: wrangleworks.github.io
+        run: |
+          git config user.name "mborodii-prog"
+          git config user.email "mborodii@binariks.com"
+          git add schema/recipes/schema_dev.json
+          if git diff --cached --quiet; then
+            echo "No changes to schema_dev.json, skipping commit."
+          else
+            git commit -m "Update dev recipe schema"
+            git push
+          fi
+
+      - name: Save Schema as Artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: schema
+          path: schema/schema_dev.json
+
+  # ── 4. Publish Python package to CodeArtifact ────────────────────────────
   publish-codeartifact:
     name: Publish RC Package
     runs-on: ubuntu-latest
-    needs: [compute-version, test-pip-install]
+    needs: [compute-version, test-pip-install, test-generate-schema]
     permissions:
       contents: read
       id-token: write   # required for OIDC AssumeRoleWithWebIdentity
@@ -176,7 +232,7 @@ jobs:
       - name: Publish to CodeArtifact
         run: twine upload --repository codeartifact dist/*
 
-  # ── 4. Trigger QA deployment in Lambda-Recipes ───────────────────────────
+  # ── 5. Trigger QA deployment in Lambda-Recipes ───────────────────────────
   # CROSS_REPO_PAT: a GitHub PAT with Actions read/write on Lambda-Recipes,
   # stored as a repository or org secret. Required to dispatch workflows across repositories.
   trigger-deploy-qa:


### PR DESCRIPTION
## Summary
- Add schema generation to the Dev RC publish workflow.
- Save the generated schema as `schema_dev.json`.
- Publish `schema_dev.json` to `wrangleworks/wrangleworks.github.io` under `schema/recipes/`.
- Use `CROSS_REPO_PAT_V2` for the cross-repo checkout/push.
- Configure the schema update commit to use `mborodii-prog <mborodii@binariks.com>`.
