### PR TITLE
Recover recipe error line numbers

### DIFF
--- a/tests/recipes/test_custom_functions.py
+++ b/tests/recipes/test_custom_functions.py
@@ -286,7 +286,7 @@ def test_pass_error():
 
     def handle_error(error):
         if (type(error).__name__ == 'TypeError' and
-            "convert.data_type - data_type andksankdl is not supported" in str(error)
+            "data_type andksankdl is not supported" in str(error)
         ):
             global test_var_pass_error
             test_var_pass_error = True
@@ -325,7 +325,7 @@ def test_pass_error_with_params():
 
     def handle_error(error, param):
         if (type(error).__name__ == 'TypeError' and
-            "convert.data_type - data_type andksankdl is not supported" in str(error) and
+            "data_type andksankdl is not supported" in str(error) and
             param == "value"
         ):
             global test_var_pass_error_params
@@ -1467,7 +1467,7 @@ def test_clear_errors_df():
     def raise_error(df):
         raise RuntimeError("This is an error")
 
-    with pytest.raises(RuntimeError, match="custom.raise_error - This is an error"):
+    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 8\) - This is an error"):
         wrangles.recipe.run(
             """
             read:
@@ -1531,7 +1531,7 @@ def test_clear_errors_read():
     def raise_error():
         raise RuntimeError("This is an error")
 
-    with pytest.raises(RuntimeError, match="custom.raise_error - This is an error"):
+    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 3\) - This is an error"):
         wrangles.recipe.run(
             """
             read:
@@ -1547,7 +1547,7 @@ def test_clear_errors_write():
     def raise_error(df):
         raise RuntimeError("This is an error")
 
-    with pytest.raises(RuntimeError, match="custom.raise_error - This is an error"):
+    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 3\) - This is an error"):
         wrangles.recipe.run(
             """
             write:
@@ -1673,7 +1673,7 @@ def test_wrangle_position_error():
     def raise_error(df):  
         raise RuntimeError("This is an error")  
       
-    with pytest.raises(RuntimeError, match="ERROR IN WRANGLE #1 custom.raise_error - This is an error"):  
+    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 8\) - This is an error"):
         wrangles.recipe.run(  
             """  
             read:  
@@ -1700,7 +1700,7 @@ def test_wrangle_position_error_2():
     def raise_error(df):  
         raise RuntimeError("This is an error")  
       
-    with pytest.raises(RuntimeError, match="ERROR IN WRANGLE #2 custom.raise_error - This is an error"):  
+    with pytest.raises(RuntimeError, match=r"custom\.raise_error \(line 17\) - This is an error"):
         wrangles.recipe.run(  
             """  
             read:  
@@ -1727,7 +1727,7 @@ def test_wrangle_position_multiple_same_type():
     """  
     Test error reporting with multiple wrangles of same type  
     """  
-    with pytest.raises(TypeError, match="ERROR IN WRANGLE #2 convert.data_type - data_type invalid_type is not supported."):  
+    with pytest.raises(TypeError, match=r"convert\.data_type \(line 12\) - data_type invalid_type is not supported\."):
         wrangles.recipe.run(  
             """  
             read:  
@@ -1756,30 +1756,30 @@ def test_complete_error_reporting_flow():
             raise RuntimeError("Batch too large")  
         return df  
       
-    with pytest.raises(RuntimeError, match="ERROR IN WRANGLE #2 batch - Batch #1 - ERROR IN WRANGLE #1 custom.batch_error - Batch too large"):  
-        wrangles.recipe.run(  
-            """  
-            read:  
-              - test:  
-                  rows: 20  
-                  values:  
-                    header1: value1  
-            wrangles:  
-                - convert.case:  
-                    input: header1  
-                    output: temp  
-                    case: upper  
-                - batch:  
-                    batch_size: 10  
-                    wrangles:  
-                        - custom.batch_error: {}  
-                        - convert.case:  
-                            input: header1  
-                            case: lower  
-                - convert.case:  
-                    input: header1  
-                    output: final  
-                    case: title  
-            """,  
-            functions=batch_error  
+    with pytest.raises(RuntimeError, match=r"batch \(line 12\) - Batch #1 - custom\.batch_error \(line 15\) - Batch too large"):
+        wrangles.recipe.run(
+            """
+            read:
+              - test:
+                  rows: 20
+                  values:
+                    header1: value1
+            wrangles:
+                - convert.case:
+                    input: header1
+                    output: temp
+                    case: upper
+                - batch:
+                    batch_size: 10
+                    wrangles:
+                        - custom.batch_error: {}
+                        - convert.case:
+                            input: header1
+                            case: lower
+                - convert.case:
+                    input: header1
+                    output: final
+                    case: title
+            """,
+            functions=batch_error
         )

--- a/tests/recipes/test_recipes.py
+++ b/tests/recipes/test_recipes.py
@@ -5,7 +5,7 @@ Specific tests for individual connectors or wrangles should be placed within
 a file for the respective wrangle/connector.
 """
 import wrangles
-from wrangles.connectors import memory
+from wrangles.connectors import memory, recipe
 import pandas as pd
 import pytest
 import time
@@ -161,6 +161,82 @@ def test_recipe_wrong_model():
     """
     with pytest.raises(ValueError, match="Using classify model_id a62c7480-500e-480c in a recipe wrangle"):
             wrangles.recipe.run('a62c7480-500e-480c')
+
+def test_recipe_model_id_wrong_type_shows_line():
+    """
+    Test the error when a model_id used within a recipe wrangle refers
+    to a model of the wrong type (an extract model used in a classify
+    wrangle). The recipe itself is valid - the problem is in the model
+    the id points to - so the error should identify that and still
+    point at the correct line of the classify wrangle.
+    """
+    recipe = """
+    read:
+      - test:
+          rows: 3
+          values:
+            header: value1
+
+    wrangles:
+      - convert.case:
+          input: header
+          output: temp
+          case: upper
+
+      - classify:
+          input: temp
+          output: result
+          model_id: fce592c9-26f5-4fd7
+    """
+    expected_line = next(
+        i for i, line in enumerate(recipe.splitlines(), start=1)
+        if "classify:" in line
+    )
+
+    with pytest.raises(ValueError) as info:
+        wrangles.recipe.run(recipe)
+
+    msg = info.value.args[0]
+    assert f"(line {expected_line})" in msg
+    assert "Using extract model_id fce592c9-26f5-4fd7 in a classify function" in msg
+
+def test_recipe_model_id_not_found_shows_line():
+    """
+    Test the error when a model_id used within a recipe wrangle is
+    well-formed but doesn't correspond to an existing/accessible model.
+    The recipe syntax is valid - the problem is the model itself - so
+    the error should still point at the correct line of the classify
+    wrangle.
+    """
+    recipe = """
+    read:
+      - test:
+          rows: 3
+          values:
+            header: value1
+
+    wrangles:
+      - convert.case:
+          input: header
+          output: temp
+          case: upper
+
+      - classify:
+          input: temp
+          output: result
+          model_id: 00000000-0000-0000
+    """
+    expected_line = next(
+        i for i, line in enumerate(recipe.splitlines(), start=1)
+        if "classify:" in line
+    )
+
+    with pytest.raises(RuntimeError) as info:
+        wrangles.recipe.run(recipe)
+
+    msg = info.value.args[0]
+    assert f"(line {expected_line})" in msg
+    assert "00000000-0000-0000" in msg
 
 def test_timeout():
     """
@@ -859,7 +935,7 @@ class TestColumnWildcards:
             )
         assert (
             info.typename == 'KeyError' and
-            "format.trim - 'Column nothing does not exist'" in info.value.args[0]
+            "format.trim (line 3) - 'Column nothing does not exist'" in info.value.args[0]
         )
 
 
@@ -982,7 +1058,7 @@ def test_enhanced_error_message_long_recipe():
           case: lower  
     """  
       
-    with pytest.raises(RuntimeError, match=r"ERROR IN WRANGLE #5 custom.failing_function - This is the actual error from wrangle #5"):  
+    with pytest.raises(RuntimeError, match=r"custom\.failing_function \(line 18\) - This is the actual error from wrangle #5"):
         wrangles.recipe.run(recipe, functions=[working_function, failing_function])
 
 def test_enhanced_error_message_read_phase():  
@@ -990,7 +1066,7 @@ def test_enhanced_error_message_read_phase():
     def failing_read():  
         raise RuntimeError("Read operation failed")  
       
-    with pytest.raises(RuntimeError, match=r"ERROR IN READ: custom.failing_read.*Read operation failed"):  
+    with pytest.raises(RuntimeError, match=r"custom\.failing_read \(line 3\) - Read operation failed"):
         wrangles.recipe.run(  
             """  
             read:  
@@ -1004,7 +1080,7 @@ def test_enhanced_error_message_write_phase():
     def failing_write(df):  
         raise RuntimeError("Write operation failed")  
       
-    with pytest.raises(RuntimeError, match=r"ERROR IN WRITE: custom.failing_write.*Write operation failed"):  
+    with pytest.raises(RuntimeError, match=r"custom\.failing_write \(line 8\) - Write operation failed"):
         wrangles.recipe.run(  
             """  
             read:  
@@ -1060,7 +1136,7 @@ def test_action_position_error():
     def fail_func():  
         raise RuntimeError("Action failed")  
       
-    with pytest.raises(RuntimeError, match="ERROR IN ACTION: custom.fail_func - Action failed"):  
+    with pytest.raises(RuntimeError, match=r"custom\.fail_func \(line 4\) - Action failed"):
         wrangles.recipe.run(  
             """  
             run:  
@@ -1068,7 +1144,47 @@ def test_action_position_error():
                 - custom.fail_func: {}  
                 - custom.fail_func: {}  
                 - custom.fail_func: {}  
-            """,  
-            functions=fail_func  
-        )  
+            """,
+            functions=fail_func
+        )
+
+
+def test_wrangle_error_includes_index_and_name_and_line():
+    # Wrangle that does not exist should raise the original exception (ValueError)
+    r = """
+        wrangles:
+        - nonexistent_wrangle:
+            input: col1
+        """
+    with pytest.raises(KeyError) as exc:
+        recipe.run(r)
+
+    msg = str(exc.value)
+    assert '(line' in msg
+    assert 'nonexistent_wrangle' in msg
+
+
+def test_read_error_shows_line():
+    r = """
+        read:
+        - nonexistent_read: {}
+        """
+    with pytest.raises(ValueError) as exc:
+        recipe.run(r)
+    msg = str(exc.value)
+    assert '(line' in msg
+    assert 'nonexistent_read' in msg
+
+
+def test_write_error_shows_line():
+    r = """
+        write:
+        - nonexistent_write: {}
+        """
+    with pytest.raises(ValueError) as exc:
+        # run will execute write even with no read; run will process wrangles then write
+        recipe.run(r)
+    msg = str(exc.value)
+    assert '(line' in msg
+    assert 'nonexistent_write' in msg
   

--- a/tests/recipes/test_recipes.py
+++ b/tests/recipes/test_recipes.py
@@ -9,6 +9,8 @@ from wrangles.connectors import memory, recipe
 import pandas as pd
 import pytest
 import time
+import concurrent.futures
+import threading
 
 
 def test_recipe_from_file():
@@ -162,7 +164,7 @@ def test_recipe_wrong_model():
     with pytest.raises(ValueError, match="Using classify model_id a62c7480-500e-480c in a recipe wrangle"):
             wrangles.recipe.run('a62c7480-500e-480c')
 
-def test_recipe_model_id_wrong_type_shows_line():
+def test_recipe_model_id_wrong_type_shows_line(monkeypatch):
     """
     Test the error when a model_id used within a recipe wrangle refers
     to a model of the wrong type (an extract model used in a classify
@@ -193,6 +195,12 @@ def test_recipe_model_id_wrong_type_shows_line():
         if "classify:" in line
     )
 
+    monkeypatch.setattr(
+        wrangles.data,
+        'model',
+        lambda model_id: {'batch_size': 100, 'purpose': 'extract'}
+    )
+
     with pytest.raises(ValueError) as info:
         wrangles.recipe.run(recipe)
 
@@ -200,7 +208,7 @@ def test_recipe_model_id_wrong_type_shows_line():
     assert f"(line {expected_line})" in msg
     assert "Using extract model_id fce592c9-26f5-4fd7 in a classify function" in msg
 
-def test_recipe_model_id_not_found_shows_line():
+def test_recipe_model_id_not_found_shows_line(monkeypatch):
     """
     Test the error when a model_id used within a recipe wrangle is
     well-formed but doesn't correspond to an existing/accessible model.
@@ -231,12 +239,18 @@ def test_recipe_model_id_not_found_shows_line():
         if "classify:" in line
     )
 
-    with pytest.raises(RuntimeError) as info:
+    monkeypatch.setattr(
+        wrangles.data,
+        'model',
+        lambda model_id: {'message': 'error'}
+    )
+
+    with pytest.raises(ValueError) as info:
         wrangles.recipe.run(recipe)
 
     msg = info.value.args[0]
     assert f"(line {expected_line})" in msg
-    assert "00000000-0000-0000" in msg
+    assert "Incorrect model_id" in msg
 
 def test_timeout():
     """
@@ -1061,6 +1075,47 @@ def test_enhanced_error_message_long_recipe():
     with pytest.raises(RuntimeError, match=r"custom\.failing_function \(line 18\) - This is the actual error from wrangle #5"):
         wrangles.recipe.run(recipe, functions=[working_function, failing_function])
 
+
+def test_concurrent_recipe_errors_use_their_own_source_lines():
+    barrier = threading.Barrier(2)
+
+    def fail_alpha(df):
+        barrier.wait()
+        raise RuntimeError("alpha failed")
+
+    def fail_beta(df):
+        barrier.wait()
+        raise RuntimeError("beta failed")
+
+    recipe_alpha = """
+    wrangles:
+      - custom.fail_alpha: {}
+    """
+    recipe_beta = """
+
+
+    wrangles:
+      - custom.fail_beta: {}
+    """
+
+    def capture_error(recipe, function):
+        try:
+            wrangles.recipe.run(
+                recipe,
+                dataframe=pd.DataFrame({'value': [1]}),
+                functions=function
+            )
+        except RuntimeError as error:
+            return str(error)
+        raise AssertionError("Recipe did not raise RuntimeError")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        alpha_future = executor.submit(capture_error, recipe_alpha, fail_alpha)
+        beta_future = executor.submit(capture_error, recipe_beta, fail_beta)
+
+    assert "custom.fail_alpha (line 3) - alpha failed" in alpha_future.result()
+    assert "custom.fail_beta (line 5) - beta failed" in beta_future.result()
+
 def test_enhanced_error_message_read_phase():  
     """Test error message prominence in read phase"""  
     def failing_read():  
@@ -1187,4 +1242,3 @@ def test_write_error_shows_line():
     msg = str(exc.value)
     assert '(line' in msg
     assert 'nonexistent_write' in msg
-  

--- a/tests/recipes/wrangles/test_convert.py
+++ b/tests/recipes/wrangles/test_convert.py
@@ -772,7 +772,7 @@ class TestConvertDataType:
             wrangles.recipe.run(recipe, dataframe=df)
         assert (
             info.typename == 'TypeError' and
-            'convert.data_type - data_type squirrel is not supported.' in info.value.args[0]
+            'convert.data_type (line 3) - data_type squirrel is not supported.' in info.value.args[0]
         )
 
 

--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -988,7 +988,7 @@ class TestExtractCodes:
         )
         assert (
             info.typename == 'ValueError' and
-            'extract.codes - Status Code: 400 - Bad Request. {"message": "min_length must be non-negative integer"} \n' in info.value.args[0]
+            'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "min_length must be non-negative integer"} \n' in info.value.args[0]
         )
 
 
@@ -1012,7 +1012,7 @@ class TestExtractCodes:
         )
         assert (
             info.typename == 'ValueError' and
-            'extract.codes - Status Code: 400 - Bad Request. {"message": "max length must be an integer greater than zero"} \n' in info.value.args[0]
+            'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "max length must be an integer greater than zero"} \n' in info.value.args[0]
         )
 
     def test_extract_codes_wrong_params_strategy(self):
@@ -1035,7 +1035,7 @@ class TestExtractCodes:
         )
         assert (
             info.typename == 'ValueError' and
-            'extract.codes - Status Code: 400 - Bad Request. {"message": "Invalid parameter strategy. Expected lenient, balanced, or strict."} \n' in info.value.args[0]
+            'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "Invalid parameter strategy. Expected lenient, balanced, or strict."} \n' in info.value.args[0]
         )
 
     def test_extract_codes_wrong_params_sort(self):
@@ -1059,8 +1059,8 @@ class TestExtractCodes:
         assert (
             info.typename == 'ValueError' and
             (
-                'extract.codes - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected input, longest, or shortest."} \n' in info.value.args[0]
-                or 'extract.codes - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected longest or shortest."} \n' in info.value.args[0]
+                'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected input, longest, or shortest."} \n' in info.value.args[0]
+                or 'extract.codes (line 3) - Status Code: 400 - Bad Request. {"message": "Invalid parameter sort_order. Expected longest or shortest."} \n' in info.value.args[0]
             )
         )
 

--- a/tests/recipes/wrangles/test_extract_unit_conversion.py
+++ b/tests/recipes/wrangles/test_extract_unit_conversion.py
@@ -68,7 +68,7 @@ def test_non_existing_unit():
             """,
             dataframe=data
         )
-    assert info.typename == 'ValueError' and info.value.args[0] == 'ERROR IN WRANGLE #1 extract.attributes - Status Code: 400 - Bad Request. {"ValueError":"Invalid desiredUnit provided"}\n \n'
+    assert info.typename == 'ValueError' and ('extract.attributes (line 3) - Status Code: 400 - Bad Request. {"ValueError":"Invalid desiredUnit provided"}\n \n') in info.value.args[0]
 
 def test_wrong_match_1():
     """

--- a/tests/recipes/wrangles/test_main.py
+++ b/tests/recipes/wrangles/test_main.py
@@ -2037,6 +2037,47 @@ class TestRename:
         )
         assert df.columns.tolist() == ["HEADER1","HEADER2"]
 
