### PR TITLE
Recover semantic recipe version selectors from #1110

### DIFF
--- a/tests/recipes/test_recipes.py
+++ b/tests/recipes/test_recipes.py
@@ -137,6 +137,53 @@ def test_recipe_by_production_version():
         list(df.columns) == ["header"]
     )
 
+
+def test_recipe_by_production_semantic_version(mocker):
+    """
+    Test running a recipe using the production semantic version
+    """
+    mocker.patch(
+        "wrangles.data.model",
+        return_value={
+            "purpose": "recipe",
+            "production_version_id": "production-version-id"
+        }
+    )
+    model_content = mocker.patch(
+        "wrangles.data.model_content",
+        return_value={"recipe": "{}"}
+    )
+
+    wrangles.recipe.run("a6bac9e7-2388-4347:production")
+
+    model_content.assert_called_once_with(
+        "a6bac9e7-2388-4347",
+        "production-version-id"
+    )
+
+
+def test_recipe_by_production_semantic_version_falls_back_to_latest(
+    mocker,
+    caplog
+):
+    """
+    Test the production semantic version falls back when none exists
+    """
+    mocker.patch(
+        "wrangles.data.model",
+        return_value={"purpose": "recipe"}
+    )
+    model_content = mocker.patch(
+        "wrangles.data.model_content",
+        return_value={"recipe": "{}"}
+    )
+
+    wrangles.recipe.run("a6bac9e7-2388-4347:production")
+
+    model_content.assert_called_once_with("a6bac9e7-2388-4347", None)
+    assert "No production version exists, defaulting to latest version" in caplog.text
+
+
 def test_recipe_by_version_latest():
     """
     Test running a recipe using a model ID and latest version

--- a/wrangles/recipe.py
+++ b/wrangles/recipe.py
@@ -129,7 +129,14 @@ def _load_recipe(
                 f'Using {purpose} model_id {model_id} in a recipe wrangle.'
             )
 
-        if 'production_version_id' in metadata.keys() and version_id is None:
+        if version_id == 'production':
+            version_id = metadata.get('production_version_id')
+            if version_id:
+                _logging.info(f": 'production' version specified, using production version {version_id}")
+            else:
+                _logging.info(": No production version exists, defaulting to latest version")
+
+        elif 'production_version_id' in metadata.keys() and version_id is None:
             version_id = metadata['production_version_id']
             _logging.info(f": No version specified, defaulting to production version {version_id}")
         


### PR DESCRIPTION
## Summary

Recovers the semantic remote-recipe selectors from #1110 onto current `main`. The original PR was accidentally merged into the legacy `dev` branch; this PR carries only that logical two-file feature and does not merge `dev`.

## What changed

- `recipe.run("<model-id>:production")` resolves the model's configured production version.
- If no production version exists, the explicit `:production` selector falls back to the latest version and logs that decision.
- Existing `:latest` behavior on current `main` remains unchanged.
- Adds focused mocked tests for production selection and fallback behavior.

## Compatibility and risk

Calls without a selector continue to prefer the configured production version. Explicit version IDs/tags and `:latest` retain their existing behavior. The change affects only remote recipe model resolution.

## Validation

- `2 passed`: the two new semantic production-selector tests.
- `wrangles/recipe.py` compiles successfully.
- `git diff --check origin/main...HEAD` passes.
- Branch is exactly one commit ahead and zero commits behind current `origin/main`.

The full credential-backed suite is left to GitHub Actions.