### PR TITLE
Protect recovered extract.custom behaviors

### DIFF
--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -1284,6 +1284,32 @@ class TestExtractCustom:
             'Pikachu' in df['Fact Output'][0]
         )
 
+    def test_extract_custom_multi_input_single_output_preserves_match_lists(self):
+        data = pd.DataFrame({
+            'col1': ['one, two'],
+            'col2': ['three four']
+        })
+        recipe = """
+        wrangles:
+        - extract.custom:
+            input:
+              - col1
+              - col2
+            output: matches
+            model_id: 73d89595-e5c9-40a4
+        """
+
+        with patch(
+            "wrangles.extract.custom",
+            side_effect=[
+                [['one', 'two']],
+                [['three', 'four']],
+            ]
+        ):
+            df = wrangles.recipe.run(recipe, dataframe=data)
+
+        assert df.iloc[0]['matches'] == ['one', 'two', 'three', 'four']
+
     def test_extract_custom_use_labels_output_format_columns_multi_input(self):
         data = pd.DataFrame({
             'col1': ['blue shirt', 'red hat'],
@@ -1335,7 +1361,31 @@ class TestExtractCustom:
             })
         )
         assert df.iloc[0]['Fact2'] == ['Charizard']
-        
+
+    def test_extract_custom_mismatched_input_output_lengths(self):
+        data = pd.DataFrame({
+            'col1': ['First Place Pikachu'],
+            'col2': ['Second Place Charizard']
+        })
+        recipe = """
+        wrangles:
+        - extract.custom:
+            input:
+                - col1
+                - col2
+            output:
+                - Fact1
+                - Fact2
+                - Fact3
+            model_id: 1eddb7e8-1b2b-4a52
+        """
+
+        with pytest.raises(
+            ValueError,
+            match='Extract must output to a single column or equal amount of columns as input.'
+        ):
+            wrangles.recipe.run(recipe, dataframe=data)
+
     def test_extract_custom_where(self):
         """
         Test custom extract with where


### PR DESCRIPTION
## Summary

Recover the remaining `extract.custom` safeguards from the legacy `dev` work without replaying obsolete implementation code.

Current `main` already contains newer implementations of the intended fixes:

- multi-input, single-output results preserve and combine match lists
- single-column API results are normalized to lists
- incompatible multi-column input/output counts raise a clear error

This PR adds the two focused regression tests that were still missing on `main`, so those recovered behaviors cannot silently regress.

## Changes

- add an offline mocked test for combining match lists across multiple inputs
- add an offline test for the mismatched input/output length error
- leave production code and package version unchanged

## Validation

- `2 passed, 241 deselected`
- `git diff --check` passes
- branch was created from current `origin/main`; scope is one test file