### PR TITLE
Recover clearer recipe wrangle logging

### DIFF
--- a/tests/recipes/test_wrangles.py
+++ b/tests/recipes/test_wrangles.py
@@ -560,8 +560,11 @@ class TestIf:
         # Check that only the executed wrangle appears in logs  
         log_messages = [msg for msg in caplog.messages if "Wrangling ::" in msg]  
 
-        assert any(": Wrangling :: convert.case :: Completed :: col1 >> should_be_logged" in msg for msg in log_messages)
-        assert not any(": Wrangling :: convert.case :: Completed :: col1 >> should_not_be_logged" in msg for msg in log_messages)  
+        assert any(
+            ": Wrangling :: convert.case :: col1 >> should_be_logged ::" in msg and msg.endswith("Completed")
+            for msg in log_messages
+        )
+        assert not any(": Wrangling :: convert.case :: col1 >> should_not_be_logged" in msg for msg in log_messages)
         assert df['should_be_logged'][0] == 'VALUE'  
         assert 'should_not_be_logged' not in df.columns
 

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -8264,9 +8264,10 @@ class TestWrangleExecutionLogging:
             """,  
             dataframe=pd.DataFrame({'Col1': ['hello']})  
         )  
-        assert ": Wrangling :: convert.case :: Completed :: Col1 >> Col2" in caplog.messages[-1]
+        assert ": Wrangling :: convert.case :: Col1 >> Col2 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
 
-    def test_dynamic_output_logging(self, caplog):  
+    def test_dynamic_output_logging(self, caplog):
         """  
         Test logging with dynamic output (new columns created)  
         """  
@@ -8280,9 +8281,10 @@ class TestWrangleExecutionLogging:
             """,  
             dataframe=pd.DataFrame({'Col1': ['hello world']}),   
         )  
-        assert ": Wrangling :: split.text :: Completed :: Col1 >> Col1, Col2" in caplog.messages[-1]
+        assert ": Wrangling :: split.text :: Col1 >> Col1, Col2 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
 
-    def test_skipped_wrangle_logging(self, caplog):  
+    def test_skipped_wrangle_logging(self, caplog):
         """  
         Test logging when wrangle is skipped due to if condition  
         """  
@@ -8302,8 +8304,9 @@ class TestWrangleExecutionLogging:
             dataframe=pd.DataFrame({'Col1': ['hello']})  
         )  
         assert any(": Wrangling :: convert.case skipped due to not passing the if statement." in msg for msg in caplog.messages)
-        assert ": Wrangling :: convert.case :: Completed :: Col1 >> Col3" in caplog.messages[-1]   
-      
+        assert ": Wrangling :: convert.case :: Col1 >> Col3 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
+
     def test_mixed_output_logging(self, caplog):  
         """  
         Test logging with mixed output types (strings and dicts)  
@@ -8319,8 +8322,9 @@ class TestWrangleExecutionLogging:
             """,  
             dataframe=pd.DataFrame({'col1': ['test']}),  
         )  
-        assert ": Wrangling :: create.column :: Completed :: None >> col2, col3, col4" in caplog.messages[-1]  
-      
+        assert ": Wrangling :: create.column :: None >> col2, col3, col4 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
+
     def test_backward_compatibility_logging(self, caplog):  
         """  
         Test that default logging still shows 'Dynamic' for backward compatibility  
@@ -8336,7 +8340,8 @@ class TestWrangleExecutionLogging:
             dataframe=pd.DataFrame({'Col1': ['hello world']})  
         )  
         print(df)
-        assert ": Wrangling :: split.text :: Completed :: Col1 >> Col1, Col2" in caplog.messages[-1]
+        assert ": Wrangling :: split.text :: Col1 >> Col1, Col2 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
 
     def test_input_overwrite_logging(self, caplog):  
         """  
@@ -8351,7 +8356,8 @@ class TestWrangleExecutionLogging:
             """,  
             dataframe=pd.DataFrame({'Col1': ['hello']}),  
         )  
-        assert ": Wrangling :: convert.case :: Completed :: Col1 >> Col1" in caplog.messages[-1]
+        assert ": Wrangling :: convert.case :: Col1 >> Col1 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
 
     def test_output_wildcard_string_logging(_self, caplog):
         df = wrangles.recipe.run(
@@ -8366,7 +8372,8 @@ class TestWrangleExecutionLogging:
                 'Col': [["Hello", "Wrangles!", "and", "World!"]]
             })
         )
-        assert ": Wrangling :: split.list :: Completed :: Col >> Col, Col1, Col2, Col3, Col4" in caplog.messages[-1]
+        assert ": Wrangling :: split.list :: Col >> Col, Col1, Col2, Col3, Col4 ::" in caplog.messages[-1]
+        assert caplog.messages[-1].endswith("Completed")
     
     def test_logging_wildcard_multi_list_no_expansion(self, caplog):  
         """  
@@ -8393,13 +8400,18 @@ class TestWrangleExecutionLogging:
         )  
 
         # Check that the wildcard is not expanded (appears as literal)
