### PR TITLE
Append Excel sheet output after first XL batch

### DIFF
--- a/tests/connectors/test_excel.py
+++ b/tests/connectors/test_excel.py
@@ -129,3 +129,42 @@ def test_excel_sheet_overwrite_accumulates_repeated_writes():
     assert excel_outputs[0]["name"] == "Results"
     assert excel_outputs[0]["action"] == "overwrite"
     assert len(excel_outputs[0]["data"]) == 1000
+
+
+def test_excel_sheet_overwrite_uses_append_after_first_external_batch():
+    """
+    WranglesXL can execute each batch as a separate Python run. In that case,
+    in-memory accumulation is not available, so later overwrite batches must be
+    returned as append actions.
+    """
+    df = pd.DataFrame({"header1": ["value1"] * 100})
+
+    memory.clear()
+    wrangles.connectors.excel.sheet.write(
+        df,
+        name="Results",
+        action="overwrite",
+        variables={"batch_number": 1, "batch_total": 10}
+    )
+    first_batch = [
+        v
+        for v in memory.dataframes.values()
+        if v.get("connector") == "excel.sheet.write"
+    ][0]
+
+    memory.clear()
+    wrangles.connectors.excel.sheet.write(
+        df,
+        name="Results",
+        action="overwrite",
+        variables={"batch_number": 2, "batch_total": 10}
+    )
+    second_batch = [
+        v
+        for v in memory.dataframes.values()
+        if v.get("connector") == "excel.sheet.write"
+    ][0]
+    memory.clear()
+
+    assert first_batch["action"] == "overwrite"
+    assert second_batch["action"] == "append"

--- a/wrangles/connectors/excel.py
+++ b/wrangles/connectors/excel.py
@@ -8,10 +8,24 @@ import logging as _logging
 class sheet():
     _schema = {}
 
-    def write(df: _pd.DataFrame, **kwargs):
+    def write(df: _pd.DataFrame, variables: dict = None, **kwargs):
         _logging.info(f": Saving data for Excel Sheet")
 
+        if variables is None:
+            variables = {}
+
         action = kwargs.get("action", "append")
+        try:
+            batch_number = int(variables.get("batch_number", 1))
+            batch_total = int(variables.get("batch_total", 1))
+        except (TypeError, ValueError):
+            batch_number = 1
+            batch_total = 1
+
+        if action == "overwrite" and batch_total > 1 and batch_number > 1:
+            kwargs["action"] = "append"
+            action = "append"
+
         name = kwargs.get("name")
         cell = kwargs.get("cell")
 


### PR DESCRIPTION
## Summary
- Make excel.sheet.write aware of WranglesXL external batch variables.
- Preserve action: overwrite for batch 1 so the sheet is replaced first.
- Convert action: overwrite to action: append for batch 2+ when batch_total > 1, so separate XL chunk executions append instead of replacing previous chunks.
- Add regression coverage for first and second external batch behavior.

## Tests
- PYTHONPATH=. pytest tests/connectors/test_excel.py -q
- Result: 5 passed.
- python -m py_compile wrangles/connectors/excel.py tests/connectors/test_excel.py