+    def test_rename_wrangles_error_shows_correct_line(self):
+        """
+        When an inner wrangle used inside rename's `wrangles:` (e.g. convert.case)
+        raises an error, the reported line number should point at that wrangle's
+        real position in the user's recipe - not the line number of the internal,
+        synthetic single-wrangle recipe that rename() builds to run it. The error
+        also should not be wrapped twice with a redundant "Failed running ... in
+        rename wrangles" message.
+        """
+        recipe = """
+        read:
+          - test:
+              rows: 3
+              values:
+                Manufacturer Name: Delos
+                Part Number: CH465517080
+
+        wrangles:
+          - rename:
+              wrangles:
+                - convert.case:
+                    input: columns
+                    case: bogus_case_value
+                - custom.add_suffix:
+                    output: columns
+        """
+        expected_line = next(
+            i for i, line in enumerate(recipe.splitlines(), start=1)
+            if "convert.case:" in line
+        )
+
+        def add_suffix(columns):
+            return columns + "_clean"
+
+        with pytest.raises(Exception) as info:
+            wrangles.recipe.run(recipe, functions=add_suffix)
+
+        msg = str(info.value)
+        assert f"(line {expected_line})" in msg
+        assert "Failed running" not in msg
+
     def test_rename_empty(self):
         """
         Test rename with empty data
@@ -2572,7 +2613,7 @@ class TestSimilarity:
             wrangles.recipe.run(recipe, dataframe=data)
         assert (
             info.typename == 'ValueError' and
-            'similarity - shapes (4,) and (5,) not aligned: 4 (dim 0) != 5 (dim 0)' in info.value.args[0]
+            'similarity (line 3) - shapes (4,) and (5,) not aligned: 4 (dim 0) != 5 (dim 0)' in info.value.args[0]
         )
 
     def test_similarity_cosine_string(self):
@@ -2766,7 +2807,7 @@ class TestSimilarity:
             wrangles.recipe.run(recipe, dataframe=data)
         assert (
             info.typename == 'ValueError' and
-            'similarity - shapes (4,) and (5,) not aligned: 4 (dim 0) != 5 (dim 0)' in info.value.args[0]
+            'similarity (line 3) - shapes (4,) and (5,) not aligned: 4 (dim 0) != 5 (dim 0)' in info.value.args[0]
         )
 
     def test_similarity_adjusted_cosine_string(self):
@@ -3961,6 +4002,57 @@ class TestRecipe:
         """
         df = wrangles.recipe.run(recipe, dataframe=data)
         assert df['col'].iloc[0] == 'MARIO'
