### PR TITLE
Recover batched Excel writes onto main

### DIFF
--- a/tests/connectors/test_excel.py
+++ b/tests/connectors/test_excel.py
@@ -129,3 +129,42 @@ def test_excel_sheet_overwrite_accumulates_repeated_writes():
     assert excel_outputs[0]["name"] == "Results"
     assert excel_outputs[0]["action"] == "overwrite"
     assert len(excel_outputs[0]["data"]) == 1000
+
+
+def test_excel_sheet_overwrite_uses_append_after_first_external_batch():
+    """
+    WranglesXL can execute each batch as a separate Python run. In that case,
+    in-memory accumulation is not available, so later overwrite batches must be
+    returned as append actions.
+    """
+    df = pd.DataFrame({"header1": ["value1"] * 100})
+
+    memory.clear()
+    wrangles.connectors.excel.sheet.write(
+        df,
+        name="Results",
+        action="overwrite",
+        variables={"batch_number": 1, "batch_total": 10}
+    )
+    first_batch = [
+        v
+        for v in memory.dataframes.values()
+        if v.get("connector") == "excel.sheet.write"
+    ][0]
+
+    memory.clear()
+    wrangles.connectors.excel.sheet.write(
+        df,
+        name="Results",
+        action="overwrite",
+        variables={"batch_number": 2, "batch_total": 10}
+    )
+    second_batch = [
+        v
+        for v in memory.dataframes.values()
+        if v.get("connector") == "excel.sheet.write"
+    ][0]
+    memory.clear()
+
+    assert first_batch["action"] == "overwrite"
+    assert second_batch["action"] == "append"

--- a/tests/connectors/test_excel.py
+++ b/tests/connectors/test_excel.py
@@ -1,4 +1,5 @@
 import wrangles
+import pandas as pd
 from wrangles.connectors import memory
 
 
@@ -31,3 +32,72 @@ def test_default_write():
         data["columns"] == ["header1", "header2"] and
         len(data["data"]) == 5
     )
+
+
+def test_recipe_wrangle_in_batch_writes_all_rows_to_excel_sheet():
+    """
+    Test the WranglesXL output connector path when a recipe wrangle is used
+    inside a batch. The Excel sheet output should receive the full combined
+    dataframe, not only one batch.
+    """
+    memory.clear()
+    wrangles.recipe.run(
+        """
+        read:
+          - test:
+              rows: 1000
+              values:
+                header1: value1
+        wrangles:
+          - batch:
+              batch_size: 100
+              wrangles:
+                - recipe:
+                    wrangles:
+                      - convert.case:
+                          input: header1
+                          case: upper
+                    write:
+                      - excel.sheet:
+                          name: Partial
+        write:
+          - excel.sheet:
+              name: Final
+        """
+    )
+
+    excel_outputs = [
+        v
+        for v in memory.dataframes.values()
+        if v.get("connector") == "excel.sheet.write"
+    ]
+    memory.clear()
+
+    assert len(excel_outputs) == 1
+    assert excel_outputs[0]["name"] == "Final"
+    assert len(excel_outputs[0]["data"]) == 1000
+
+
+def test_excel_sheet_append_accumulates_repeated_writes():
+    """
+    WranglesXL may receive repeated writes to the same sheet when work is
+    batched. Default append behavior should accumulate rows in one payload.
+    """
+    memory.clear()
+    df = pd.DataFrame({"header1": ["value1"] * 1000})
+    for start in range(0, 1000, 100):
+        wrangles.connectors.excel.sheet.write(
+            df.iloc[start:start + 100],
+            name="Results"
+        )
+
+    excel_outputs = [
+        v
+        for v in memory.dataframes.values()
+        if v.get("connector") == "excel.sheet.write"
+    ]
+    memory.clear()
+
+    assert len(excel_outputs) == 1
+    assert excel_outputs[0]["name"] == "Results"
+    assert len(excel_outputs[0]["data"]) == 1000

