### PR TITLE
1104 distinguish authentication failures 401 from model authorization failures 403

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,82 @@
+import pytest
+
+import wrangles.data as data
+
+
+class FakeResponse:
+    def __init__(self, status_code, body=None):
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+MODEL_ID = "93d92b4c-9f49-4ff5"
+
+
+def _mock_model_response(monkeypatch, response):
+    monkeypatch.setattr(data._auth, "get_access_token", lambda: "token")
+    monkeypatch.setattr(data._utils, "request_retries", lambda **kwargs: response)
+
+
+@pytest.mark.parametrize(
+    "call_model_endpoint",
+    [
+        lambda: data.model(MODEL_ID),
+        lambda: data.model_update(MODEL_ID, {"name": "Updated model"}),
+        lambda: data.model_content(MODEL_ID),
+    ],
+)
+def test_model_endpoints_raise_authentication_error_for_401(monkeypatch, call_model_endpoint):
+    _mock_model_response(monkeypatch, FakeResponse(401))
+
+    with pytest.raises(data.AuthenticationError) as info:
+        call_model_endpoint()
+
+    assert isinstance(info.value, RuntimeError)
+    assert str(info.value) == (
+        f"Authentication failed while accessing model {MODEL_ID}. "
+        "The access token may have expired; refresh credentials and retry."
+    )
+
+
+@pytest.mark.parametrize(
+    "call_model_endpoint",
+    [
+        lambda: data.model(MODEL_ID),
+        lambda: data.model_update(MODEL_ID, {"name": "Updated model"}),
+        lambda: data.model_content(MODEL_ID),
+    ],
+)
+def test_model_endpoints_raise_authorization_error_for_403(monkeypatch, call_model_endpoint):
+    _mock_model_response(monkeypatch, FakeResponse(403))
+
+    with pytest.raises(data.AuthorizationError) as info:
+        call_model_endpoint()
+
+    assert isinstance(info.value, RuntimeError)
+    assert str(info.value) == (
+        f"Access denied to model {MODEL_ID}. Check the user's model permissions."
+    )
+
+
+def test_model_success_returns_metadata(monkeypatch):
+    metadata = {"id": MODEL_ID, "name": "Model"}
+    _mock_model_response(monkeypatch, FakeResponse(200, metadata))
+
+    assert data.model(MODEL_ID) == metadata
+
+
+def test_model_update_success_returns_none(monkeypatch):
+    _mock_model_response(monkeypatch, FakeResponse(204))
+
+    assert data.model_update(MODEL_ID, {"name": "Updated model"}) is None
+
+
+def test_model_content_success_returns_content(monkeypatch):
+    content = {"Settings": {}, "Columns": ["Key"], "Data": [["A"]]}
+    _mock_model_response(monkeypatch, FakeResponse(200, content))
+
+    assert data.model_content(MODEL_ID) == content

--- a/wrangles/data.py
+++ b/wrangles/data.py
@@ -6,6 +6,27 @@ from . import auth as _auth
 from . import utils as _utils
 
 
+class AuthenticationError(RuntimeError):
+    pass
+
+
+class AuthorizationError(RuntimeError):
+    pass
+
+
+def _raise_model_response_error(response, id: str, action: str) -> None:
+    if response.status_code == 401:
+        raise AuthenticationError(
+            f'Authentication failed while accessing model {id}. '
+            'The access token may have expired; refresh credentials and retry.'
+        )
+    if response.status_code == 403:
+        raise AuthorizationError(
+            f"Access denied to model {id}. Check the user's model permissions."
+        )
+    raise RuntimeError(f'Something went wrong trying to {action} model {id}')
+
+
 class user():
     """
     Get user data
@@ -48,10 +69,8 @@ def model(id: str):
             )
     if response.ok:
         return response.json()
-    elif response.status_code in [401, 403]:
-        raise RuntimeError(f'Access denied to model {id}')
     else:
-        raise RuntimeError(f'Something went wrong trying to access model {id}')
+        _raise_model_response_error(response, id, 'access')
 
 
 def model_update(id: str, metadata: dict) -> None:
@@ -70,10 +89,8 @@ def model_update(id: str, metadata: dict) -> None:
                     'json': metadata
                 }
             )
-    if response.status_code in [401, 403]:
-        raise RuntimeError(f'Access denied to model {id}')
-    elif not response.ok:
-        raise RuntimeError(f'Something went wrong trying to update model {id}')
+    if not response.ok:
+        _raise_model_response_error(response, id, 'update')
 
 
 def model_content(id: str, version_id: str = None) -> list:
@@ -97,7 +114,5 @@ def model_content(id: str, version_id: str = None) -> list:
             )
     if response.ok:
         return response.json()
-    elif response.status_code in [401, 403]:
-        raise RuntimeError(f'Access denied to model {id}')
     else:
-        raise RuntimeError(f'Something went wrong trying to access model {id}')
+        _raise_model_response_error(response, id, 'access')


### PR DESCRIPTION
## Summary

Distinguishes authentication failures from authorization failures when WranglesPY receives protected model endpoint errors.

Previously, HTTP `401 Unauthorized` and `403 Forbidden` responses from model/data endpoints both raised:

```text
Access denied to model {model_id}
```

That made expired or invalid access tokens look like model permission issues. This PR keeps the original HTTP meaning at the WranglesPY boundary.

## Changes

- Added `wrangles.data.AuthenticationError(RuntimeError)`
- Added `wrangles.data.AuthorizationError(RuntimeError)`
- Added shared model response error helper in `wrangles/data.py`
- Updated model/data functions to use distinct handling:
  - `401` raises `AuthenticationError`
  - `403` raises `AuthorizationError`
- Updated consistently across:
  - `wrangles.data.model`
  - `wrangles.data.model_update`
  - `wrangles.data.model_content`
- Added focused mocked tests for 401, 403, and successful responses
- Added release note for the improved diagnostic behavior

## User-Facing Behavior

HTTP `401` now raises:

```text
Authentication failed while accessing model {model_id}. The access token may have expired; refresh credentials and retry.
```

HTTP `403` now raises:

```text
Access denied to model {model_id}. Check the user's model permissions.
```

Both exceptions inherit from `RuntimeError`, so existing callers catching `RuntimeError` remain compatible.

## Testing

```bash
pytest tests/test_data.py -q
```

Result:

```text
9 passed
```

## Notes

This is compatible with API-Core's model endpoint behavior, where invalid/missing tokens return `401` and insufficient model permissions return `403`.

After release, Lambda-Recipes should update its pinned WranglesPY version and verify that the authentication-specific message reaches WranglesXL correctly.
