### PR TITLE
Recover pandas compatibility and batch-copy safety

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [metadata]
 description_file = README.md
+
+[tool:pytest]
+filterwarnings =
+    ignore:'imghdr' is deprecated and slated for removal in Python 3.13:DeprecationWarning:apprise\.utils\.pgp

--- a/tests/recipes/wrangles/test_extract.py
+++ b/tests/recipes/wrangles/test_extract.py
@@ -2262,7 +2262,7 @@ class TestExtractRegex:
         data = pd.DataFrame({
             'col': ['Random Pikachu Random', 'Random', 'Random Random Pikachu']
         })
-        recipe = """
+        recipe = r"""
         wrangles:
         - extract.regex:
             input: col
@@ -2280,7 +2280,7 @@ class TestExtractRegex:
         data = pd.DataFrame({
             'col': ['Random Pikachu Random', 'Random', 'Random Random Pikachu']
         })
-        recipe = """
+        recipe = r"""
         wrangles:
         - extract.regex:
             input: col

--- a/wrangles/recipe_wrangles/extract.py
+++ b/wrangles/recipe_wrangles/extract.py
@@ -1248,7 +1248,7 @@ def date_range(df: _pd.DataFrame, start_time: _pd.Timestamp, end_time: _pd.Times
         'business month starts': 'BMS',
         'quarters': 'Q',
         'quarter starts': 'QS',
-        'years': 'Y',
+        'years': 'YE',
         'business hours': 'BH',
         'hours': 'H',
         'minutes': 'T',

--- a/wrangles/recipe_wrangles/main.py
+++ b/wrangles/recipe_wrangles/main.py
@@ -283,7 +283,12 @@ def batch(
         pool_executor = _futures.ThreadPoolExecutor
 
     with pool_executor(max_workers=threads) as executor:
-        batches = list(_divide_batches(df, batch_size))
+        # Pandas row slices may be views. Give each worker an independent
+        # dataframe so nested wrangles can safely add or transform columns.
+        batches = [
+            batch.copy()
+            for batch in _divide_batches(df, batch_size)
+        ]
 
         if use_multiprocessing:
             # Set a chunk size for process pool executor
@@ -1393,7 +1398,7 @@ def python(
         exception = None
 
     # Raise a warniing for illegal python variables
-    if _re.search('\${.*\s.*}', command):
+    if _re.search(r'\${.*\s.*}', command):
         _logging.warning(f'Spaces should be dropped in python wrangle variables in order to be valid python syntax.')
 
     # Clean up variables and replace column variables with the column name


### PR DESCRIPTION
## Summary

Recover the small pandas/Python compatibility and batch-worker safety patch from legacy `dev` commit `e222c5bc` onto current `main`.

## What changed

- copy every dataframe slice before dispatching a batch worker, preventing nested wrangles from mutating pandas views
- retain the newer context propagation used by threaded batch execution
- use pandas' current `YE` frequency alias for yearly date ranges
- make Python-wrangle variable detection a raw regex, avoiding an invalid escape warning
- make two regex recipe fixtures raw strings for the same reason
- suppress the known third-party `imghdr` deprecation warning emitted by `apprise.utils.pgp`

## Impact

This reduces pandas view/copy ambiguity in parallel batches and keeps date-range and regex behavior compatible with newer pandas and Python versions. There is no recipe schema change.

## Validation

- 67 focused tests passed across:
  - `TestExtractRegex`
  - `TestExtractDateRange`
  - `TestPython`
  - `TestBatch`
- `git diff --check origin/main...HEAD` passed
- branch is 0 commits behind current `origin/main`

## Recovery source

Recovers direct legacy `dev` commit `e222c5bc` while preserving the newer batch concurrency work already merged through #1121.