--- a/tests/connectors/test_excel.py
+++ b/tests/connectors/test_excel.py
@@ -103,6 +103,42 @@ def test_excel_sheet_append_accumulates_repeated_writes():
     assert len(excel_outputs[0]["data"]) == 1000
 
 
+def test_excel_sheet_append_aligns_dynamic_batch_columns_by_name():
+    """
+    Dynamic dictionary keys can create different columns in each batch.
+    Accumulated Excel output must union the columns and align values by name
+    instead of stacking each batch positionally.
+    """
+    memory.clear()
+    batches = [
+        pd.DataFrame({"ID": [1], "A": [1], "X": [97]}),
+        pd.DataFrame({"ID": [2], "B": [2], "Y": [98]}),
+        pd.DataFrame({"ID": [3], "C": [3], "Z": [99]}),
+        pd.DataFrame({"ID": [4], "D": [4], "Zz": [100]}),
+    ]
+
+    for df in batches:
+        wrangles.connectors.excel.sheet.write(df, name="Results")
+
+    excel_outputs = [
+        v
+        for v in memory.dataframes.values()
+        if v.get("connector") == "excel.sheet.write"
+    ]
+    memory.clear()
+
+    assert len(excel_outputs) == 1
+    assert excel_outputs[0]["columns"] == [
+        "ID", "A", "X", "B", "Y", "C", "Z", "D", "Zz"
+    ]
+    assert excel_outputs[0]["data"] == [
+        [1, 1, 97, "", "", "", "", "", ""],
+        [2, "", "", 2, 98, "", "", "", ""],
+        [3, "", "", "", "", 3, 99, "", ""],
+        [4, "", "", "", "", "", "", 4, 100],
+    ]
+
+
 def test_excel_sheet_overwrite_accumulates_repeated_writes():
     """
     Batched WranglesXL runs may emit repeated overwrite writes to the same
@@ -129,6 +165,39 @@ def test_excel_sheet_overwrite_accumulates_repeated_writes():
     assert excel_outputs[0]["name"] == "Results"
     assert excel_outputs[0]["action"] == "overwrite"
     assert len(excel_outputs[0]["data"]) == 1000
+
+
+def test_excel_sheet_overwrite_aligns_reordered_columns_by_name():
+    """
+    Overwrite batches with the same columns in a different order must retain
+    the first payload's column order without shifting values.
+    """
+    memory.clear()
+    wrangles.connectors.excel.sheet.write(
+        pd.DataFrame({"ID": [1], "A": [1], "X": [97]}),
+        name="Results",
+        action="overwrite"
+    )
+    wrangles.connectors.excel.sheet.write(
+        pd.DataFrame({"X": [98], "ID": [2], "A": [2]}),
+        name="Results",
+        action="overwrite"
+    )
+
+    excel_outputs = [
+        v
+        for v in memory.dataframes.values()
+        if v.get("connector") == "excel.sheet.write"
+    ]
+    memory.clear()
+
+    assert len(excel_outputs) == 1
+    assert excel_outputs[0]["columns"] == ["ID", "A", "X"]
+    assert excel_outputs[0]["data"] == [
+        [1, 1, 97],
+        [2, 2, 98],
+    ]
+    assert excel_outputs[0]["action"] == "overwrite"
 
 
 def test_excel_sheet_overwrite_uses_append_after_first_external_batch():

--- a/tests/connectors/test_excel.py
+++ b/tests/connectors/test_excel.py
@@ -101,3 +101,31 @@ def test_excel_sheet_append_accumulates_repeated_writes():
     assert len(excel_outputs) == 1
     assert excel_outputs[0]["name"] == "Results"
     assert len(excel_outputs[0]["data"]) == 1000
+
+
+def test_excel_sheet_overwrite_accumulates_repeated_writes():
+    """
+    Batched WranglesXL runs may emit repeated overwrite writes to the same
+    sheet. The connector should still return one full payload so Excel replaces
+    the sheet with all rows, not just the final batch.
+    """
+    memory.clear()
+    df = pd.DataFrame({"header1": ["value1"] * 1000})
+    for start in range(0, 1000, 100):
+        wrangles.connectors.excel.sheet.write(
+            df.iloc[start:start + 100],
+            name="Results",
+            action="overwrite"
+        )
+
+    excel_outputs = [
+        v
+        for v in memory.dataframes.values()
+        if v.get("connector") == "excel.sheet.write"
+    ]
+    memory.clear()
+
+    assert len(excel_outputs) == 1
+    assert excel_outputs[0]["name"] == "Results"
+    assert excel_outputs[0]["action"] == "overwrite"
+    assert len(excel_outputs[0]["data"]) == 1000

--- a/tests/connectors/test_recipe.py
+++ b/tests/connectors/test_recipe.py
@@ -137,6 +137,42 @@ def test_wrangles():
     )
     assert df["header1"][0] == "VALUE1"
 
+
+def test_recipe_wrangle_in_batch_does_not_write_partial_batches():
+    """
+    Test that a recipe used as a wrangle does not run its own write step
+    once per batch. The outer recipe should write the final combined result.
+    """
+    memory.clear()
+
+    wrangles.recipe.run(
+        """
+        read:
+          - test:
+              rows: 1000
+              values:
+                header1: value1
+        wrangles:
+          - batch:
+              batch_size: 100
+              wrangles:
+                - recipe:
+                    wrangles:
+                      - convert.case:
+                          input: header1
+                          case: upper
+                    write:
+                      - memory:
+                          id: partial_recipe_write
+        write:
+          - memory:
+              id: final_recipe_write
+        """
+    )
+
+    assert "partial_recipe_write" not in memory.dataframes
+    assert len(memory.dataframes["final_recipe_write"]["data"]) == 1000
+
 def test_write():
     """
     Test write defined within the recipe

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -5715,6 +5715,41 @@ class TestBatch:
             number_of_batches[0] == 1000
         )
 