+
+    def test_recipe_wrangle_model_id_nested_error_shows_nested_line(self):
+        """
+        When the recipe wrangle's name is a model_id that itself points to
+        another recipe (rather than a synthetic/inline recipe fragment),
+        an error inside that nested recipe should be attributed to a line
+        within that nested recipe's own source - not the outer recipe's
+        line, and not lost entirely.
+        """
+        nested_recipe_text = """
+wrangles:
+  - convert.case:
+      input: temp
+      case: bogus_case_value
+"""
+        expected_line = next(
+            i for i, line in enumerate(nested_recipe_text.splitlines(), start=1)
+            if "convert.case:" in line
+        )
+
+        def fake_model(model_id):
+            return {'purpose': 'recipe'}
+
+        def fake_model_content(model_id, version_id=None):
+            return {'recipe': nested_recipe_text}
+
+        outer_recipe = """
+        read:
+          - test:
+              rows: 3
+              values:
+                header: value1
+
+        wrangles:
+          - convert.case:
+              input: header
+              output: temp
+              case: upper
+
+          - recipe:
+              name: aaaaaaaa-bbbb-cccc
+              input: temp
+        """
+
+        with patch('wrangles.recipe._data.model', side_effect=fake_model), \
+             patch('wrangles.recipe._data.model_content', side_effect=fake_model_content):
+            with pytest.raises(Exception) as info:
+                wrangles.recipe.run(outer_recipe)
+
+        msg = str(info.value)
+        assert f"(line {expected_line})" in msg
 
     def test_recipe_input(self):
         """
@@ -5360,7 +5452,8 @@ class TestAccordion:
             )
         assert (
             err.typename == 'KeyError' and
-            'accordion - "Did you forget' in err.value.args[0]
+            'accordion (line' in err.value.args[0] and
+            'Did you forget' in err.value.args[0]
         )
 
     def test_accordion_invalid_wrangles_column_output(self):
@@ -5394,7 +5487,8 @@ class TestAccordion:
             )
         assert (
             err.typename == 'KeyError' and
-            "accordion - \'Did you forget" in err.value.args[0]
+            'accordion (line' in err.value.args[0] and
+            'Did you forget' in err.value.args[0]
         )
 
     def test_accordion_inconsistent_lengths(self):
@@ -5468,7 +5562,8 @@ class TestAccordion:
             )
         assert (
             err.typename == 'KeyError' and
-            'accordion - "Did you forget' in err.value.args[0]
+            'accordion (line' in err.value.args[0] and
+            'Did you forget' in err.value.args[0]
         )
 
     def test_accordion_empty_list(self):
@@ -6127,7 +6222,7 @@ class TestBatch:
                 raise KeyError("column1 does not exist")  
             return df  
         
-        with pytest.raises(KeyError, match=r'Batch #2 - "ERROR IN WRANGLE #1 custom\.fail_on_2nd_batch.*"'):  
+        with pytest.raises(KeyError, match=r'Batch #2 - "custom\.fail_on_2nd_batch.*"'):
             wrangles.recipe.run(  
                 """  
                 read:  

