### PR TITLE
Prevent recipe wrangle from writing partial batches

### DIFF
--- a/tests/connectors/test_recipe.py
+++ b/tests/connectors/test_recipe.py
@@ -137,6 +137,42 @@ def test_wrangles():
     )
     assert df["header1"][0] == "VALUE1"
 
+
+def test_recipe_wrangle_in_batch_does_not_write_partial_batches():
+    """
+    Test that a recipe used as a wrangle does not run its own write step
+    once per batch. The outer recipe should write the final combined result.
+    """
+    memory.clear()
+
+    wrangles.recipe.run(
+        """
+        read:
+          - test:
+              rows: 1000
+              values:
+                header1: value1
+        wrangles:
+          - batch:
+              batch_size: 100
+              wrangles:
+                - recipe:
+                    wrangles:
+                      - convert.case:
+                          input: header1
+                          case: upper
+                    write:
+                      - memory:
+                          id: partial_recipe_write
+        write:
+          - memory:
+              id: final_recipe_write
+        """
+    )
+
+    assert "partial_recipe_write" not in memory.dataframes
+    assert len(memory.dataframes["final_recipe_write"]["data"]) == 1000
+
 def test_write():
     """
     Test write defined within the recipe

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -1452,7 +1452,7 @@ def recipe(
     input: _Union[str, int, list] = None,
     output: _Union[str, list] = None,
     name: str = None,
-    variables = {},
+    variables = None,
     functions: _Union[_types.FunctionType, list] = [],
     **kwargs
 ) -> _pd.DataFrame:
@@ -1472,6 +1472,8 @@ def recipe(
             type: object
             description: A dictionary of variables to pass to the recipe
     """
+    if variables is None:
+        variables = {}
     if not name: name = kwargs
 
     df_temp = df.copy() # copy of the original df
@@ -1484,18 +1486,25 @@ def recipe(
     if output is None and input is not None:
         output = input
 
+    recipe_object, functions = _recipe._load_recipe(
+        name,
+        variables=variables,
+        functions=functions
+    )
+    recipe_object.pop('write', None)
+
     # If output columns are specified, only apply to those
     if output:
         if not isinstance(output, list): output = [output]
         df[output] = _recipe.run(
-            name,
+            recipe_object,
             variables=variables,
             functions=functions,
             dataframe=df_temp
         )[output]
     else:
         df = _recipe.run(
-            name,
+            recipe_object,
             variables=variables,
             functions=functions,
             dataframe=df_temp


### PR DESCRIPTION
## Summary
- Prevent nested recipe writes from running when ecipe is used as a wrangle.
- Fix batch scenarios where an attached recipe with its own write step overwrote spreadsheet output once per batch, leaving only the final partial batch.
- Add regression coverage for 1000 input rows with atch_size: 100, ensuring only the outer final write persists all 1000 rows.

## Tests
- Targeted recipe connector tests passed: 12 passed, 2 deselected.
- Targeted batch tests passed: 6 passed.
- python -m py_compile wrangles/recipe_wrangles/main.py tests/connectors/test_recipe.py passed.