### PR TITLE
change log ouput

### DIFF
--- a/tests/recipes/test_wrangles.py
+++ b/tests/recipes/test_wrangles.py
@@ -560,8 +560,11 @@ class TestIf:
         # Check that only the executed wrangle appears in logs  
         log_messages = [msg for msg in caplog.messages if "Wrangling ::" in msg]  
 
-        assert any(": Wrangling :: convert.case :: Completed :: col1 >> should_be_logged" in msg for msg in log_messages)
-        assert not any(": Wrangling :: convert.case :: Completed :: col1 >> should_not_be_logged" in msg for msg in log_messages)  
+        assert any(
+            ": Wrangling :: convert.case :: col1 >> should_be_logged ::" in msg and msg.endswith("Completed")
+            for msg in log_messages
+        )
+        assert not any(": Wrangling :: convert.case :: col1 >> should_not_be_logged" in msg for msg in log_messages)
         assert df['should_be_logged'][0] == 'VALUE'  
         assert 'should_not_be_logged' not in df.columns
 

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -8229,9 +8229,10 @@ class TestWrangleExecutionLogging:
             """,  
             dataframe=pd.DataFrame({'Col1': ['hello']})  
         )  
-        assert ": Wrangling :: convert.case :: Completed :: Col1 >> Col2" in caplog.messages[-1]
+        assert ": Wrangling :: convert.case :: Col1 >> Col2 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
 
-    def test_dynamic_output_logging(self, caplog):  
+    def test_dynamic_output_logging(self, caplog):
         """  
         Test logging with dynamic output (new columns created)  
         """  
@@ -8245,9 +8246,10 @@ class TestWrangleExecutionLogging:
             """,  
             dataframe=pd.DataFrame({'Col1': ['hello world']}),   
         )  
-        assert ": Wrangling :: split.text :: Completed :: Col1 >> Col1, Col2" in caplog.messages[-1]
+        assert ": Wrangling :: split.text :: Col1 >> Col1, Col2 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
 
-    def test_skipped_wrangle_logging(self, caplog):  
+    def test_skipped_wrangle_logging(self, caplog):
         """  
         Test logging when wrangle is skipped due to if condition  
         """  
@@ -8267,8 +8269,9 @@ class TestWrangleExecutionLogging:
             dataframe=pd.DataFrame({'Col1': ['hello']})  
         )  
         assert any(": Wrangling :: convert.case skipped due to not passing the if statement." in msg for msg in caplog.messages)
-        assert ": Wrangling :: convert.case :: Completed :: Col1 >> Col3" in caplog.messages[-1]   
-      
+        assert ": Wrangling :: convert.case :: Col1 >> Col3 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
+
     def test_mixed_output_logging(self, caplog):  
         """  
         Test logging with mixed output types (strings and dicts)  
@@ -8284,8 +8287,9 @@ class TestWrangleExecutionLogging:
             """,  
             dataframe=pd.DataFrame({'col1': ['test']}),  
         )  
-        assert ": Wrangling :: create.column :: Completed :: None >> col2, col3, col4" in caplog.messages[-1]  
-      
+        assert ": Wrangling :: create.column :: None >> col2, col3, col4 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
+
     def test_backward_compatibility_logging(self, caplog):  
         """  
         Test that default logging still shows 'Dynamic' for backward compatibility  
@@ -8301,7 +8305,8 @@ class TestWrangleExecutionLogging:
             dataframe=pd.DataFrame({'Col1': ['hello world']})  
         )  
         print(df)
-        assert ": Wrangling :: split.text :: Completed :: Col1 >> Col1, Col2" in caplog.messages[-1]
+        assert ": Wrangling :: split.text :: Col1 >> Col1, Col2 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
 
     def test_input_overwrite_logging(self, caplog):  
         """  