--- a/tests/recipes/wrangles/test_pandas.py
+++ b/tests/recipes/wrangles/test_pandas.py
@@ -381,7 +381,7 @@ class TestCopy:
             wrangles.recipe.run(recipe=recipe, dataframe=data)
         assert (
             info.typename == "ValueError" and 
-            str(info.value) == "ERROR IN WRANGLE #1 copy - Input and output must be the same length"
+            ("copy (line 3) - Input and output must be the same length") in str(info.value)
         )
 
     def test_copy_shorthand(self):
@@ -902,7 +902,7 @@ class TestExplode:
             )
         assert (
             info.typename == "ValueError" and 
-            str(info.value) == "ERROR IN WRANGLE #1 explode - columns must have matching element counts"
+            ("explode (line 3) - columns must have matching element counts") in str(info.value)
         )
 
     def test_explode_reset_index_default(self):

--- a/wrangles/connectors/concurrent.py
+++ b/wrangles/connectors/concurrent.py
@@ -5,6 +5,7 @@ other write connectors concurrently.
 import pandas as _pd
 import wrangles as _wrangles
 import concurrent.futures as _futures
+import contextvars as _contextvars
 import types as _types
 from typing import Union as _Union
 
@@ -38,12 +39,22 @@ def run(
     with pool_executor(max_workers=max_concurrency) as executor:
         futures = []
         for run_definition in run:
-            future = executor.submit(
-                _wrangles.recipe.run,
-                recipe= {'run': {"on_start": [run_definition]}},
-                variables=variables,
-                functions=functions
-            )
+            if use_multiprocessing:
+                future = executor.submit(
+                    _wrangles.recipe.run,
+                    recipe={'run': {"on_start": [run_definition]}},
+                    variables=variables,
+                    functions=functions
+                )
+            else:
+                future = executor.submit(
+                    _contextvars.copy_context().run,
+                    _wrangles.recipe.run,
+                    {'run': {"on_start": [run_definition]}},
+                    variables,
+                    None,
+                    functions
+                )
             futures.append(future)
         
         # Wait for all futures to complete
@@ -97,13 +108,28 @@ def read(
         pool_executor = _futures.ThreadPoolExecutor
     
     with pool_executor(max_workers=max_concurrency) as executor:
-        dfs = list(executor.map(
-            _wrangles.recipe.run,
-            [{'read': [read_definition]} for read_definition in read],
-            [variables for _ in read],
-            [None for _ in read],
-            [functions for _ in read]
-        ))
+        recipes = [{'read': [read_definition]} for read_definition in read]
+        if use_multiprocessing:
+            dfs = list(executor.map(
+                _wrangles.recipe.run,
+                recipes,
+                [variables for _ in read],
+                [None for _ in read],
+                [functions for _ in read]
+            ))
+        else:
+            futures = [
+                executor.submit(
+                    _contextvars.copy_context().run,
+                    _wrangles.recipe.run,
+                    recipe,
+                    variables,
+                    None,
+                    functions
+                )
+                for recipe in recipes
+            ]
+            dfs = [future.result() for future in futures]
 
     return dfs
 
@@ -160,13 +186,23 @@ def write(
     with pool_executor(max_workers=max_concurrency) as executor:
         futures = []
         for write_definition in write:
-            future = executor.submit(
-                _wrangles.recipe.run,
-                recipe= {'write': [write_definition]},
-                dataframe=df.copy(),
-                variables=variables,
-                functions=functions
-            )
+            if use_multiprocessing:
+                future = executor.submit(
+                    _wrangles.recipe.run,
+                    recipe={'write': [write_definition]},
+                    dataframe=df.copy(),
+                    variables=variables,
+                    functions=functions
+                )
+            else:
+                future = executor.submit(
+                    _contextvars.copy_context().run,
+                    _wrangles.recipe.run,
+                    {'write': [write_definition]},
+                    variables,
+                    df.copy(),
+                    functions
+                )
             futures.append(future)
         
         # Wait for all futures to complete

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -13,6 +13,7 @@ import importlib as _importlib
 import re as _re
 import warnings as _warnings
 import concurrent.futures as _futures
+import threading as _threading
 import time as _time
 import pandas as _pandas
 import requests as _requests
@@ -39,6 +40,20 @@ except ImportError:
     from yaml import SafeDumper as _YAMLDumper
 
 _logging.getLogger().setLevel(_logging.INFO)
+
+# Text of the recipe currently being executed, used as a best-effort source
+# for error line lookups. Only the outermost recipe.run() call updates this -
+# see _RECIPE_RUN_DEPTH below.
+_CURRENT_RECIPE_STRING = None
+
+# Tracks how many recipe.run() calls are nested on the current call stack.
+# Wrangles such as `rename` run an inner recipe.run() internally to execute
+# their `wrangles:` steps; that inner call must not overwrite
+# _CURRENT_RECIPE_STRING with its own synthetic, re-dumped recipe fragment,
+# otherwise error line lookups for the inner wrangles would point at the
+# wrong (synthetic) source instead of the user's actual recipe.
+_RECIPE_RUN_DEPTH = 0
+_RECIPE_RUN_DEPTH_LOCK = _threading.Lock()
 
 
 # Suppress pandas performance warnings
@@ -83,12 +98,23 @@ def _load_recipe(
     # Dict to store functions stored within a model
     model_functions = {}
 
+    # Whether recipe_string was fetched from an independently addressable
+    # source (a URL, a model_id, or a file path) rather than being an inline
+    # string/dict built by a wrangle at runtime (e.g. rename's inner
+    # wrangles). Fetched sources have their own real, navigable line numbers
+    # and should always be tracked for error line lookups - even when this
+    # is a nested recipe.run() call (e.g. a model_id that itself points to
+    # another recipe) - unlike synthetic inline recipes, which should defer
+    # to whatever recipe text the outer call was already tracking.
+    _is_external_source = False
+
     # If the recipe to read is from "https://" or "http://"
     if 'https://' == recipe[:8] or 'http://' == recipe[:7]:
         response = _requests.get(recipe)
         if str(response.status_code)[0] != '2':
             raise ValueError(f'Error getting recipe from url: {response.url}\nReason: {response.reason}-{response.status_code}')
         recipe_string = response.text
+        _is_external_source = True
 
     # If recipe matches xxxxxxxx-xxxx-xxxx, it's probably a model
     elif _re.match(r"^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}$", recipe.split(':')[0].strip()):
@@ -117,6 +143,7 @@ def _load_recipe(
 
         model_contents = _data.model_content(model_id, version_id)
         recipe_string = model_contents['recipe']
+        _is_external_source = True
         model_functions = model_contents.get('functions', {})
         if model_functions:
             spec = _importlib.util.spec_from_loader('custom_functions', loader=None)
@@ -146,6 +173,7 @@ def _load_recipe(
         try:
             with open(recipe, "r", encoding='utf-8') as f:
                 recipe_string = f.read()
+            _is_external_source = True
         except:
             raise RuntimeError(
                 f'Error reading recipe: "{recipe}". ' \
@@ -220,10 +248,98 @@ def _load_recipe(
         if key != 'recipe_variables'
     }
 
+    # Keep a copy of the raw recipe string for line lookups.
+    #
+    # Always do this for the outermost recipe.run() call, and also for any
+    # nested call whose recipe came from an independently addressable source
+    # (a URL, model_id, or file path) - e.g. a model_id that itself points to
+    # another recipe. That fetched recipe has its own real, navigable lines,
+    # so errors inside it should be attributed there.
+    #
+    # For nested calls built from an inline dict/string (e.g. rename's inner
+    # wrangles, or a hardcoded template a wrangle runs internally), skip the
+    # update - that "recipe" is a synthetic fragment with no line numbers
+    # meaningful to the user, so keep pointing at whatever recipe text the
+    # outer call was already tracking.
+    if _RECIPE_RUN_DEPTH <= 1 or _is_external_source:
+        global _CURRENT_RECIPE_STRING
+        _CURRENT_RECIPE_STRING = recipe_string
+
     # Check if there are any templated valued to update
     recipe_object = _replace_templated_values(recipe_object, variables)
 
     return recipe_object, functions
+
+
+def _find_item_line(item_name: str, occurrence_index: int = 1) -> int:
+    """Best-effort: find the 1-based line number of the Nth occurrence of
+    an item defined as "- item_name:" in the last loaded recipe string.
+    Returns None if not found.
+    """
+    if not _CURRENT_RECIPE_STRING:
+        return None
+    try:
+        # Use [ \t]* rather than \s* around the dash/name/colon so a blank
+        # line immediately before the match can't be swallowed into it -
+        # \s* matches newlines too, which would anchor the match (and its
+        # line number) to the preceding blank line instead of the real one.
+        pattern = _re.compile(r"^[ \t]*-[ \t]*" + _re.escape(item_name) + r"[ \t]*:", _re.MULTILINE)
+        matches = list(pattern.finditer(_CURRENT_RECIPE_STRING))
+        if not matches:
+            return None
+        if len(matches) == 1:
+            # Only one occurrence in the recipe - use it regardless of the
+            # requested index, since the index may not align with a global count
+            m = matches[0]
+        elif occurrence_index < 1 or occurrence_index > len(matches):
+            # Requested occurrence is out of range - fall back to the last match
+            m = matches[-1]
+        else:
+            m = matches[occurrence_index - 1]
+        # line numbers are 1-based
+        return _CURRENT_RECIPE_STRING[:m.start()].count('\n') + 1
+    except Exception:
+        return None
+
+
+def _wrap_and_raise(section: str, name: str, index: int, original_exception: Exception):
+    # If this exception was already enhanced by a nested recipe.run() call
+    # (e.g. an inner wrangle used by rename's `wrangles:`), propagate it as-is
+    # instead of wrapping it again - otherwise the message and line number
+    # would be duplicated and the real (inner) line number would be buried.
+    # Tracked via an attribute (rather than sniffing the message text) since
+    # intermediate code sometimes reformats the message (e.g. rename always
+    # re-raises as RuntimeError) independently of whether it was already
+    # enhanced.
+    if getattr(original_exception, '_wrangles_error_wrapped', False):
+        raise original_exception
+
+    line = None
+    try:
+        # For wrangles, we may have an index
+        if section.upper() == 'WRANGLE' and index is not None:
+            line = _find_item_line(name, index)
+        else:
+            # Best-effort: find first occurrence
+            line = _find_item_line(name, 1)
+    except Exception:
+        line = None
+
+    # Build enhanced message but keep original exception class so tests expecting
+    # original exceptions continue to work. The exception type name isn't
+    # included here - Python already prefixes it automatically when the
+    # exception is displayed (e.g. "KeyError: convert.case (line 10) - ...").
+    orig_msg = f"{original_exception}"
+    header = name or ""
+    if line is not None:
+        header += f" (line {line})"
+
+    enhanced = " - ".join([p for p in [header, orig_msg] if p])
+
+    # Re-raise same exception type with enhanced message
+    wrapped_exception = original_exception.__class__(enhanced)
+    wrapped_exception._wrangles_error_wrapped = True
+    raise wrapped_exception.with_traceback(original_exception.__traceback__) from None
 
 
 def _run_actions(
@@ -282,8 +398,8 @@ def _run_actions(
                 # Execute the function
                 func(**args)
             except Exception as e:
-                # Append name of wrangle to message and pass through exception
-                raise e.__class__(f"ERROR IN ACTION: {action_type} - {e}").with_traceback(e.__traceback__) from None
+                # Wrap with enhanced error information
+                _wrap_and_raise('ACTION', action_type, None, e)
 
 def _read_data(
     recipe: _Union[dict, list],
@@ -393,8 +509,8 @@ def _read_data(
                     raise RuntimeError(f"Function {read_type} did not return a dataframe")
 
             except Exception as e:
-                # Append name of read to message and pass through exception
-                raise e.__class__(f"ERROR IN READ: {read_type} - {e}").with_traceback(e.__traceback__) from None
+                # Wrap with enhanced error information
+                _wrap_and_raise('READ', read_type, None, e)
     if len(results) == 1:
         return results[0]
     else:
@@ -837,8 +953,8 @@ def _execute_wrangles(
                         _logging.info(f": Wrangling :: {wrangle} :: {input_display} >> {output_display} :: {_wrangle_elapsed:.3f}s Completed")
 
             except Exception as e:
-                # Append name of wrangle to message and pass through exception
-                raise e.__class__(f"ERROR IN WRANGLE #{i} {wrangle} - {e}").with_traceback(e.__traceback__) from None
+                # Wrap with enhanced error information and include wrangle index
+                _wrap_and_raise('WRANGLE', wrangle, i, e)
 
     return df
 
@@ -993,8 +1109,8 @@ def _write_data(
                     # Execute the function
                     func(df_temp, **args)
             except Exception as e:
-                # Append name of wrangle to message and pass through exception
-                raise e.__class__(f"ERROR IN WRITE: {export_type} - {e}").with_traceback(e.__traceback__) from None
+                # Wrap with enhanced error information
+                _wrap_and_raise('WRITE', export_type, None, e)
     return df_return
 
 
@@ -1099,39 +1215,46 @@ def run(
     if variables is None:
         variables = {}
 
-    # Parse recipe
-    recipe, functions = _load_recipe(
-        recipe,
-        variables,
-        functions or {}
-    )
+    global _RECIPE_RUN_DEPTH
+    with _RECIPE_RUN_DEPTH_LOCK:
+        _RECIPE_RUN_DEPTH += 1
+    try:
+        # Parse recipe
+        recipe, functions = _load_recipe(
+            recipe,
+            variables,
+            functions or {}
+        )
 
-    with _futures.ThreadPoolExecutor(max_workers=1) as executor:
-        try:
-            future = executor.submit(
-                _run_thread,
-                recipe,
-                variables,
-                dataframe,
-                functions
-            )
-            return future.result(timeout)
-        
-        except _futures.TimeoutError as e:
+        with _futures.ThreadPoolExecutor(max_workers=1) as executor:
             try:
-                executor._threads.clear()
-                # Run any actions requested if the recipe fails
-                if 'on_failure' in recipe.get('run', {}).keys():
-                    _run_actions(recipe['run']['on_failure'], functions, variables, e)
-            except:
-                pass
-            raise TimeoutError(f"Recipe timed out. Limit: {timeout}s")
+                future = executor.submit(
+                    _run_thread,
+                    recipe,
+                    variables,
+                    dataframe,
+                    functions
+                )
+                return future.result(timeout)
 
-        except Exception as e:
-            try:
-                # Run any actions requested if the recipe fails
-                if 'on_failure' in recipe.get('run', {}).keys():
-                    _run_actions(recipe['run']['on_failure'], functions, variables, e)
-            except:
-                pass
-            raise
+            except _futures.TimeoutError as e:
+                try:
+                    executor._threads.clear()
+                    # Run any actions requested if the recipe fails
+                    if 'on_failure' in recipe.get('run', {}).keys():
+                        _run_actions(recipe['run']['on_failure'], functions, variables, e)
+                except:
+                    pass
+                raise TimeoutError(f"Recipe timed out. Limit: {timeout}s")
+
+            except Exception as e:
+                try:
+                    # Run any actions requested if the recipe fails
+                    if 'on_failure' in recipe.get('run', {}).keys():
+                        _run_actions(recipe['run']['on_failure'], functions, variables, e)
+                except:
+                    pass
+                raise
+    finally:
+        with _RECIPE_RUN_DEPTH_LOCK:
+            _RECIPE_RUN_DEPTH -= 1

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -13,7 +13,7 @@ import importlib as _importlib
 import re as _re
 import warnings as _warnings
 import concurrent.futures as _futures
-import threading as _threading
+import contextvars as _contextvars
 import time as _time
 import pandas as _pandas
 import requests as _requests
@@ -41,19 +41,15 @@ except ImportError:
 
 _logging.getLogger().setLevel(_logging.INFO)
 
-# Text of the recipe currently being executed, used as a best-effort source
-# for error line lookups. Only the outermost recipe.run() call updates this -
-# see _RECIPE_RUN_DEPTH below.
-_CURRENT_RECIPE_STRING = None
-
-# Tracks how many recipe.run() calls are nested on the current call stack.
-# Wrangles such as `rename` run an inner recipe.run() internally to execute
-# their `wrangles:` steps; that inner call must not overwrite
-# _CURRENT_RECIPE_STRING with its own synthetic, re-dumped recipe fragment,
-# otherwise error line lookups for the inner wrangles would point at the
-# wrong (synthetic) source instead of the user's actual recipe.
-_RECIPE_RUN_DEPTH = 0
-_RECIPE_RUN_DEPTH_LOCK = _threading.Lock()
+# Recipe source and nesting state used for best-effort error line lookups.
+# Context variables isolate simultaneous recipe.run() calls. Each run creates
+# a new dictionary so nested recipes can update their own source without
+# mutating the parent run's context. The context is copied into the worker
+# thread below, where recipe wrangles and any nested runs execute.
+_RECIPE_RUN_CONTEXT = _contextvars.ContextVar(
+    'wrangles_recipe_run_context',
+    default=None
+)
 
 
 # Suppress pandas performance warnings
@@ -261,9 +257,9 @@ def _load_recipe(
     # update - that "recipe" is a synthetic fragment with no line numbers
     # meaningful to the user, so keep pointing at whatever recipe text the
     # outer call was already tracking.
-    if _RECIPE_RUN_DEPTH <= 1 or _is_external_source:
-        global _CURRENT_RECIPE_STRING
-        _CURRENT_RECIPE_STRING = recipe_string
+    run_context = _RECIPE_RUN_CONTEXT.get()
+    if run_context is not None and (run_context['depth'] <= 1 or _is_external_source):
+        run_context['recipe_string'] = recipe_string
 
     # Check if there are any templated valued to update
     recipe_object = _replace_templated_values(recipe_object, variables)
@@ -276,7 +272,9 @@ def _find_item_line(item_name: str, occurrence_index: int = 1) -> int:
     an item defined as "- item_name:" in the last loaded recipe string.
     Returns None if not found.
     """
-    if not _CURRENT_RECIPE_STRING:
+    run_context = _RECIPE_RUN_CONTEXT.get()
+    recipe_string = run_context.get('recipe_string') if run_context else None
+    if not recipe_string:
         return None
     try:
         # Use [ \t]* rather than \s* around the dash/name/colon so a blank
@@ -284,7 +282,7 @@ def _find_item_line(item_name: str, occurrence_index: int = 1) -> int:
         # \s* matches newlines too, which would anchor the match (and its
         # line number) to the preceding blank line instead of the real one.
         pattern = _re.compile(r"^[ \t]*-[ \t]*" + _re.escape(item_name) + r"[ \t]*:", _re.MULTILINE)
-        matches = list(pattern.finditer(_CURRENT_RECIPE_STRING))
+        matches = list(pattern.finditer(recipe_string))
         if not matches:
             return None
         if len(matches) == 1:
@@ -297,7 +295,7 @@ def _find_item_line(item_name: str, occurrence_index: int = 1) -> int:
         else:
             m = matches[occurrence_index - 1]
         # line numbers are 1-based
-        return _CURRENT_RECIPE_STRING[:m.start()].count('\n') + 1
+        return recipe_string[:m.start()].count('\n') + 1
     except Exception:
         return None
 
@@ -1215,9 +1213,12 @@ def run(
     if variables is None:
         variables = {}
 
-    global _RECIPE_RUN_DEPTH
-    with _RECIPE_RUN_DEPTH_LOCK:
-        _RECIPE_RUN_DEPTH += 1
+    parent_context = _RECIPE_RUN_CONTEXT.get()
+    run_context = {
+        'depth': (parent_context.get('depth', 0) if parent_context else 0) + 1,
+        'recipe_string': parent_context.get('recipe_string') if parent_context else None
+    }
+    context_token = _RECIPE_RUN_CONTEXT.set(run_context)
     try:
         # Parse recipe
         recipe, functions = _load_recipe(
@@ -1228,7 +1229,9 @@ def run(
 
         with _futures.ThreadPoolExecutor(max_workers=1) as executor:
             try:
+                worker_context = _contextvars.copy_context()
                 future = executor.submit(
+                    worker_context.run,
                     _run_thread,
                     recipe,
                     variables,
@@ -1256,5 +1259,4 @@ def run(
                     pass
                 raise
     finally:
-        with _RECIPE_RUN_DEPTH_LOCK:
-            _RECIPE_RUN_DEPTH -= 1
+        _RECIPE_RUN_CONTEXT.reset(context_token)

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -18,6 +18,7 @@ import json as _json
 import numpy as _np
 import math as _math
 import concurrent.futures as _futures
+import contextvars as _contextvars
 from ..openai import _divide_batches
 from ..classify import classify as _classify
 from ..standardize import standardize as _standardize
@@ -283,22 +284,38 @@ def batch(
 
     with pool_executor(max_workers=threads) as executor:
         batches = list(_divide_batches(df, batch_size))
-        
-        # Set a chunk size for process pool executor
-        # to reduce overhead of process creation
-        chunksize = min(max(len(batches) // threads, 1), 20)
 
-        results = executor.map(
-            _batch_thread,
-            batches,
-            range(1, len(batches) + 1), 
-            [wrangles] * len(batches),
-            [functions] * len(batches),
-            [variables] * len(batches),
-            [timeout] * len(batches),
-            [on_error] * len(batches),
-            chunksize = chunksize
-        )
+        if use_multiprocessing:
+            # Set a chunk size for process pool executor
+            # to reduce overhead of process creation.
+            chunksize = min(max(len(batches) // threads, 1), 20)
+            results = executor.map(
+                _batch_thread,
+                batches,
+                range(1, len(batches) + 1),
+                [wrangles] * len(batches),
+                [functions] * len(batches),
+                [variables] * len(batches),
+                [timeout] * len(batches),
+                [on_error] * len(batches),
+                chunksize=chunksize
+            )
+        else:
+            futures = [
+                executor.submit(
+                    _contextvars.copy_context().run,
+                    _batch_thread,
+                    batch_df,
+                    batch_num,
+                    wrangles,
+                    functions,
+                    variables,
+                    timeout,
+                    on_error
+                )
+                for batch_num, batch_df in enumerate(batches, 1)
+            ]
+            results = [future.result() for future in futures]
 
     return _pd.concat(results)
 
@@ -469,13 +486,23 @@ def concurrent(
             ):
                 raise ValueError('Using concurrent requires that each wrangle specify output column(s).')
 
-            future = executor.submit(
-                _wrangles.recipe.run,
-                recipe= {'wrangles': [wrangle_definition]},
-                dataframe=df.copy(),
-                variables=variables,
-                functions=functions
-            )
+            if use_multiprocessing:
+                future = executor.submit(
+                    _wrangles.recipe.run,
+                    recipe={'wrangles': [wrangle_definition]},
+                    dataframe=df.copy(),
+                    variables=variables,
+                    functions=functions
+                )
+            else:
+                future = executor.submit(
+                    _contextvars.copy_context().run,
+                    _wrangles.recipe.run,
+                    {'wrangles': [wrangle_definition]},
+                    variables,
+                    df.copy(),
+                    functions
+                )
             futures.append(future)
 
             # Add output columns to reference on completion

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -130,6 +130,9 @@ def accordion(
         )
     except KeyError as e:
         e.args = (f"Did you forget the column in the accordion input or propagate? - {e.args[0]}",)
+        # The message just changed, so it no longer reads as already-wrapped -
+        # let the outer accordion wrangle add its own line-number wrap on top.
+        e._wrangles_error_wrapped = False
         raise e
 
     try:
@@ -144,6 +147,9 @@ def accordion(
         )
     except KeyError as e:
         e.args = (f"Did you forget the column in the accordion output? - {e.args[0]}",)
+        # The message just changed, so it no longer reads as already-wrapped -
+        # let the outer accordion wrangle add its own line-number wrap on top.
+        e._wrangles_error_wrapped = False
         raise e
 
     df_temp = df_temp.set_index(f"index_asbjdbasjk_{random_str}")[output]
@@ -1627,7 +1633,14 @@ def rename(
                         variables=kwargs.get("variables", {})
                     )["columns"].tolist()
                 except Exception as e:
-                    raise RuntimeError(f"Failed running {wrangle_name} in rename wrangles: {e}")
+                    # Preserve the inner wrangle's own message (which already
+                    # includes the correct line number and a suggestion when
+                    # available) rather than burying it behind extra text.
+                    # Also carry over the "already wrapped" marker so the
+                    # outer rename wrangle doesn't wrap it a second time.
+                    wrapped = RuntimeError(f"{e}")
+                    wrapped._wrangles_error_wrapped = getattr(e, '_wrangles_error_wrapped', False)
+                    raise wrapped.with_traceback(e.__traceback__) from None
 
                 if len(target) != len(result):
                     raise RuntimeError(


### PR DESCRIPTION
## Summary

Recover recipe error line-number reporting from legacy-dev PR #1084 onto current `main`, with concurrency hardening for simultaneous and nested recipes.

## What changed

- retain the original exception type while prefixing failures with the failing read, wrangle, write, or action name and its best-effort source line
- preserve meaningful outer-recipe line numbers through nested meta-wrangles such as `rename`, `batch`, and recipe-model execution
- avoid duplicate wrapping when a nested error has already been annotated
- isolate recipe source context between simultaneous `recipe.run()` calls
- propagate that source context through internal batch and concurrent thread pools
- make new model-metadata tests deterministic and independent of live authentication

## Impact

Recipe failures now identify the relevant recipe line, for example `convert.case (line 10) - ...`, which should shorten diagnosis of long and nested recipes. Existing exception classes remain unchanged for compatibility.

No recipe schema or successful data-processing behavior changes.

## Concurrency refinement

The original #1084 implementation stored the active recipe source in process-wide globals. That could attribute one recipe's error to another recipe when runs overlapped. This recovery uses context-local state and explicitly carries it into worker threads, including nested batch and concurrent connectors.

## Validation

- 34 focused error-reporting tests passed
- 22 batch/concurrent recipe tests passed
- 5 concurrent connector tests passed
- 4 targeted source-isolation/model tests passed
- affected modules compile successfully
- `git diff --check origin/main...HEAD` passed
- branch is 0 commits behind current `origin/main`

## Recovery source

Supersedes the feature previously merged only into legacy `dev` through #1084.