### PR TITLE
Add value counts aggregation to select.group_by

### DIFF
--- a/tests/recipes/wrangles/test_select.py
+++ b/tests/recipes/wrangles/test_select.py
@@ -1940,6 +1940,27 @@ class TestGroupBy:
             list(df.values[1]) == ['b', [4], [8]]
         )
 
+    def test_group_by_value_counts_as_json_safe_dictionary(self):
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+              - select.group_by:
+                  counts:
+                    - Selection: Selection Counts
+                    - Review: Review Counts
+                  auto_rename_columns: false
+            """,
+            dataframe=pd.DataFrame({
+                "Selection": ["Primary", "Primary", "None"],
+                "Review": [False, False, True],
+            }),
+        )
+
+        assert df.to_dict(orient="records") == [{
+            "Selection Counts": {"Primary": 2, "None": 1},
+            "Review Counts": {"false": 2, "true": 1},
+        }]
+
 
     def test_group_by_where(self):
         """

--- a/tests/recipes/wrangles/test_select.py
+++ b/tests/recipes/wrangles/test_select.py
@@ -1951,14 +1951,14 @@ class TestGroupBy:
                   auto_rename_columns: false
             """,
             dataframe=pd.DataFrame({
-                "Selection": ["Primary", "Primary", "None"],
-                "Review": [False, False, True],
+                "Selection": ["Primary", "Primary", "None", None],
+                "Review": [False, False, True, None],
             }),
         )
 
         assert df.to_dict(orient="records") == [{
-            "Selection Counts": {"Primary": 2, "None": 1},
-            "Review Counts": {"false": 2, "true": 1},
+            "Selection Counts": {"Primary": 2, "None": 1, "null": 1},
+            "Review Counts": {"false": 2, "true": 1, "null": 1},
         }]
 
 

--- a/wrangles/recipe_wrangles/select.py
+++ b/wrangles/recipe_wrangles/select.py
@@ -318,6 +318,13 @@ def group_by(
           - string
           - array
         description: The count of values for these column(s)
+      counts:
+        type:
+          - string
+          - array
+        description: >-
+          Return a dictionary containing the count of each distinct value for
+          these column(s). Keys are converted to JSON-safe strings.
       std:
         type:
           - string
@@ -399,6 +406,20 @@ def group_by(
         # Add option to group as a list
         elif operation == "list":
             operation = list
+        elif operation == "counts":
+            def counts(values):
+                output = {}
+                for value, count in values.value_counts(dropna=False).items():
+                    if _pd.isna(value):
+                        key = "null"
+                    elif isinstance(value, bool):
+                        key = str(value).lower()
+                    else:
+                        key = str(value)
+                    output[key] = int(count)
+                return output
+            counts.__name__ = "counts"
+            operation = counts
 
         if not isinstance(columns, list): columns = [columns]
         for column in columns:

--- a/wrangles/recipe_wrangles/select.py
+++ b/wrangles/recipe_wrangles/select.py
@@ -324,7 +324,8 @@ def group_by(
           - array
         description: >-
           Return a dictionary containing the count of each distinct value for
-          these column(s). Keys are converted to JSON-safe strings.
+          these column(s). Keys are converted to JSON-safe strings; missing
+          values use the key "null" and booleans use lowercase "true"/"false".
       std:
         type:
           - string


### PR DESCRIPTION
## Summary

- add a `counts` aggregation to `select.group_by`
- return each distinct value and its frequency as a dictionary
- convert dictionary keys to JSON-safe strings
- represent missing values as `null` and booleans as lowercase `true` or `false`
- support existing per-column output renaming behavior

## Why

Grouped recipes sometimes need the distribution of values within each group rather than only a scalar count or a list of the original values. Without this aggregation, recipes need additional transformations to construct a value-to-frequency mapping.

## Impact

Recipes can now request value counts directly:

```yaml
wrangles:
  - select.group_by:
      by: Group
      counts:
        - Selection: Selection Counts
      auto_rename_columns: false
```

The resulting `Selection Counts` value is a JSON-safe dictionary such as `{"Primary": 2, "None": 1}`.

## Validation

- complete `TestGroupBy` class: `30 passed`
- grouped smoke coverage for strings, nulls, and booleans passed
- `git diff --check` passed
- two existing Python invalid-escape `SyntaxWarning` warnings were emitted; no test failures
