### PR TITLE
Fix recipe schema so nested recipe: wrangles accept where

### DIFF
--- a/schema/generate_recipe_schema.py
+++ b/schema/generate_recipe_schema.py
@@ -158,24 +158,28 @@ getMethodDocs(schema['wrangles'], wrangles.recipe._recipe_wrangles, '')
 
 # Add common wrangle properties
 for wrangle in schema['wrangles']:
-    if "properties" not in schema['wrangles'][wrangle]:
-        schema['wrangles'][wrangle]["properties"] = {}
+    if "properties" in schema['wrangles'][wrangle]:
+        wrangle_properties = schema['wrangles'][wrangle]['properties']
+    else:
+        # Wrangles defined with a top-level anyOf (e.g. recipe, which is
+        # recursive) keep their properties in the final anyOf branch
+        wrangle_properties = schema['wrangles'][wrangle]['anyOf'][-1]['properties']
 
-    schema['wrangles'][wrangle]['properties']["if"] = {
+    wrangle_properties["if"] = {
         "$ref": f"#/$defs/wrangles/commonProperties/if"
     }
 
     if wrangle not in wrangles.config.where_not_implemented:
         if wrangle in wrangles.config.where_overwrite_output:
-            schema['wrangles'][wrangle]['properties']['where'] = {
+            wrangle_properties['where'] = {
                 "$ref": "#/$defs/wrangles/commonProperties/where_special"
             }
         else:
-            schema['wrangles'][wrangle]['properties']['where'] = {
+            wrangle_properties['where'] = {
                 "$ref": "#/$defs/wrangles/commonProperties/where"
             }
 
-        schema['wrangles'][wrangle]['properties']["where_params"] = {
+        wrangle_properties["where_params"] = {
             "$ref": f"#/$defs/wrangles/commonProperties/where_params"
         }
 

--- a/schema/recipe_base_schema.json
+++ b/schema/recipe_base_schema.json
@@ -63,6 +63,15 @@
     "alias": {
       "type": "array",
       "description": "Placeholder to store YAML anchor values for use with aliases elsewhere in the recipe"
+    },
+    "where": {
+      "$ref": "#/$defs/wrangles/commonProperties/where"
+    },
+    "where_params": {
+      "$ref": "#/$defs/wrangles/commonProperties/where_params"
+    },
+    "if": {
+      "$ref": "#/$defs/wrangles/commonProperties/if"
     }
   },
   "$defs": {


### PR DESCRIPTION
## Summary
- The `recipe` wrangle (used to run a sub-recipe/"recipe-ception") is the only wrangle whose docstring schema uses a top-level `anyOf` instead of a plain `properties` block, since it's recursive.
- `schema/generate_recipe_schema.py`'s common-property injection loop assumed every wrangle has a top-level `properties` key, so `where`/`where_params`/`if` were silently added to an orphan `properties` dict that the validator never consulted for `recipe`.
- Result: valid recipes using `where` on a nested `recipe:` wrangle were rejected by the generated JSON schema (IDE/editor validation), even though it works correctly at runtime.

## Fix
- `schema/generate_recipe_schema.py`: fall back to merging common properties into the last `anyOf` branch's `properties`, matching the existing pattern already used for `read`/`write` wrangles.
- `schema/recipe_base_schema.json`: added `where`/`where_params`/`if` as optional root properties, since the recursive `$ref: "#"` branch (inline nested recipe) points back at the root schema.