### PR TITLE
Update Devcontainer to support Local Windows/WSL Developement

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,48 @@
+# WranglesPY development container
+
+The shared `devcontainer.json` is intentionally host-neutral. VS Code on Windows
+and GitHub Codespaces both use the same Python 3.13 container definition.
+
+## Windows with Docker Desktop
+
+Docker Desktop's Linux engine must be ready before VS Code evaluates the
+devcontainer. From the repository root, run:
+
+```powershell
+.\.devcontainer\wait-for-docker.ps1
+```
+
+The helper starts Docker Desktop when necessary and waits until the selected
+Docker context can reach a Linux server. When it reports that Docker is ready,
+open the repository in VS Code and run:
+
+```text
+Dev Containers: Reopen in Container
+```
+
+Use `Dev Containers: Rebuild Container` after changing `devcontainer.json` or
+the dependency files.
+
+`Dev Containers: Attach to Running Container...` remains useful as a recovery
+option when this repository's container is already running. It is not the
+normal workflow because attaching does not necessarily apply this repository's
+creation commands and VS Code customizations.
+
+## GitHub Codespaces
+
+Create or reopen the Codespace normally. Codespaces reads
+`.devcontainer/devcontainer.json` directly. The Windows readiness helper is not
+referenced by the configuration and does not run in Codespaces.
+
+## Quick diagnosis
+
+Before reopening locally, both commands should succeed:
+
+```powershell
+docker context show
+docker version
+```
+
+`docker version` must show a Linux server section. A missing
+`dockerDesktopLinuxEngine` named pipe means Docker Desktop is still starting,
+not that `devcontainer.json` selected the wrong engine.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,8 @@
 		"vscode": {
 			"extensions": [
 				"redhat.vscode-yaml",
-				"GitHub.copilot"
+				"GitHub.copilot",
+				"editorconfig.editorconfig"
 			],
 			"settings": {
 				"yaml.schemas": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-	"name": "Python 3",
+	"name": "WranglesPY (Python 3.13)",
 
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.13-bookworm",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -12,8 +12,13 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
-	"onCreateCommand": "pip install pytest==9.0.2 lorem pytest-mock",
-	"postCreateCommand": "pip3 install --user -r requirements.txt",
+	"remoteUser": "vscode",
+	"remoteEnv": {
+		"PATH": "${containerEnv:PATH}:/home/vscode/.local/bin"
+	},
+
+	// Mirror the full CI test environment and install this checkout in editable mode.
+	"postCreateCommand": "python -m pip install --user --upgrade pip && python -m pip install --user -r requirements-full.txt pytest==9.0.2 pytest-mock -e .",
 
 	// Configure tool-specific properties.
 	"customizations": {
@@ -21,19 +26,23 @@
 			"extensions": [
 				"redhat.vscode-yaml",
 				"GitHub.copilot",
-				"editorconfig.editorconfig"
+				"editorconfig.editorconfig",
+				"ms-python.python",
+				"ms-python.vscode-pylance"
 			],
 			"settings": {
+				"files.eol": "\n",
+				"files.associations": {
+					"*.recipe": "yaml"
+				},
 				"yaml.schemas": {
 					"https://public.wrangle.works/schema/recipes/schema.json": ["*.wrgl.yml", "*.wrgl.yaml", "*.recipe"]
 				},
+				"python.defaultInterpreterPath": "/usr/local/bin/python",
 				"python.testing.pytestArgs": ["tests"],
 				"python.testing.unittestEnabled": false,
-    			"python.testing.pytestEnabled": true
+				"python.testing.pytestEnabled": true
 			}
 		}
 	}
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 }

