### PR TITLE
Accumulate batched Excel sheet writes

### DIFF
--- a/tests/connectors/test_excel.py
+++ b/tests/connectors/test_excel.py
@@ -1,4 +1,5 @@
 import wrangles
+import pandas as pd
 from wrangles.connectors import memory
 
 
@@ -31,3 +32,72 @@ def test_default_write():
         data["columns"] == ["header1", "header2"] and
         len(data["data"]) == 5
     )
+
+
+def test_recipe_wrangle_in_batch_writes_all_rows_to_excel_sheet():
+    """
+    Test the WranglesXL output connector path when a recipe wrangle is used
+    inside a batch. The Excel sheet output should receive the full combined
+    dataframe, not only one batch.
+    """
+    memory.clear()
+    wrangles.recipe.run(
+        """
+        read:
+          - test:
+              rows: 1000
+              values:
+                header1: value1
+        wrangles:
+          - batch:
+              batch_size: 100
+              wrangles:
+                - recipe:
+                    wrangles:
+                      - convert.case:
+                          input: header1
+                          case: upper
+                    write:
+                      - excel.sheet:
+                          name: Partial
+        write:
+          - excel.sheet:
+              name: Final
+        """
+    )
+
+    excel_outputs = [
+        v
+        for v in memory.dataframes.values()
+        if v.get("connector") == "excel.sheet.write"
+    ]
+    memory.clear()
+
+    assert len(excel_outputs) == 1
+    assert excel_outputs[0]["name"] == "Final"
+    assert len(excel_outputs[0]["data"]) == 1000
+
+
+def test_excel_sheet_append_accumulates_repeated_writes():
+    """
+    WranglesXL may receive repeated writes to the same sheet when work is
+    batched. Default append behavior should accumulate rows in one payload.
+    """
+    memory.clear()
+    df = pd.DataFrame({"header1": ["value1"] * 1000})
+    for start in range(0, 1000, 100):
+        wrangles.connectors.excel.sheet.write(
+            df.iloc[start:start + 100],
+            name="Results"
+        )
+
+    excel_outputs = [
+        v
+        for v in memory.dataframes.values()
+        if v.get("connector") == "excel.sheet.write"
+    ]
+    memory.clear()
+
+    assert len(excel_outputs) == 1
+    assert excel_outputs[0]["name"] == "Results"
+    assert len(excel_outputs[0]["data"]) == 1000

--- a/wrangles/connectors/excel.py
+++ b/wrangles/connectors/excel.py
@@ -11,6 +11,25 @@ class sheet():
     def write(df: _pd.DataFrame, **kwargs):
         _logging.info(f": Saving data for Excel Sheet")
 
+        action = kwargs.get("action", "append")
+        name = kwargs.get("name")
+        cell = kwargs.get("cell")
+
+        if action == "append":
+            for saved in reversed(list(_memory.dataframes.values())):
+                if (
+                    isinstance(saved, dict)
+                    and saved.get("connector") == "excel.sheet.write"
+                    and saved.get("name") == name
+                    and saved.get("cell") == cell
+                    and saved.get("action", "append") == "append"
+                    and saved.get("columns") == df.columns.tolist()
+                ):
+                    new_data = df.to_dict(orient="split")
+                    saved["data"].extend(new_data["data"])
+                    saved["index"].extend(new_data["index"])
+                    return
+
         _memory.write(
             df,
             connector = "excel.sheet.write",


### PR DESCRIPTION
## Summary
- Accumulate repeated excel.sheet writes to the same sheet when action is the default append.
- Handles WranglesXL batch flows where each batch emits a 100-row sheet payload, so the connector returns one combined output instead of separate partial outputs.
- Add XL-specific regression coverage for 1000 rows written in 100-row chunks.

## Tests
- Targeted Excel and recipe connector tests passed: 15 passed, 2 deselected.