### PR TITLE
Recover select.group_by value counts from #1114

### DIFF
--- a/tests/recipes/wrangles/test_select.py
+++ b/tests/recipes/wrangles/test_select.py
@@ -1940,6 +1940,27 @@ class TestGroupBy:
             list(df.values[1]) == ['b', [4], [8]]
         )
 
+    def test_group_by_value_counts_as_json_safe_dictionary(self):
+        df = wrangles.recipe.run(
+            """
+            wrangles:
+              - select.group_by:
+                  counts:
+                    - Selection: Selection Counts
+                    - Review: Review Counts
+                  auto_rename_columns: false
+            """,
+            dataframe=pd.DataFrame({
+                "Selection": ["Primary", "Primary", "None", None],
+                "Review": [False, False, True, None],
+            }),
+        )
+
+        assert df.to_dict(orient="records") == [{
+            "Selection Counts": {"Primary": 2, "None": 1, "null": 1},
+            "Review Counts": {"false": 2, "true": 1, "null": 1},
+        }]
+
 
     def test_group_by_where(self):
         """

--- a/wrangles/recipe_wrangles/select.py
+++ b/wrangles/recipe_wrangles/select.py
@@ -318,6 +318,14 @@ def group_by(
           - string
           - array
         description: The count of values for these column(s)
+      counts:
+        type:
+          - string
+          - array
+        description: >-
+          Return a dictionary containing the count of each distinct value for
+          these column(s). Keys are converted to JSON-safe strings; missing
+          values use the key "null" and booleans use lowercase "true"/"false".
       std:
         type:
           - string
@@ -399,6 +407,20 @@ def group_by(
         # Add option to group as a list
         elif operation == "list":
             operation = list
+        elif operation == "counts":
+            def counts(values):
+                output = {}
+                for value, count in values.value_counts(dropna=False).items():
+                    if _pd.isna(value):
+                        key = "null"
+                    elif isinstance(value, bool):
+                        key = str(value).lower()
+                    else:
+                        key = str(value)
+                    output[key] = int(count)
+                return output
+            counts.__name__ = "counts"
+            operation = counts
 
         if not isinstance(columns, list): columns = [columns]
         for column in columns:


### PR DESCRIPTION
## Summary

Recovers the `select.group_by counts` aggregation from #1114 onto current `main`. The original PR was accidentally merged into the legacy `dev` branch; this PR carries only that logical two-file feature and does not merge `dev`.

## What changed

- Adds a `counts` aggregation to `select.group_by`.
- Returns a dictionary mapping each distinct value to its frequency.
- Converts dictionary keys to JSON-safe strings.
- Represents missing values as `"null"` and booleans as lowercase `"true"` / `"false"`.
- Preserves existing per-column output renaming and `auto_rename_columns` behavior.

Example:

```yaml
wrangles:
  - select.group_by:
      by: Group
      counts:
        - Selection: Selection Counts
      auto_rename_columns: false
```

## Compatibility and risk

This is an additive aggregation option. Existing `select.group_by` operations and naming behavior are unchanged.

## Validation

- Complete `TestGroupBy` class: `30 passed`.
- `wrangles/recipe_wrangles/select.py` compiles successfully.
- `git diff --check origin/main...HEAD` passes.
- Branch is exactly one commit ahead and zero commits behind current `origin/main`.

The full repository suite is left to GitHub Actions.