--- a/.devcontainer/wait-for-docker.ps1
+++ b/.devcontainer/wait-for-docker.ps1
@@ -1,0 +1,52 @@
+[CmdletBinding()]
+param(
+    [ValidateRange(10, 600)]
+    [int]$TimeoutSeconds = 180
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    throw 'Docker CLI was not found. Install or repair Docker Desktop before opening the dev container.'
+}
+
+function Get-DockerServerOs {
+    $serverOs = docker version --format '{{.Server.Os}}' 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        return $serverOs.Trim()
+    }
+
+    return $null
+}
+
+$serverOs = Get-DockerServerOs
+if (-not $serverOs) {
+    $dockerDesktopPath = Join-Path $env:ProgramFiles 'Docker\Docker\Docker Desktop.exe'
+    if (-not (Test-Path -LiteralPath $dockerDesktopPath)) {
+        throw "Docker Desktop is not responding and was not found at '$dockerDesktopPath'."
+    }
+
+    Write-Host 'Starting Docker Desktop...'
+    Start-Process -FilePath $dockerDesktopPath
+}
+
+$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+Write-Host "Waiting up to $TimeoutSeconds seconds for the Docker Linux engine..."
+
+do {
+    $serverOs = Get-DockerServerOs
+    if ($serverOs -eq 'linux') {
+        $context = docker context show
+        Write-Host "Docker is ready (context: $context, server: linux)."
+        Write-Host "In VS Code, run 'Dev Containers: Reopen in Container'."
+        exit 0
+    }
+
+    if ($serverOs) {
+        throw "Docker is running a '$serverOs' engine. Switch Docker Desktop to Linux containers and try again."
+    }
+
+    Start-Sleep -Seconds 2
+} while ((Get-Date) -lt $deadline)
+
+throw "Docker Desktop did not expose its Linux engine within $TimeoutSeconds seconds. Check Docker Desktop before retrying."

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{bat,cmd}]
+end_of_line = crlf
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Keep all text files LF in both Git and the working tree
+* text=auto eol=lf
+
+# Windows command scripts genuinely require/prefer CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Explicit binary exclusions
+*.png -text
+*.jpg -text
+*.jpeg -text
+*.gif -text
+*.ico -text
+*.pdf -text
+*.zip -text
+*.tar -text
+*.gz -text
+*.bz2 -text
+*.7z -text

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,7 +20,7 @@
 - **Data Formats:** openpyxl (Excel), xlsxwriter
 - **AI/ML:** OpenAI integration, Hugging Face models
 - **Testing:** pytest (9.0.2), pytest-mock, lorem (test data generation)
-- **Containerization:** Docker (Python 3.11-slim-bookworm base)
+- **Containerization:** Production Docker image uses Python 3.11-slim-bookworm; development container uses Python 3.13-bookworm
 
 ## Project Structure
 
@@ -174,7 +174,7 @@ def test_function_error():
 ## Recipe System
 
 ### Recipe File Format
-Recipes use YAML with `.wrgl.yml` or `.wrgl.yaml` extensions:
+Recipes use YAML with `.wrgl.yml`, `.wrgl.yaml` or `.recipe` extensions:
 
 ```yaml
 read:
@@ -198,10 +198,10 @@ wrangles.recipe recipe.wrgl.yml
 
 # From Python
 import wrangles
-wrangles.recipe.run('recipe.wrgl.yml')
+wrangles.recipe.run('my_recipe.wrgl.yml')
 
 # With custom functions
-wrangles.recipe recipe.wrgl.yml -f custom_functions.py
+wrangles.recipe my_other_recipe.recipe -f custom_functions.py
 ```
 
 ### Custom Functions
@@ -214,8 +214,8 @@ Custom functions can be added to recipes:
 
 ### GitHub Actions Workflows
 - **publish-main.yml:** Main CI pipeline
-  - Pytest on multiple OS (Ubuntu, Windows, macOS-14, macOS-latest)
-  - Tests Python 3.11, 3.12, 3.13
+  - Pytest on multiple OS (Ubuntu, Windows)
+  - Tests Python 3.11, 3.13
   - Test pip installation
   - Generate and test JSON schema
   - Build and push Docker image

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,7 @@
 - **Cloud/External:** boto3 (AWS S3), simple-salesforce, fabric (SFTP)
 - **Data Formats:** openpyxl (Excel), xlsxwriter
 - **AI/ML:** OpenAI integration, Hugging Face models
-- **Testing:** pytest (7.4.4), pytest-mock, lorem (test data generation)
+- **Testing:** pytest (9.0.2), pytest-mock, lorem (test data generation)
 - **Containerization:** Docker (Python 3.11-slim-bookworm base)
 
 ## Project Structure
@@ -57,11 +57,12 @@ WranglesPY/
 
 ## Installation & Setup
 
-### Standard Installation
+### Development Installation
 ```bash
 pip install --upgrade pip
-pip install pytest==7.4.4 lorem pytest-mock
-pip install -r requirements.txt
+pip install pytest==9.0.2 pytest-mock
+pip install -r requirements-full.txt
+pip install -e .
 ```
 
 ### macOS-specific Requirements
@@ -74,9 +75,9 @@ pip install -r requirements.txt
 
 ### Development Container
 The project includes a `.devcontainer/devcontainer.json` for VS Code:
-- Base image: `mcr.microsoft.com/devcontainers/python:1-3.12-bullseye`
-- Auto-installs pytest, lorem, pytest-mock on creation
-- Includes YAML schema validation for `.wrgl.yml` files
+- Base image: `mcr.microsoft.com/devcontainers/python:1-3.13-bookworm`
+- Auto-installs the full test dependencies and the package in editable mode
+- Includes YAML schema validation for `.wrgl.yml` and `.recipe` files
 - Configured for pytest test discovery
 
 ## Testing


### PR DESCRIPTION
1. Update devcontainer.json to current environment and extensions
2. Adopt linux line end convention so that  local windows development does create back & forth line end diffs. 