### PR TITLE
Combine extract.custom hotfixes for dev

### DIFF
--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -99,7 +99,7 @@ class TestExtractAddress:
             where: elevation > 2000
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output'] == "" and df.iloc[1]['output'] == '742 Evergreen St'
+        assert df.iloc[0]['output'] == "" and df.iloc[1]['output'] == ['742 Evergreen St']
         
     
     def test_address_multi_input(self):
@@ -1106,7 +1106,7 @@ class TestExtractCustom:
             model_id: 1eddb7e8-1b2b-4a52
         """
         df =  wrangles.recipe.run(recipe, dataframe=data)
-        assert df['Fact Out'][0] == 'Charizard'
+        assert df['Fact Out'][0] == ['Charizard']
 
     def test_extract_custom_3(self):
         """
@@ -1313,6 +1313,32 @@ class TestExtractCustom:
         assert df.iloc[1]['colour'] == ['red']
         assert df.iloc[1]['size'] == ['large']
 
+    def test_extract_custom_multi_input_single_output_preserves_match_lists(self):
+        data = pd.DataFrame({
+            'Colm 1': ['one, two'],
+            'Colm 2': ['three four']
+        })
+        recipe = """
+        wrangles:
+        - extract.custom:
+            input:
+              - Colm 1
+              - Colm 2
+            output: my_output_colm
+            model_id: 73d89595-e5c9-40a4
+        """
+
+        with patch(
+            "wrangles.extract.custom",
+            side_effect=[
+                [['one', 'two']],
+                [['three', 'four']],
+            ]
+        ):
+            df = wrangles.recipe.run(recipe, dataframe=data)
+
+        assert df.iloc[0]['my_output_colm'] == ['one', 'two', 'three', 'four']
+
     def test_extract_custom_mulit_input_output(self):
         """
         Multiple output and inputs
@@ -1355,7 +1381,7 @@ class TestExtractCustom:
             where: col1 LIKE col2
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['output col'] == "" and df.iloc[2]['output col'] == 'Charizard'
+        assert df.iloc[0]['output col'] == "" and df.iloc[2]['output col'] == ['Charizard', 'Pikachu']
 
     def test_extract_custom_multi_io_where(self):
         """
@@ -2767,7 +2793,7 @@ class TestExtractHTML:
             data_type: links
         """
         df = wrangles.recipe.run(recipe, dataframe=self.df)
-        assert df.iloc[0]['Links'] == 'https://www.wrangleworks.com/'
+        assert df.iloc[0]['Links'] == ['https://www.wrangleworks.com/']
 
     def test_extract_html_where(self):
         """