+    def test_batch_dynamic_dictionary_columns_align_by_name(self):
+        """
+        Dynamic dictionary keys can produce different columns in every batch.
+        The combined result must union those columns and align values by name.
+        """
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+              - batch:
+                  batch_size: 1
+                  wrangles:
+                    - split.dictionary:
+                        input: Spec Dicts
+            """,
+            dataframe=pd.DataFrame({
+                "ID": [1, 2, 3, 4],
+                "Spec Dicts": [
+                    {"A": "1", "X": "97"},
+                    {"B": "2", "Y": "98"},
+                    {"C": "3", "Z": "99"},
+                    {"D": "4", "Zz": "100"},
+                ]
+            })
+        )
+
+        assert df.columns.tolist() == [
+            "ID", "Spec Dicts", "A", "X", "B", "Y", "C", "Z", "D", "Zz"
+        ]
+        assert df[["A", "X", "B", "Y", "C", "Z", "D", "Zz"]].values.tolist() == [
+            ["1", "97", "", "", "", "", "", ""],
+            ["", "", "2", "98", "", "", "", ""],
+            ["", "", "", "", "3", "99", "", ""],
+            ["", "", "", "", "", "", "4", "100"],
+        ]
+
     def test_batch_preserves_order(self):
         """
         Test batch preserves

--- a/wrangles/connectors/excel.py
+++ b/wrangles/connectors/excel.py
@@ -5,6 +5,60 @@ import pandas as _pd
 from . import memory as _memory
 import logging as _logging
 