@@ -8316,7 +8321,8 @@ class TestWrangleExecutionLogging:
             """,  
             dataframe=pd.DataFrame({'Col1': ['hello']}),  
         )  
-        assert ": Wrangling :: convert.case :: Completed :: Col1 >> Col1" in caplog.messages[-1]
+        assert ": Wrangling :: convert.case :: Col1 >> Col1 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
 
     def test_output_wildcard_string_logging(_self, caplog):
         df = wrangles.recipe.run(
@@ -8331,7 +8337,8 @@ class TestWrangleExecutionLogging:
                 'Col': [["Hello", "Wrangles!", "and", "World!"]]
             })
         )
-        assert ": Wrangling :: split.list :: Completed :: Col >> Col, Col1, Col2, Col3, Col4" in caplog.messages[-1]
+        assert ": Wrangling :: split.list :: Col >> Col, Col1, Col2, Col3, Col4 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
     
     def test_logging_wildcard_multi_list_no_expansion(self, caplog):  
         """  
@@ -8358,13 +8365,18 @@ class TestWrangleExecutionLogging:
         )  
 
         # Check that the wildcard is not expanded (appears as literal)
-        assert any('Completed :: col1, col2 >> col*, other' in message for message in caplog.messages)
+        assert any(
+            'col1, col2 >> col*, other ::' in message and message.endswith('Completed')
+            for message in caplog.messages
+        )
 
     def test_multiple_wrangles_logging(self, caplog):
         """
         Test that Starting and Completed messages are logged for each wrangle
         in a multi-step recipe, in the correct order.
         """
+        import logging
+        caplog.set_level(logging.DEBUG)
         wrangles.recipe.run(
             """
             wrangles:
@@ -8393,11 +8405,14 @@ class TestWrangleExecutionLogging:
 
         # Verify order: Starting then Completed for each wrangle
         assert ': Wrangling :: convert.case :: Starting' in wrangle_logs[0]
-        assert ': Wrangling :: convert.case :: Completed :: col1 >> col2' in wrangle_logs[1]
+        assert ': Wrangling :: convert.case :: col1 >> col2 ::' in wrangle_logs[1]
+        assert wrangle_logs[1].endswith('Completed')
         assert ': Wrangling :: merge.concatenate :: Starting' in wrangle_logs[2]
-        assert ': Wrangling :: merge.concatenate :: Completed :: col1, col2 >> col3' in wrangle_logs[3]
+        assert ': Wrangling :: merge.concatenate :: col1, col2 >> col3 ::' in wrangle_logs[3]
+        assert wrangle_logs[3].endswith('Completed')
         assert ': Wrangling :: convert.case :: Starting' in wrangle_logs[4]
-        assert ': Wrangling :: convert.case :: Completed :: col3 >> col4' in wrangle_logs[5]
+        assert ': Wrangling :: convert.case :: col3 >> col4 ::' in wrangle_logs[5]
+        assert wrangle_logs[5].endswith('Completed')
 
     def test_completed_log_includes_duration(self, caplog):
         """
@@ -8416,15 +8431,17 @@ class TestWrangleExecutionLogging:
         )
         completed_msg = next(
             msg for msg in caplog.messages
-            if ': Wrangling :: convert.case :: Completed ::' in msg
+            if ': Wrangling :: convert.case ::' in msg
         )
-        assert re.search(r'::\s*\d+\.\d{3}s$', completed_msg), \
-            f"Expected duration suffix like ':: 0.001s' in: {completed_msg}"
+        assert re.search(r'::\s*\d+\.\d{3}s Completed$', completed_msg), \
+            f"Expected duration suffix like ':: 0.001s Completed' in: {completed_msg}"
 
     def test_starting_log_single_wrangle(self, caplog):
         """
         Test that a Starting message is logged before Completed for a single wrangle.
         """
