### PR TITLE
Fix extract.ai implicit input excluding output columns

### DIFF
--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -3498,6 +3498,50 @@ class TestExtractAI:
             result = wrangles.recipe.run(recipe, dataframe=df)
         assert result.iloc[0]["tags"] == "wrench | 25mm"
 
+    def test_ai_existing_output_column_is_not_used_as_implicit_input(self):
+        df = pd.DataFrame({
+            "data": [
+                "wrench 25mm",
+                "6m cable",
+                "screwdriver 3mm"
+            ],
+            "length": [123, 123, 123]
+        })
+        recipe = """
+        wrangles:
+        - extract.ai:
+            api_key: dummy
+            output:
+              length:
+                type: string
+                description: >-
+                  Any lengths found in the data
+                  such as cm, m, ft, etc.
+        """
+
+        with patch(
+            "wrangles.extract.ai",
+            return_value=[
+                {"length": "25mm"},
+                {"length": "6m"},
+                {"length": "3mm"}
+            ]
+        ) as mock_ai:
+            result = wrangles.recipe.run(recipe, dataframe=df)
+
+        assert mock_ai.call_args.kwargs["output"] == {
+            "length": {
+                "type": "string",
+                "description": "Any lengths found in the data such as cm, m, ft, etc."
+            }
+        }
+        assert mock_ai.call_args.args[0] == [
+            {"data": "wrench 25mm"},
+            {"data": "6m cable"},
+            {"data": "screwdriver 3mm"}
+        ]
+        assert result["length"].tolist() == ["25mm", "6m", "3mm"]
+
     def test_ai(self):
         """
         Test openai extract with a single input and output

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -400,15 +400,6 @@ def ai(
     """
     output_format_normalized = _normalize_output_format(output_format, "columns")
 
-    # If input is provided, extract only those columns
-    # Otherwise, provide the whole dataframe
-    if input is not None:
-        if not isinstance(input, list):
-            input = [input]
-        df_temp = df[input]
-    else:
-        df_temp = df
-    
     # Target columns will contain a list of column names
     # to insert to created results into
     target_columns = None
@@ -459,6 +450,20 @@ def ai(
     # If a schema has been provided, define the target columns
     if not target_columns and output is not None:
         target_columns = list(output.keys())
+
+    # If input is provided, extract only those columns. Otherwise, provide
+    # the whole dataframe except columns this wrangle is about to overwrite.
+    if input is not None:
+        if not isinstance(input, list):
+            input = [input]
+        df_temp = df[input]
+    else:
+        input_columns = [
+            column
+            for column in df.columns
+            if not target_columns or column not in target_columns
+        ]
+        df_temp = df[input_columns]
 
     results = _extract.ai(
         df_temp.to_dict(orient='records'),
@@ -1583,4 +1588,3 @@ def regex(
             _write_regex(input_column, [output_column])
 
     return df
-


### PR DESCRIPTION
## Summary

Fixes `extract.ai` recipe behavior when an output column already exists in the input dataframe.

Previously, if `extract.ai` was run without an explicit `input`, the entire dataframe was sent to the AI model, including columns that the wrangle was about to overwrite. This meant an existing output column value could influence the extraction result.

For example, an existing `length = 123` column could cause some rows to keep `123` instead of extracting values like `25mm` or `3mm` from the source text.

## Changes

- Updated `extract.ai` recipe handling so implicit input excludes target output columns.
- Preserved explicit `input:` behavior exactly as requested by the recipe.
- Added a mocked regression test covering an existing output column.
- Confirmed existing mocked output-format behavior still passes.

## Behavior

Given:

```yaml
wrangles:
- create.column:
    output: length
    value: 123

- extract.ai:
    model: gpt-4o-mini
    api_key: ${OPENAI_API_KEY}
    output:
      length:
        type: string
        description: Any lengths found in the data
```

`extract.ai` now sends only the source input columns to the model by default, not the pre-existing `length` output column.

Expected output:

```text
data              length
wrench 25mm       25mm
6m cable          6m
screwdriver 3mm   3mm