@@ -2860,9 +2886,9 @@ class TestExtractBrackets:
 
     def test_extract_brackets_single_item_output_list(self):
         """
-        Providing output as an explicit single-item list implies
-        Columns format - only as many matches as named columns are
-        kept, any additional matches are dropped
+        Providing output as an explicit single-item list should behave
+        the same as a bare string output - the full list of matches is
+        kept, not just the first one
         """
         data = pd.DataFrame({
             'col': ['(a) (b) (c)']
@@ -2875,7 +2901,7 @@ class TestExtractBrackets:
                 - col1
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['col1'] == 'a' and list(df.columns) == ['col', 'col1']
+        assert df.iloc[0]['col1'] == ['a', 'b', 'c'] and list(df.columns) == ['col', 'col1']
 
     def test_extract_brackets_single_item_output_list_no_matches(self):
         """
@@ -2893,7 +2919,7 @@ class TestExtractBrackets:
                 - col1
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
-        assert df.iloc[0]['col1'] == "" and 'col1' in df.columns
+        assert df.iloc[0]['col1'] == [] and 'col1' in df.columns
 
     def test_extract_brackets_2(self):
         """

--- a/wrangles/extract.py
+++ b/wrangles/extract.py
@@ -526,10 +526,26 @@ def custom(
 
     if isinstance(results, dict) and "data" in results and "columns" in results:
         if len(results["columns"]) == 1:
-            results = [
-                row[0]
-                for row in results["data"]
-            ]
+            # For a single output column, the service returns the matches
+            # as a ", " joined string rather than an array. Convert this
+            # back into a list of matches to preserve the expected output type.
+            def _entities_to_list(value):
+                if isinstance(value, list):
+                    return value
+                if value in (None, ""):
+                    return []
+                return [item.strip() for item in value.split(",")]
+
+            if use_labels:
+                results = [
+                    {results["columns"][0]: _entities_to_list(row[0])}
+                    for row in results["data"]
+                ]
+            else:
+                results = [
+                    _entities_to_list(row[0])
+                    for row in results["data"]
+                ]
         else:
             results = [
                 {results["columns"][i]: row[i] for i in range(len(row))}

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -8,7 +8,6 @@ import pandas as _pd
 from .. import extract as _extract
 from .. import data as _data
 
-
 _OUTPUT_FORMAT_ALIASES = {
     "json": "json",
     "json list": "json_list",
@@ -188,7 +187,6 @@ def _combine_list_rows(rows):
             combined.append(row)
     return list(dict.fromkeys(combined))
 
-
 def _combine_dict_rows(rows):
     combined = {}
     for row in rows:
@@ -198,7 +196,6 @@ def _combine_dict_rows(rows):
             values = value if isinstance(value, list) else [value]
             combined[key] = _combine_list_rows([combined.get(key, []), values])
     return combined
-
 
 def address(
     df: _pd.DataFrame,
@@ -250,7 +247,7 @@ def address(
     if output is None: output = input
 
     # Whether output was explicitly given as a list of column names
-    output_is_list = isinstance(output, list)
+    output_is_list = isinstance(output, list) and len(output) > 1
 
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
@@ -610,7 +607,7 @@ def attributes(
     if output is None: output = input
 
     # Whether output was explicitly given as a list of column names
-    output_is_list = isinstance(output, list)
+    output_is_list = isinstance(output, list) and len(output) > 1
 
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
@@ -734,7 +731,7 @@ def brackets(
     if output is None: output = input
 
     # Whether output was explicitly given as a list of column names
-    output_is_list = isinstance(output, list)
+    output_is_list = isinstance(output, list) and len(output) > 1
 
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
@@ -882,7 +879,7 @@ def codes(
     if output is None: output = input
 
     # Whether output was explicitly given as a list of column names
-    output_is_list = isinstance(output, list)
+    output_is_list = isinstance(output, list) and len(output) > 1
 
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
@@ -1003,7 +1000,7 @@ def custom(
     if output is None: output = input
 
     # Whether output was explicitly given as a list of column names
-    output_is_list = isinstance(output, list)
+    output_is_list = isinstance(output, list) and len(output) > 1
 
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
@@ -1326,7 +1323,7 @@ def html(
     if output is None: output = input
 
     # Whether output was explicitly given as a list of column names
-    output_is_list = isinstance(output, list)
+    output_is_list = isinstance(output, list) and len(output) > 1
 
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
@@ -1420,7 +1417,7 @@ def properties(
     if output is None: output = input
 
     # Whether output was explicitly given as a list of column names
-    output_is_list = isinstance(output, list)
+    output_is_list = isinstance(output, list) and len(output) > 1
 
     # If a string provided, convert to list
     if not isinstance(input, list): input = [input]
@@ -1546,7 +1543,7 @@ def regex(
         output = input
 
     # Whether output was explicitly given as a list of column names
-    output_is_list = isinstance(output, list)
+    output_is_list = isinstance(output, list) and len(output) > 1
 
     # If a string is provided, convert to list
     if not isinstance(input, list):
@@ -1583,4 +1580,3 @@ def regex(
             _write_regex(input_column, [output_column])
 
     return df
-


### PR DESCRIPTION
## Summary

Combines the two extract.custom hotfix branches into one PR targeting dev.

## Changes

- Preserves list output from extract.custom when the service returns single-column data as a string.
- Keeps explicit single-item output lists as list-style outputs instead of forcing columns output.
- Fixes multi-input/single-output extract.custom merging so per-input match lists are combined into one de-duplicated output list.
- Keeps labeled multi-input output_format: Columns behavior working.

## Testing

```powershell
$env:PYTHONPATH='.'; pytest tests\recipes\wrangles\test_extract.py::TestExtractCustom::test_extract_custom_multi_input_single_output_preserves_match_lists tests\recipes\wrangles\test_extract.py::TestExtractCustom::test_extract_custom_use_labels_output_format_columns_multi_input tests\recipes\wrangles\test_extract.py::TestExtractBrackets::test_extract_brackets_single_item_output_list tests\recipes\wrangles\test_extract.py::TestExtractBrackets::test_extract_brackets_single_item_output_list_no_matches -q
```

Result: 4 passed.