+
+def _append_rows_by_column(saved: dict, df: _pd.DataFrame) -> bool:
+    """
+    Append a dataframe to an orient="split" payload, aligning values by column
+    name and adding newly encountered columns in first-seen order.
+    """
+    new_data = df.to_dict(orient="split")
+    saved_columns = saved["columns"]
+    new_columns = new_data["columns"]
+
+    # Duplicate labels cannot be aligned by name unambiguously. Preserve the
+    # existing behavior for identical layouts, but leave different layouts as
+    # separate writes rather than risking a positional shift.
+    if (
+        saved_columns != new_columns
+        and (
+            not _pd.Index(saved_columns).is_unique
+            or not _pd.Index(new_columns).is_unique
+        )
+    ):
+        return False
+
+    combined_columns = saved_columns + [
+        column
+        for column in new_columns
+        if column not in saved_columns
+    ]
+
+    if combined_columns == saved_columns == new_columns:
+        saved["data"].extend(new_data["data"])
+    else:
+        added_columns = len(combined_columns) - len(saved_columns)
+        if added_columns:
+            saved["data"] = [
+                list(row) + [""] * added_columns
+                for row in saved["data"]
+            ]
+
+        column_positions = {
+            column: position
+            for position, column in enumerate(combined_columns)
+        }
+        for row in new_data["data"]:
+            aligned_row = [""] * len(combined_columns)
+            for column, value in zip(new_columns, row):
+                aligned_row[column_positions[column]] = value
+            saved["data"].append(aligned_row)
+
+        saved["columns"] = combined_columns
+
+    saved["index"].extend(new_data["index"])
+    return True
+
+
 class sheet():
     _schema = {}
 
@@ -37,14 +91,11 @@ class sheet():
                     and saved.get("name") == name
                     and saved.get("cell") == cell
                     and saved.get("action", "append") in ("append", "overwrite")
-                    and saved.get("columns") == df.columns.tolist()
                 ):