-        assert any('Completed :: col1, col2 >> col*, other' in message for message in caplog.messages)
+        assert any(
+            'col1, col2 >> col*, other ::' in message and message.endswith('Completed')
+            for message in caplog.messages
+        )
 
     def test_multiple_wrangles_logging(self, caplog):
         """
         Test that Starting and Completed messages are logged for each wrangle
         in a multi-step recipe, in the correct order.
         """
+        import logging
+        caplog.set_level(logging.DEBUG)
         wrangles.recipe.run(
             """
             wrangles:
@@ -8428,11 +8440,14 @@ class TestWrangleExecutionLogging:
 
         # Verify order: Starting then Completed for each wrangle
         assert ': Wrangling :: convert.case :: Starting' in wrangle_logs[0]
-        assert ': Wrangling :: convert.case :: Completed :: col1 >> col2' in wrangle_logs[1]
+        assert ': Wrangling :: convert.case :: col1 >> col2 ::' in wrangle_logs[1]
+        assert wrangle_logs[1].endswith('Completed')
         assert ': Wrangling :: merge.concatenate :: Starting' in wrangle_logs[2]
-        assert ': Wrangling :: merge.concatenate :: Completed :: col1, col2 >> col3' in wrangle_logs[3]
+        assert ': Wrangling :: merge.concatenate :: col1, col2 >> col3 ::' in wrangle_logs[3]
+        assert wrangle_logs[3].endswith('Completed')
         assert ': Wrangling :: convert.case :: Starting' in wrangle_logs[4]
-        assert ': Wrangling :: convert.case :: Completed :: col3 >> col4' in wrangle_logs[5]
+        assert ': Wrangling :: convert.case :: col3 >> col4 ::' in wrangle_logs[5]
+        assert wrangle_logs[5].endswith('Completed')
 
     def test_completed_log_includes_duration(self, caplog):
         """
@@ -8451,15 +8466,17 @@ class TestWrangleExecutionLogging:
         )
         completed_msg = next(
             msg for msg in caplog.messages
-            if ': Wrangling :: convert.case :: Completed ::' in msg
+            if ': Wrangling :: convert.case ::' in msg
         )
-        assert re.search(r'::\s*\d+\.\d{3}s$', completed_msg), \
-            f"Expected duration suffix like ':: 0.001s' in: {completed_msg}"
+        assert re.search(r'::\s*\d+\.\d{3}s Completed$', completed_msg), \
+            f"Expected duration suffix like ':: 0.001s Completed' in: {completed_msg}"
 
     def test_starting_log_single_wrangle(self, caplog):
         """
         Test that a Starting message is logged before Completed for a single wrangle.
         """
+        import logging
+        caplog.set_level(logging.DEBUG)
         wrangles.recipe.run(
             """
             wrangles:
@@ -8473,7 +8490,7 @@ class TestWrangleExecutionLogging:
         wrangle_logs = [msg for msg in caplog.messages if ': Wrangling :: convert.case ::' in msg]
         assert len(wrangle_logs) == 2
         assert ': Wrangling :: convert.case :: Starting' in wrangle_logs[0]
-        assert ': Wrangling :: convert.case :: Completed ::' in wrangle_logs[1]
+        assert wrangle_logs[1].endswith('Completed')
 
 
 @pytest.mark.usefixtures("caplog")

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -547,7 +547,7 @@ def _execute_wrangles(
                     if key in params.keys():
                         common_params[key] = params.pop(key)
 
-                _logging.info(f": Wrangling :: {wrangle} :: Starting")
+                _logging.debug(f": Wrangling :: {wrangle} :: Starting")
                 _wrangle_start_time = _time.perf_counter()
 
                 if wrangle.split('.')[0] == 'pandas':
@@ -834,7 +834,7 @@ def _execute_wrangles(
                             
                         output_display = ', '.join(str(col) for col in output_columns)
                         _wrangle_elapsed = _time.perf_counter() - _wrangle_start_time
-                        _logging.info(f": Wrangling :: {wrangle} :: Completed :: {input_display} >> {output_display} :: {_wrangle_elapsed:.3f}s")
+                        _logging.info(f": Wrangling :: {wrangle} :: {input_display} >> {output_display} :: {_wrangle_elapsed:.3f}s Completed")
 
             except Exception as e:
                 # Append name of wrangle to message and pass through exception


### PR DESCRIPTION
## Summary

Recover the logging improvements from legacy-dev PR #1106 onto current `main`.

## What changed

- move per-wrangle `Starting` messages from INFO to DEBUG
- keep completed wrangles at INFO
- format completion messages as `input >> output :: duration Completed`, making the terminal state easy to scan at the end of each line
- update the affected logging assertions for the recovered format

## Impact

Normal INFO logs become less noisy while retaining one completion record per executed wrangle. DEBUG logging still exposes both start and completion events for detailed tracing.

There is no API, recipe-schema, or data-processing behavior change.

## Validation

- 12 focused execution-logging tests passed
- 40 additional debug-logging tests passed
- `git diff --check origin/main...HEAD` passed
- branch is 0 commits behind current `origin/main`

## Recovery source

Supersedes the product change previously merged only into legacy `dev` through #1106.