+        import logging
+        caplog.set_level(logging.DEBUG)
         wrangles.recipe.run(
             """
             wrangles:
@@ -8438,7 +8455,7 @@ class TestWrangleExecutionLogging:
         wrangle_logs = [msg for msg in caplog.messages if ': Wrangling :: convert.case ::' in msg]
         assert len(wrangle_logs) == 2
         assert ': Wrangling :: convert.case :: Starting' in wrangle_logs[0]
-        assert ': Wrangling :: convert.case :: Completed ::' in wrangle_logs[1]
+        assert wrangle_logs[1].endswith('Completed')
 
 
 @pytest.mark.usefixtures("caplog")

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -547,7 +547,7 @@ def _execute_wrangles(
                     if key in params.keys():
                         common_params[key] = params.pop(key)
 
-                _logging.info(f": Wrangling :: {wrangle} :: Starting")
+                _logging.debug(f": Wrangling :: {wrangle} :: Starting")
                 _wrangle_start_time = _time.perf_counter()
 
                 if wrangle.split('.')[0] == 'pandas':
@@ -834,7 +834,7 @@ def _execute_wrangles(
                             
                         output_display = ', '.join(str(col) for col in output_columns)
                         _wrangle_elapsed = _time.perf_counter() - _wrangle_start_time
-                        _logging.info(f": Wrangling :: {wrangle} :: Completed :: {input_display} >> {output_display} :: {_wrangle_elapsed:.3f}s")
+                        _logging.info(f": Wrangling :: {wrangle} :: {input_display} >> {output_display} :: {_wrangle_elapsed:.3f}s Completed")
 
             except Exception as e:
                 # Append name of wrangle to message and pass through exception


### PR DESCRIPTION
## Summary

Changes the per-wrangle execution log output during a recipe run:

- The `Starting` log for each wrangle step is now emitted at `DEBUG` level instead of `INFO`, so it no longer shows up by default — only the `Completed` summary does.
- The `Completed` log message moves the `Completed` marker to the **end** of the line, after the duration, instead of directly after the wrangle name.

Also updates the existing wrangle-logging test suite (`tests/recipes/test_wrangles.py`, `tests/recipes/wrangles/test_main.py`) to assert against the new message format, and to opt in to `DEBUG` level where a test specifically needs to observe the `Starting` message.

## Before / After

**Default (INFO) log output for a recipe with one `convert.case` step:**

Before:
```
INFO : Wrangling :: convert.case :: Starting
INFO : Wrangling :: convert.case :: Completed :: Col1 >> Col2 :: 0.001s
```

After:
```
INFO : Wrangling :: convert.case :: Col1 >> Col2 :: 0.001s Completed
```

(`Starting` is still emitted, but only visible when logging is configured at `DEBUG` level.)

**Multi-step recipe, at `DEBUG` level:**

Before:
```
INFO  : Wrangling :: convert.case :: Starting
INFO  : Wrangling :: convert.case :: Completed :: col1 >> col2 :: 0.001s
INFO  : Wrangling :: merge.concatenate :: Starting
INFO  : Wrangling :: merge.concatenate :: Completed :: col1, col2 >> col3 :: 0.002s
```

After:
```
DEBUG : Wrangling :: convert.case :: Starting
INFO  : Wrangling :: convert.case :: col1 >> col2 :: 0.001s Completed
DEBUG : Wrangling :: merge.concatenate :: Starting
INFO  : Wrangling :: merge.concatenate :: col1, col2 >> col3 :: 0.002s Completed
```

## Why

Trims default (`INFO`-level) recipe output down to one line per wrangle step — the completion line already contains everything the start line did (wrangle name, timing) plus the outcome, so the separate `Starting` line was redundant noise for anyone not debugging step-by-step. It's kept at `DEBUG` for cases where interleaving/ordering across steps still needs to be inspected.

## Code changes

`wrangles/recipe.py`, in `_execute_wrangles`:

```diff
-                _logging.info(f": Wrangling :: {wrangle} :: Starting")
+                _logging.debug(f": Wrangling :: {wrangle} :: Starting")
                 _wrangle_start_time = _time.perf_counter()
...
-                        _logging.info(f": Wrangling :: {wrangle} :: Completed :: {input_display} >> {output_display} :: {_wrangle_elapsed:.3f}s")
+                        _logging.info(f": Wrangling :: {wrangle} :: {input_display} >> {output_display} :: {_wrangle_elapsed:.3f}s Completed")
```