-                    new_data = df.to_dict(orient="split")
-                    saved["data"].extend(new_data["data"])
-                    saved["index"].extend(new_data["index"])
-                    if action == "overwrite":
-                        saved["action"] = "overwrite"
-                    return
+                    if _append_rows_by_column(saved, df):
+                        if action == "overwrite":
+                            saved["action"] = "overwrite"
+                        return
 
         _memory.write(
             df,

--- a/wrangles/connectors/excel.py
+++ b/wrangles/connectors/excel.py
@@ -8,10 +8,24 @@ import logging as _logging
 class sheet():
     _schema = {}
 
-    def write(df: _pd.DataFrame, **kwargs):
+    def write(df: _pd.DataFrame, variables: dict = None, **kwargs):
         _logging.info(f": Saving data for Excel Sheet")
 
+        if variables is None:
+            variables = {}
+
         action = kwargs.get("action", "append")
+        try:
+            batch_number = int(variables.get("batch_number", 1))
+            batch_total = int(variables.get("batch_total", 1))
+        except (TypeError, ValueError):
+            batch_number = 1
+            batch_total = 1
+
+        if action == "overwrite" and batch_total > 1 and batch_number > 1:
+            kwargs["action"] = "append"
+            action = "append"
+
         name = kwargs.get("name")
         cell = kwargs.get("cell")
 

--- a/wrangles/connectors/excel.py
+++ b/wrangles/connectors/excel.py
@@ -11,6 +11,25 @@ class sheet():
     def write(df: _pd.DataFrame, **kwargs):
         _logging.info(f": Saving data for Excel Sheet")
 
+        action = kwargs.get("action", "append")
+        name = kwargs.get("name")
+        cell = kwargs.get("cell")
+
+        if action == "append":
+            for saved in reversed(list(_memory.dataframes.values())):
+                if (
+                    isinstance(saved, dict)
+                    and saved.get("connector") == "excel.sheet.write"
+                    and saved.get("name") == name
+                    and saved.get("cell") == cell
+                    and saved.get("action", "append") == "append"
+                    and saved.get("columns") == df.columns.tolist()
+                ):
+                    new_data = df.to_dict(orient="split")
+                    saved["data"].extend(new_data["data"])
+                    saved["index"].extend(new_data["index"])
+                    return
+
         _memory.write(
             df,
             connector = "excel.sheet.write",

--- a/wrangles/connectors/excel.py
+++ b/wrangles/connectors/excel.py
@@ -15,19 +15,21 @@ class sheet():
         name = kwargs.get("name")
         cell = kwargs.get("cell")
 
-        if action == "append":
+        if action in ("append", "overwrite"):
             for saved in reversed(list(_memory.dataframes.values())):
                 if (
                     isinstance(saved, dict)
                     and saved.get("connector") == "excel.sheet.write"
                     and saved.get("name") == name
                     and saved.get("cell") == cell
-                    and saved.get("action", "append") == "append"
+                    and saved.get("action", "append") in ("append", "overwrite")
                     and saved.get("columns") == df.columns.tolist()
                 ):
                     new_data = df.to_dict(orient="split")
                     saved["data"].extend(new_data["data"])
                     saved["index"].extend(new_data["index"])
+                    if action == "overwrite":
+                        saved["action"] = "overwrite"
                     return
 
         _memory.write(

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -1417,7 +1417,7 @@ def recipe(
     input: _Union[str, int, list] = None,
     output: _Union[str, list] = None,
     name: str = None,
-    variables = {},
+    variables = None,
     functions: _Union[_types.FunctionType, list] = [],
     **kwargs
 ) -> _pd.DataFrame:
@@ -1437,6 +1437,8 @@ def recipe(
             type: object
             description: A dictionary of variables to pass to the recipe
     """
+    if variables is None:
+        variables = {}
     if not name: name = kwargs
 
     df_temp = df.copy() # copy of the original df
@@ -1449,18 +1451,25 @@ def recipe(
     if output is None and input is not None:
         output = input
 
+    recipe_object, functions = _recipe._load_recipe(
+        name,
+        variables=variables,
+        functions=functions
+    )
+    recipe_object.pop('write', None)
+
     # If output columns are specified, only apply to those
     if output:
         if not isinstance(output, list): output = [output]
         df[output] = _recipe.run(
-            name,
+            recipe_object,
             variables=variables,
             functions=functions,
             dataframe=df_temp
         )[output]
     else:
         df = _recipe.run(
-            name,
+            recipe_object,
             variables=variables,
             functions=functions,
             dataframe=df_temp


### PR DESCRIPTION
## What changed

- prevent recipe batching from writing partial intermediate results
- accumulate repeated Excel sheet writes in both append and overwrite modes
- switch subsequent overwrite batches to append so earlier output is retained
- union dynamic or reordered batch columns in first-seen order
- align every row by column name rather than by positional order
- add focused connector and recipe regression coverage for all of these cases

## Why

Recipe batches can write repeatedly to the same Excel sheet. Without this chain, intermediate batches can be written independently, overwrite mode can discard earlier rows, and dynamic dictionary keys can shift values into the wrong columns when batches are combined positionally. These are silent data-loss or data-alignment risks.

## Recovery provenance

This is a clean recovery of the five commits previously merged to legacy `dev` in #1112.

- branch created from current `origin/main`
- verified zero commits behind `main` before recovery
- replayed the complete prerequisite chain in its original order
- `git range-diff` shows all five recovered commits are patch-equivalent to the preserved #1112 chain
- no `dev` branch, synchronization commit, or merge commit was included
- final scope is limited to five Excel/recipe implementation and test files

Original PR: #1112

## Compatibility and risk

The intended behavior change is limited to repeated writes produced by recipe batching. Single writes retain their existing path. The main risk is batch accumulation or column-union behavior, covered directly by the focused tests.

Rollback is the normal revert of this five-commit PR; no data migration or configuration change is required.

## Validation

- **8 passed**: every newly added regression test
- **37 passed, 2 deselected**: complete Excel connector tests, recipe connector tests, and `TestBatch`
- the two deselected tests require live authentication to `sso.wrangle.works` and failed only because that external service is unavailable from the local sandbox
- existing pandas `SettingWithCopyWarning` warnings remain; no new test failure was attributed to this recovery
- `git diff --check` passed
- branch is zero commits behind `main`
- changed-file scope against `main`:
  - `tests/connectors/test_excel.py`
  - `tests/connectors/test_recipe.py`
  - `tests/recipes/wrangles/test_main.py`
  - `wrangles/connectors/excel.py`
  - `wrangles/recipe_wrangles/main.py`